### PR TITLE
Potential fix for code scanning alert no. 1: Incomplete multi-character sanitization

### DIFF
--- a/imports/lib/FhirDehydrator.js
+++ b/imports/lib/FhirDehydrator.js
@@ -5,6 +5,7 @@ let has = _.has;
 let findIndex = _.findIndex;
 
 import moment from 'moment';
+import sanitizeHtml from 'sanitize-html';
 import FhirUtilities from './FhirUtilities';
   
 //========================================================================================
@@ -3399,8 +3400,10 @@ export function flattenOperationOutcome(outcome) {
   result.language = get(outcome, 'language', '');
   
   // Narrative text
-  result.text = get(outcome, 'text.div', '')
-    .replace(/<[^>]*>/g, ''); // Strip HTML tags
+  result.text = sanitizeHtml(get(outcome, 'text.div', ''), {
+    allowedTags: [], // Remove all HTML tags
+    allowedAttributes: {} // Remove all attributes
+  });
     
   // Issue details (taking first issue if multiple exist)
   if (Array.isArray(outcome.issue)) {

--- a/package.json
+++ b/package.json
@@ -82,7 +82,8 @@
     "validator": "^13.12.0",
     "winston": "^3.14.2",
     "xlsx": "^0.16.0",
-    "xml2js": "^0.4.23"
+    "xml2js": "^0.4.23",
+    "sanitize-html": "^2.17.0"
   },
   "meteor": {
     "mainModule": {


### PR DESCRIPTION
Potential fix for [https://github.com/node-on-fhir/honeycomb/security/code-scanning/1](https://github.com/node-on-fhir/honeycomb/security/code-scanning/1)

To address the issue, we will replace the current regular expression-based sanitization with a more robust and well-tested library, such as `sanitize-html`. This library is specifically designed to handle HTML sanitization and ensures that all unsafe tags and attributes are removed. By using `sanitize-html`, we can simplify the sanitization process and improve security.

Steps to fix:
1. Install the `sanitize-html` library if it is not already installed.
2. Replace the `.replace(/<[^>]*>/g, '')` call with a call to `sanitizeHtml()` to sanitize the `text.div` field.
3. Configure `sanitizeHtml` to remove all HTML tags and return plain text.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
