### PR TITLE
security(deps): migrate role-acl → CASL; remediate critical Dependabot alerts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "@accounts/rest-client": "0.33.1",
         "@accounts/server": "0.33.1",
         "@breejs/later": "4.1.0",
+        "@casl/ability": "^7.0.0",
         "@cornerstonejs/core": "^1.78.0",
         "@cornerstonejs/dicom-image-loader": "^1.78.0",
         "@cornerstonejs/streaming-image-volume-loader": "^1.78.0",
@@ -90,7 +91,7 @@
         "lodash": "4.17.21",
         "material-ui-rc-color-picker": "1.0.4",
         "meteor": "^3.3.2",
-        "meteor-node-stubs": "1.2.21",
+        "meteor-node-stubs": "1.2.27",
         "moment": "^2.29.4",
         "mongo-query": "^0.5.7",
         "mongoose": "^8.5.3",
@@ -114,7 +115,6 @@
         "react-simple-chatbot": "0.6.1",
         "react-swipeable": "^7.0.1",
         "react18-vis-timeline": "2.0.4",
-        "role-acl": "^4.5.4",
         "sanitize-html": "^2.17.0",
         "setimmediate": "^1.0.5",
         "simpl-schema": "^3.4.6",
@@ -2530,6 +2530,18 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@casl/ability": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@casl/ability/-/ability-7.0.0.tgz",
+      "integrity": "sha512-QhwRflkTucpdS2uw1XScrzLWbgLYJGvPoq2Xm5OjeRci3dwtPixxnjUKJ04Ss1ivNS9tZQ8y4sjWeelWsrwo4g==",
+      "license": "MIT",
+      "dependencies": {
+        "@ucast/mongo2js": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/stalniy/casl/blob/master/BACKERS.md"
+      }
+    },
     "node_modules/@cesium/engine": {
       "version": "23.0.1",
       "resolved": "https://registry.npmjs.org/@cesium/engine/-/engine-23.0.1.tgz",
@@ -2569,24 +2581,12 @@
       "license": "Apache-2.0"
     },
     "node_modules/@cesium/engine/node_modules/protobufjs": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.0.0.tgz",
-      "integrity": "sha512-jx6+sE9h/UryaCZhsJWbJtTEy47yXoGNYI4z8ZaRncM0zBKeRqjO2JEcOUYwrYGb1WLhXM1FfMzW3annvFv0rw==",
-      "hasInstallScript": true,
+      "version": "8.6.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.6.4.tgz",
+      "integrity": "sha512-/+XMv9JalknuncEJSwsyEVlwcxVLKx2iaoSUXFZA86MJkdqyOdfrlB1sB7S6aKyUk9tl20YY+SgQe5J2sJHTcg==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
-        "@types/node": ">=13.7.0",
-        "long": "^5.0.0"
+        "long": "^5.3.2"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -5059,15 +5059,6 @@
       },
       "peerDependencies": {
         "hono": "^4"
-      }
-    },
-    "node_modules/@huggingface/jinja": {
-      "version": "0.2.2",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -9252,50 +9243,6 @@
         "url": "https://opencollective.com/popperjs"
       }
     },
-    "node_modules/@protobufjs/aspromise": {
-      "version": "1.1.2",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/base64": {
-      "version": "1.1.2",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/codegen": {
-      "version": "2.0.4",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/eventemitter": {
-      "version": "1.1.0",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/fetch": {
-      "version": "1.1.0",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.1",
-        "@protobufjs/inquire": "^1.1.0"
-      }
-    },
-    "node_modules/@protobufjs/float": {
-      "version": "1.0.2",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/inquire": {
-      "version": "1.1.0",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/path": {
-      "version": "1.1.2",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/pool": {
-      "version": "1.1.0",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/utf8": {
-      "version": "1.1.0",
-      "license": "BSD-3-Clause"
-    },
     "node_modules/@ranfdev/deepobj": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@ranfdev/deepobj/-/deepobj-1.0.2.tgz",
@@ -10817,12 +10764,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/long": {
-      "version": "4.0.2",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/@types/mime": {
       "version": "1.3.5",
       "license": "MIT"
@@ -11316,6 +11257,41 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
+    "node_modules/@ucast/core": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@ucast/core/-/core-2.0.0.tgz",
+      "integrity": "sha512-4XVx6LzPXZGvnZO5jp39cm/G4UvuwvEdtmg+9+4+zl6uFkCcB7UJacvtMYeBE56GJVT99Zqy6Pii7dGJq3Kz9Q==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@ucast/js": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@ucast/js/-/js-4.0.1.tgz",
+      "integrity": "sha512-9O5xPBvwEWQk2WvO69Eh2WJB8QljVZ2vRVdFvfnKjlZwWXcYxp1lqLBhwXBU1AtuSgCvKhJPkXdjKJggUmAmQQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ucast/core": "2.0.0"
+      }
+    },
+    "node_modules/@ucast/mongo": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@ucast/mongo/-/mongo-3.0.0.tgz",
+      "integrity": "sha512-kwuSH+kdB4GCR0LGhy/PEDm4PCflur89AlK82kNiYD0FvsA8A/p+0sx7m+/R8mMFAlmlkAd3VXp7sM/cLLYWYg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ucast/core": "2.0.0"
+      }
+    },
+    "node_modules/@ucast/mongo2js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@ucast/mongo2js/-/mongo2js-2.0.0.tgz",
+      "integrity": "sha512-vNBZzRnsfLr/TSxEoxz6W6hHQ5tmWsfEeC0nCq5z8RezC1AqIRy3cfHm8AGvlGtcn+cTSFQcZremfqnz6wm+nQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ucast/core": "2.0.0",
+        "@ucast/js": "4.0.1",
+        "@ucast/mongo": "3.0.0"
+      }
+    },
     "node_modules/@uiw/color-convert": {
       "version": "2.9.2",
       "license": "MIT",
@@ -11565,20 +11541,6 @@
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@xtuc/long": "4.2.2"
-      }
-    },
-    "node_modules/@xenova/transformers": {
-      "version": "2.17.2",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@huggingface/jinja": "^0.2.2",
-        "onnxruntime-web": "1.14.0",
-        "sharp": "^0.32.0"
-      },
-      "optionalDependencies": {
-        "onnxruntime-node": "1.14.0"
       }
     },
     "node_modules/@xmldom/xmldom": {
@@ -13238,92 +13200,6 @@
       "version": "1.0.2",
       "license": "MIT"
     },
-    "node_modules/bare-events": {
-      "version": "2.8.2",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "peerDependencies": {
-        "bare-abort-controller": "*"
-      },
-      "peerDependenciesMeta": {
-        "bare-abort-controller": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/bare-fs": {
-      "version": "4.5.2",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "bare-events": "^2.5.4",
-        "bare-path": "^3.0.0",
-        "bare-stream": "^2.6.4",
-        "bare-url": "^2.2.2",
-        "fast-fifo": "^1.3.2"
-      },
-      "engines": {
-        "bare": ">=1.16.0"
-      },
-      "peerDependencies": {
-        "bare-buffer": "*"
-      },
-      "peerDependenciesMeta": {
-        "bare-buffer": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/bare-os": {
-      "version": "3.6.2",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "bare": ">=1.14.0"
-      }
-    },
-    "node_modules/bare-path": {
-      "version": "3.0.0",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "bare-os": "^3.0.1"
-      }
-    },
-    "node_modules/bare-stream": {
-      "version": "2.7.0",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "streamx": "^2.21.0"
-      },
-      "peerDependencies": {
-        "bare-buffer": "*",
-        "bare-events": "*"
-      },
-      "peerDependenciesMeta": {
-        "bare-buffer": {
-          "optional": true
-        },
-        "bare-events": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/bare-url": {
-      "version": "2.3.2",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "bare-path": "^3.0.0"
-      }
-    },
     "node_modules/base": {
       "version": "0.11.2",
       "license": "MIT",
@@ -13519,7 +13395,7 @@
     },
     "node_modules/bl": {
       "version": "4.1.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "buffer": "^5.5.0",
@@ -13529,7 +13405,7 @@
     },
     "node_modules/bl/node_modules/buffer": {
       "version": "5.7.1",
-      "devOptional": true,
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -13552,7 +13428,7 @@
     },
     "node_modules/bl/node_modules/readable-stream": {
       "version": "3.6.2",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.3",
@@ -13565,7 +13441,7 @@
     },
     "node_modules/bl/node_modules/string_decoder": {
       "version": "1.3.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
@@ -13587,6 +13463,7 @@
     },
     "node_modules/bn.js": {
       "version": "4.12.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/body-parser": {
@@ -13763,6 +13640,7 @@
     },
     "node_modules/brorand": {
       "version": "1.1.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/browser-resolve": {
@@ -14980,19 +14858,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/color": {
-      "version": "4.2.3",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "color-convert": "^2.0.1",
-        "color-string": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=12.5.0"
-      }
-    },
     "node_modules/color-convert": {
       "version": "3.1.3",
       "license": "MIT",
@@ -15009,22 +14874,6 @@
       "engines": {
         "node": ">=12.20"
       }
-    },
-    "node_modules/color-string": {
-      "version": "1.9.1",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "color-name": "^1.0.0",
-        "simple-swizzle": "^0.2.2"
-      }
-    },
-    "node_modules/color-string/node_modules/color-name": {
-      "version": "1.1.4",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
     },
     "node_modules/color-support": {
       "version": "1.1.3",
@@ -16194,7 +16043,7 @@
     },
     "node_modules/decompress-response": {
       "version": "6.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mimic-response": "^3.1.0"
@@ -16246,15 +16095,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/deep-extend": {
-      "version": "0.6.0",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=4.0.0"
       }
     },
     "node_modules/deep-is": {
@@ -17413,6 +17253,7 @@
     },
     "node_modules/elliptic": {
       "version": "6.6.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "bn.js": "^4.11.9",
@@ -18487,15 +18328,6 @@
         "node": ">=0.8.x"
       }
     },
-    "node_modules/events-universal": {
-      "version": "1.0.1",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "bare-events": "^2.7.0"
-      }
-    },
     "node_modules/eventsource": {
       "version": "3.0.7",
       "license": "MIT",
@@ -18597,15 +18429,6 @@
     "node_modules/expand-brackets/node_modules/ms": {
       "version": "2.0.0",
       "license": "MIT"
-    },
-    "node_modules/expand-template": {
-      "version": "2.0.3",
-      "license": "(MIT OR WTFPL)",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/expand-tilde": {
       "version": "2.0.2",
@@ -18985,12 +18808,6 @@
     "node_modules/fast-diff": {
       "version": "1.3.0",
       "license": "Apache-2.0"
-    },
-    "node_modules/fast-fifo": {
-      "version": "1.3.2",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
     },
     "node_modules/fast-glob": {
       "version": "3.3.3",
@@ -19521,12 +19338,6 @@
       "version": "3.3.3",
       "license": "ISC"
     },
-    "node_modules/flatbuffers": {
-      "version": "1.12.0",
-      "license": "SEE LICENSE IN LICENSE.txt",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/flatted": {
       "version": "2.0.2",
       "license": "ISC"
@@ -19811,7 +19622,7 @@
     },
     "node_modules/fs-constants": {
       "version": "1.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fs-extra": {
@@ -20072,12 +19883,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/github-from-package": {
-      "version": "0.0.0",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
     },
     "node_modules/gl-matrix": {
       "version": "3.4.4",
@@ -20489,12 +20294,6 @@
       "version": "1.4.0",
       "license": "MIT"
     },
-    "node_modules/guid-typescript": {
-      "version": "1.0.9",
-      "license": "ISC",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/gulp": {
       "version": "3.9.1",
       "license": "MIT",
@@ -20855,6 +20654,7 @@
     },
     "node_modules/hash.js": {
       "version": "1.1.7",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.3",
@@ -20909,6 +20709,7 @@
     },
     "node_modules/hmac-drbg": {
       "version": "1.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "hash.js": "^1.0.3",
@@ -23801,13 +23602,6 @@
         "graceful-fs": "^4.1.6"
       }
     },
-    "node_modules/jsonpath-plus": {
-      "version": "0.18.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.0"
-      }
-    },
     "node_modules/jsonpointer": {
       "version": "5.0.1",
       "license": "MIT",
@@ -24505,7 +24299,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -24525,7 +24318,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -24547,7 +24339,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -24569,7 +24360,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -24591,7 +24381,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -24613,7 +24402,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -24635,7 +24423,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -24657,7 +24444,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -24679,7 +24465,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -24701,7 +24486,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -24723,7 +24507,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -25088,12 +24871,6 @@
       "integrity": "sha512-WpG9CcFAOjz/FtNht+QJeGpvVl/cdR6P0z6OcXSkr8wFJOsV2GRj2j10JLfjuA4aYkcKCNIEqRGCyTife9R8/g==",
       "license": "MIT"
     },
-    "node_modules/long": {
-      "version": "4.0.0",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/longest": {
       "version": "1.0.1",
       "license": "MIT",
@@ -25269,23 +25046,6 @@
       "license": "Apache-2.0",
       "optional": true,
       "peer": true
-    },
-    "node_modules/matcher": {
-      "version": "1.1.1",
-      "license": "MIT",
-      "dependencies": {
-        "escape-string-regexp": "^1.0.4"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/matcher/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.0"
-      }
     },
     "node_modules/material-ui-rc-color-picker": {
       "version": "1.0.4",
@@ -25666,7 +25426,9 @@
       }
     },
     "node_modules/meteor-node-stubs": {
-      "version": "1.2.21",
+      "version": "1.2.27",
+      "resolved": "https://registry.npmjs.org/meteor-node-stubs/-/meteor-node-stubs-1.2.27.tgz",
+      "integrity": "sha512-FiT2i2DBiArWAL+BiVze9vUdKrpI3IuPH76hLm8d/KMTCQyqXYOFDS8VWFUxFvMsrpXkFloOiNaHkhiTjzI5mw==",
       "bundleDependencies": [
         "@meteorjs/crypto-browserify",
         "assert",
@@ -25701,7 +25463,6 @@
         "console-browserify": "^1.2.0",
         "constants-browserify": "^1.0.0",
         "domain-browser": "^4.23.0",
-        "elliptic": "^6.6.1",
         "events": "^3.3.0",
         "https-browserify": "^1.0.0",
         "os-browserify": "^0.3.0",
@@ -25710,6 +25471,7 @@
         "punycode": "^1.4.1",
         "querystring-es3": "^0.2.1",
         "readable-stream": "^3.6.2",
+        "sha.js": "^2.4.12",
         "stream-browserify": "^3.0.0",
         "stream-http": "^3.2.0",
         "string_decoder": "^1.3.0",
@@ -25796,7 +25558,7 @@
       }
     },
     "node_modules/meteor-node-stubs/node_modules/@meteorjs/create-ecdh/node_modules/bn.js": {
-      "version": "4.12.2",
+      "version": "4.12.3",
       "inBundle": true,
       "license": "MIT"
     },
@@ -25836,7 +25598,7 @@
       }
     },
     "node_modules/meteor-node-stubs/node_modules/asn1.js/node_modules/bn.js": {
-      "version": "4.12.2",
+      "version": "4.12.3",
       "inBundle": true,
       "license": "MIT"
     },
@@ -25886,7 +25648,7 @@
       "license": "MIT"
     },
     "node_modules/meteor-node-stubs/node_modules/bn.js": {
-      "version": "5.2.2",
+      "version": "5.2.3",
       "inBundle": true,
       "license": "MIT"
     },
@@ -26130,7 +25892,7 @@
       }
     },
     "node_modules/meteor-node-stubs/node_modules/diffie-hellman/node_modules/bn.js": {
-      "version": "4.12.2",
+      "version": "4.12.3",
       "inBundle": true,
       "license": "MIT"
     },
@@ -26502,7 +26264,7 @@
       }
     },
     "node_modules/meteor-node-stubs/node_modules/miller-rabin/node_modules/bn.js": {
-      "version": "4.12.2",
+      "version": "4.12.3",
       "inBundle": true,
       "license": "MIT"
     },
@@ -26679,7 +26441,7 @@
       }
     },
     "node_modules/meteor-node-stubs/node_modules/public-encrypt/node_modules/bn.js": {
-      "version": "4.12.2",
+      "version": "4.12.3",
       "inBundle": true,
       "license": "MIT"
     },
@@ -26689,7 +26451,7 @@
       "license": "MIT"
     },
     "node_modules/meteor-node-stubs/node_modules/qs": {
-      "version": "6.14.0",
+      "version": "6.14.2",
       "inBundle": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -26805,15 +26567,22 @@
       "license": "MIT"
     },
     "node_modules/meteor-node-stubs/node_modules/sha.js": {
-      "version": "2.4.11",
+      "version": "2.4.12",
       "inBundle": true,
       "license": "(MIT AND BSD-3-Clause)",
       "dependencies": {
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
+        "inherits": "^2.0.4",
+        "safe-buffer": "^5.2.1",
+        "to-buffer": "^1.2.0"
       },
       "bin": {
         "sha.js": "bin.js"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/meteor-node-stubs/node_modules/side-channel": {
@@ -27587,7 +27356,7 @@
     },
     "node_modules/mimic-response": {
       "version": "3.1.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -27598,10 +27367,12 @@
     },
     "node_modules/minimalistic-assert": {
       "version": "1.0.1",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/minimalistic-crypto-utils": {
       "version": "1.0.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/minimatch": {
@@ -27843,12 +27614,6 @@
       "bin": {
         "mkdirp": "bin/cmd.js"
       }
-    },
-    "node_modules/mkdirp-classic": {
-      "version": "0.5.3",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
     },
     "node_modules/mocha": {
       "version": "10.8.2",
@@ -28214,12 +27979,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/napi-build-utils": {
-      "version": "2.0.0",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
     },
     "node_modules/natives": {
       "version": "1.1.6",
@@ -28703,7 +28462,7 @@
     },
     "node_modules/node-abi": {
       "version": "3.85.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "semver": "^7.3.5"
@@ -28714,7 +28473,7 @@
     },
     "node_modules/node-abi/node_modules/semver": {
       "version": "7.7.3",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -29056,10 +28815,6 @@
       "integrity": "sha512-9d1HbpKLh3sdWlhXMhU6MMH+wQzKkrgfRkYV0EBdvt99YJfj0ilCJrWRDYG2130Tm4GXbEoTCx5b34JSaP+HhA==",
       "license": "MIT"
     },
-    "node_modules/notation": {
-      "version": "1.3.6",
-      "license": "MIT"
-    },
     "node_modules/npm-package-arg": {
       "version": "11.0.3",
       "license": "ISC",
@@ -29132,10 +28887,6 @@
     },
     "node_modules/oauth2-server/node_modules/bluebird": {
       "version": "3.5.0",
-      "license": "MIT"
-    },
-    "node_modules/oauth2-server/node_modules/lodash": {
-      "version": "4.17.4",
       "license": "MIT"
     },
     "node_modules/oauth2-server/node_modules/statuses": {
@@ -29687,49 +29438,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/onnx-proto": {
-      "version": "4.0.4",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "protobufjs": "^6.8.8"
-      }
-    },
-    "node_modules/onnxruntime-common": {
-      "version": "1.14.0",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
-    "node_modules/onnxruntime-node": {
-      "version": "1.14.0",
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32",
-        "darwin",
-        "linux"
-      ],
-      "peer": true,
-      "dependencies": {
-        "onnxruntime-common": "~1.14.0"
-      }
-    },
-    "node_modules/onnxruntime-web": {
-      "version": "1.14.0",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "flatbuffers": "^1.12.0",
-        "guid-typescript": "^1.0.9",
-        "long": "^4.0.0",
-        "onnx-proto": "^4.0.4",
-        "onnxruntime-common": "~1.14.0",
-        "platform": "^1.3.6"
       }
     },
     "node_modules/open": {
@@ -30569,12 +30277,6 @@
       "version": "2.8.1",
       "license": "0BSD"
     },
-    "node_modules/platform": {
-      "version": "1.3.6",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/playwright": {
       "version": "1.57.0",
       "license": "Apache-2.0",
@@ -30743,50 +30445,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
-      }
-    },
-    "node_modules/prebuild-install": {
-      "version": "7.1.3",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "detect-libc": "^2.0.0",
-        "expand-template": "^2.0.3",
-        "github-from-package": "0.0.0",
-        "minimist": "^1.2.3",
-        "mkdirp-classic": "^0.5.3",
-        "napi-build-utils": "^2.0.0",
-        "node-abi": "^3.3.0",
-        "pump": "^3.0.0",
-        "rc": "^1.2.7",
-        "simple-get": "^4.0.0",
-        "tar-fs": "^2.0.0",
-        "tunnel-agent": "^0.6.0"
-      },
-      "bin": {
-        "prebuild-install": "bin.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/prebuild-install/node_modules/chownr": {
-      "version": "1.1.4",
-      "license": "ISC",
-      "optional": true,
-      "peer": true
-    },
-    "node_modules/prebuild-install/node_modules/tar-fs": {
-      "version": "2.1.4",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "chownr": "^1.1.1",
-        "mkdirp-classic": "^0.5.2",
-        "pump": "^3.0.0",
-        "tar-stream": "^2.1.4"
       }
     },
     "node_modules/prelude-ls": {
@@ -30971,32 +30629,6 @@
       "version": "1.2.4",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/protobufjs": {
-      "version": "6.11.4",
-      "hasInstallScript": true,
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
-        "@types/long": "^4.0.1",
-        "@types/node": ">=13.7.0",
-        "long": "^4.0.0"
-      },
-      "bin": {
-        "pbjs": "bin/pbjs",
-        "pbts": "bin/pbts"
-      }
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
@@ -31296,21 +30928,6 @@
         "quickselect": "^3.0.0"
       }
     },
-    "node_modules/rc": {
-      "version": "1.2.8",
-      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "deep-extend": "^0.6.0",
-        "ini": "~1.3.0",
-        "minimist": "^1.2.0",
-        "strip-json-comments": "~2.0.1"
-      },
-      "bin": {
-        "rc": "cli.js"
-      }
-    },
     "node_modules/rc-align": {
       "version": "2.4.5",
       "license": "MIT",
@@ -31360,15 +30977,6 @@
     "node_modules/rc-util/node_modules/react-is": {
       "version": "16.13.1",
       "license": "MIT"
-    },
-    "node_modules/rc/node_modules/strip-json-comments": {
-      "version": "2.0.1",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/react": {
       "version": "18.3.1",
@@ -32459,17 +32067,6 @@
       "license": "BSD-3-Clause",
       "optional": true
     },
-    "node_modules/role-acl": {
-      "version": "4.5.4",
-      "license": "MIT",
-      "dependencies": {
-        "jsonpath-plus": "^0.18.0",
-        "lodash.clonedeep": "^4.5.0",
-        "lodash.flattendeep": "^4.4.0",
-        "matcher": "^1.0.0",
-        "notation": "^1.3.5"
-      }
-    },
     "node_modules/rollup": {
       "version": "3.30.0",
       "dev": true,
@@ -33051,47 +32648,6 @@
       "version": "1.1.0",
       "license": "MIT"
     },
-    "node_modules/sharp": {
-      "version": "0.32.6",
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "color": "^4.2.3",
-        "detect-libc": "^2.0.2",
-        "node-addon-api": "^6.1.0",
-        "prebuild-install": "^7.1.1",
-        "semver": "^7.5.4",
-        "simple-get": "^4.0.1",
-        "tar-fs": "^3.0.4",
-        "tunnel-agent": "^0.6.0"
-      },
-      "engines": {
-        "node": ">=14.15.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/sharp/node_modules/node-addon-api": {
-      "version": "6.1.0",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
-    "node_modules/sharp/node_modules/semver": {
-      "version": "7.7.3",
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "license": "MIT",
@@ -33117,7 +32673,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.3",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
       "devOptional": true,
       "license": "MIT",
       "engines": {
@@ -33236,54 +32794,9 @@
         "npm": ">=8"
       }
     },
-    "node_modules/simple-concat": {
-      "version": "1.0.1",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/simple-fmt": {
       "version": "0.1.0",
       "license": "MIT"
-    },
-    "node_modules/simple-get": {
-      "version": "4.0.1",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "decompress-response": "^6.0.0",
-        "once": "^1.3.1",
-        "simple-concat": "^1.0.0"
-      }
     },
     "node_modules/simple-is": {
       "version": "0.2.0",
@@ -33299,21 +32812,6 @@
         "bplist-parser": "0.3.1",
         "plist": "^3.0.5"
       }
-    },
-    "node_modules/simple-swizzle": {
-      "version": "0.2.4",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "is-arrayish": "^0.3.1"
-      }
-    },
-    "node_modules/simple-swizzle/node_modules/is-arrayish": {
-      "version": "0.3.4",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
     },
     "node_modules/simple-update-notifier": {
       "version": "2.0.0",
@@ -34087,17 +33585,6 @@
       "version": "0.1.2",
       "license": "BSD-3-Clause"
     },
-    "node_modules/streamx": {
-      "version": "2.23.0",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "events-universal": "^1.0.0",
-        "fast-fifo": "^1.3.2",
-        "text-decoder": "^1.1.0"
-      }
-    },
     "node_modules/string_decoder": {
       "version": "0.10.31",
       "license": "MIT"
@@ -34476,48 +33963,9 @@
         "node": ">=10"
       }
     },
-    "node_modules/tar-fs": {
-      "version": "3.1.1",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "pump": "^3.0.0",
-        "tar-stream": "^3.1.5"
-      },
-      "optionalDependencies": {
-        "bare-fs": "^4.0.1",
-        "bare-path": "^3.0.0"
-      }
-    },
-    "node_modules/tar-fs/node_modules/b4a": {
-      "version": "1.7.3",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "peerDependencies": {
-        "react-native-b4a": "*"
-      },
-      "peerDependenciesMeta": {
-        "react-native-b4a": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/tar-fs/node_modules/tar-stream": {
-      "version": "3.1.7",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "b4a": "^1.6.4",
-        "fast-fifo": "^1.2.0",
-        "streamx": "^2.15.0"
-      }
-    },
     "node_modules/tar-stream": {
       "version": "2.2.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "bl": "^4.0.3",
@@ -34532,7 +33980,7 @@
     },
     "node_modules/tar-stream/node_modules/end-of-stream": {
       "version": "1.4.5",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
@@ -34540,7 +33988,7 @@
     },
     "node_modules/tar-stream/node_modules/readable-stream": {
       "version": "3.6.2",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.3",
@@ -34553,7 +34001,7 @@
     },
     "node_modules/tar-stream/node_modules/string_decoder": {
       "version": "1.3.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
@@ -34798,29 +34246,6 @@
       },
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/text-decoder": {
-      "version": "1.2.3",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "b4a": "^1.6.4"
-      }
-    },
-    "node_modules/text-decoder/node_modules/b4a": {
-      "version": "1.7.3",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "peerDependencies": {
-        "react-native-b4a": "*"
-      },
-      "peerDependenciesMeta": {
-        "react-native-b4a": {
-          "optional": true
-        }
       }
     },
     "node_modules/text-hex": {
@@ -35391,18 +34816,6 @@
       "version": "0.0.1",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/tunnel-agent": {
-      "version": "0.6.0",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
-      },
-      "engines": {
-        "node": "*"
-      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "start": "meteor run",
     "test": "meteor test --once --driver-package meteortesting:mocha",
     "test:lib": "bash scripts/run-lib-tests.sh",
+    "test:acl": "node --test server/lib/CaslAccessControl.parity.test.mjs",
     "test-app": "TEST_WATCH=1 meteor test --full-app --driver-package meteortesting:mocha",
     "visualize": "meteor --production --extra-packages bundle-visualizer",
     "desktop": "meteor-desktop",
@@ -28,13 +29,13 @@
     "postinstall": "node scripts/copy-cesium-assets.js"
   },
   "dependencies": {
-    "fqm-execution": "1.8.5",
     "@accounts/client": "0.33.1",
     "@accounts/client-password": "0.32.2",
     "@accounts/mongo": "0.34.1",
     "@accounts/rest-client": "0.33.1",
     "@accounts/server": "0.33.1",
     "@breejs/later": "4.1.0",
+    "@casl/ability": "^7.0.0",
     "@cornerstonejs/core": "^1.78.0",
     "@cornerstonejs/dicom-image-loader": "^1.78.0",
     "@cornerstonejs/streaming-image-volume-loader": "^1.78.0",
@@ -94,6 +95,7 @@
     "file-dialog": "0.0.8",
     "formidable": "^3.5.4",
     "formik": "^2.4.6",
+    "fqm-execution": "1.8.5",
     "google-map-react": "2.2.1",
     "history": "^5.3.0",
     "jsonwebtoken": "^9.0.2",
@@ -101,7 +103,7 @@
     "lodash": "4.17.21",
     "material-ui-rc-color-picker": "1.0.4",
     "meteor": "^3.3.2",
-    "meteor-node-stubs": "1.2.21",
+    "meteor-node-stubs": "1.2.27",
     "moment": "^2.29.4",
     "mongo-query": "^0.5.7",
     "mongoose": "^8.5.3",
@@ -125,7 +127,6 @@
     "react-simple-chatbot": "0.6.1",
     "react-swipeable": "^7.0.1",
     "react18-vis-timeline": "2.0.4",
-    "role-acl": "^4.5.4",
     "sanitize-html": "^2.17.0",
     "setimmediate": "^1.0.5",
     "simpl-schema": "^3.4.6",
@@ -172,6 +173,12 @@
     "bson": "^6.8.0",
     "mongodb": "^6.8.0",
     "color-convert": "^3.1.2",
-    "glob": "^11.0.0"
+    "glob": "^11.0.0",
+    "sha.js": "^2.4.12",
+    "shell-quote": "^1.8.4",
+    "protobufjs": "^8.0.1",
+    "oauth2-server": {
+      "lodash": "^4.17.21"
+    }
   }
 }

--- a/server/ConsentEngineHttp.js
+++ b/server/ConsentEngineHttp.js
@@ -2,7 +2,7 @@
 import { Consents } from '../imports/lib/schemas/SimpleSchemas/Consents';
 import { FhirUtilities } from '../imports/lib/FhirUtilities';
 
-import { AccessControl } from 'role-acl';
+import { AccessControl } from './lib/CaslAccessControl.js';
 
 import { Meteor } from 'meteor/meteor';
 import { Random } from 'meteor/random';

--- a/server/FhirEndpoints.js
+++ b/server/FhirEndpoints.js
@@ -788,7 +788,9 @@ if(typeof serverRouteManifest === "object"){
                         console.log('Checking if role exists:', roles.includes(userRole));
                         
                         if(roles.includes(userRole)) {
-                          permission = acl.can(userRole).execute('access').sync().on(routeResourceType);
+                          // Pass the record's actual security label so confidentiality
+                          // clearance is enforced against this record (not a default).
+                          permission = acl.can(userRole).execute('access').with({securityLabel: recordSecurityLevel}).sync().on(routeResourceType);
                           accessGranted = permission.granted;
                           console.log('Permission check details:');
                           console.log('  - Role:', userRole);

--- a/server/lib/CaslAccessControl.js
+++ b/server/lib/CaslAccessControl.js
@@ -1,0 +1,177 @@
+// server/lib/CaslAccessControl.js
+// Drop-in replacement for role-acl's `AccessControl`, backed by CASL. It re-exposes
+// the exact subset of role-acl's fluent surface that this codebase uses, so call
+// sites in FhirEndpoints.js / DicomEndpoints.js / ConsentEngineHttp.js change zero
+// lines — only the import source swaps from 'role-acl' to './CaslAccessControl.js'.
+//
+// Behavior faithfully reproduces role-acl's verified runtime quirks for the RBAC
+// allow-list (the "coat-check" defense):
+//   - unknown role throws AccessControlError: Role not found: "<role>"
+//   - grant('<role>') with no .on() does NOT register the role (query throws -> deny)
+//   - comma-joined action strings ("access, correct") match any element
+//   - valid role / no matching rule -> { granted:false, attributes:[] } (no throw)
+//   - .sync() returns a plain object; the async form (no .sync()) returns a Promise
+//
+// It INTENTIONALLY diverges from role-acl in one way: confidentiality conditions
+// are actually enforced (role-acl ignored fluent .when()). A record's meta.security
+// label is compared ordinally against the role's clearance. This is the deliberate
+// "make enforcement real" change from the approved plan; it only affects requests
+// against labeled records and is covered by the decision-matrix test.
+
+import {
+  aclRecordToPermissionRule,
+  compilePermissionRules,
+  clearanceForRole,
+  rankOfLabel,
+  labelFromContext,
+  splitActions
+} from './PermissionModel.js';
+
+export class AccessControlError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'AccessControlError';
+  }
+}
+
+// Returned by acl.grant(role) — accumulates a grant via .execute().on().when().
+class GrantBuilder {
+  constructor(acl, role) {
+    this._acl = acl;
+    this._role = role;
+    this._action = undefined;
+  }
+  execute(action) {
+    this._action = action;
+    return this;
+  }
+  on(resource, attributes = ['*']) {
+    // A grant only registers its role once it targets a resource+action — matching
+    // role-acl, where a bare grant('PAT') leaves PAT unqueryable.
+    const rule = this._acl._addRecord({
+      role: this._role,
+      action: this._action,
+      resource,
+      attributes
+    });
+    // role-acl returns the grant so callers can chain .when(); preserve that.
+    return {
+      when: (condition) => {
+        if (rule && condition) {
+          rule._condition = condition;
+          this._acl._dirty = true;
+        }
+        return this;
+      }
+    };
+  }
+}
+
+// Returned by acl.can(role) — builds and evaluates a permission query.
+class Query {
+  constructor(acl, role) {
+    this._acl = acl;
+    this._role = role;
+    this._action = undefined;
+    this._ctx = {};
+    this._sync = false;
+  }
+  execute(action) {
+    this._action = action;
+    return this;
+  }
+  with(ctx) {
+    this._ctx = ctx || {};
+    return this;
+  }
+  sync() {
+    this._sync = true;
+    return this;
+  }
+  on(resource) {
+    const result = this._acl._evaluate(this._role, this._action, resource, this._ctx);
+    return this._sync ? result : Promise.resolve(result);
+  }
+}
+
+export class AccessControl {
+  // `records` (optional) is the object-form constructor used by ConsentEngineHttp:
+  // an array of flat role-acl grant records ({ role, action, resource, attributes, condition? }).
+  constructor(records) {
+    this._rules = [];          // minimal Permission.rule[] — the internal IR
+    this._roles = new Set();   // roles with at least one completed grant
+    this._abilities = null;    // Map<role, MongoAbility>, compiled lazily
+    this._dirty = true;
+    if (Array.isArray(records)) {
+      records.forEach((rec) => this._addRecord(rec));
+    }
+  }
+
+  grant(role) {
+    return new GrantBuilder(this, role);
+  }
+
+  can(role) {
+    return new Query(this, role);
+  }
+
+  getRoles() {
+    return [...this._roles];
+  }
+
+  getGrants() {
+    return this._rules;
+  }
+
+  // Append a flat grant record as a Permission.rule. Returns the stored rule so
+  // GrantBuilder.when() can attach a condition to it. A record without a resource
+  // or action does not register the role (matches role-acl's bare-grant behavior).
+  _addRecord(rec) {
+    if (!rec || !rec.role || !rec.resource || !rec.action) return null;
+    const rule = aclRecordToPermissionRule(rec);
+    this._rules.push(rule);
+    this._roles.add(rec.role);
+    this._dirty = true;
+    return rule;
+  }
+
+  _abilitiesMap() {
+    if (this._dirty || !this._abilities) {
+      this._abilities = compilePermissionRules(this._rules);
+      this._dirty = false;
+    }
+    return this._abilities;
+  }
+
+  _evaluate(role, action, resource, ctx) {
+    // role-acl throws on an unknown/unregistered role; endpoints catch this -> deny.
+    if (!this._roles.has(role)) {
+      throw new AccessControlError(`Role not found: "${role}"`);
+    }
+
+    const ability = this._abilitiesMap().get(role);
+    const label = labelFromContext(ctx);
+    const subject = {
+      type: resource,
+      confidentiality: label == null ? undefined : String(label).trim()
+    };
+
+    // Axis 1: RBAC allow-list (role x resource x action), incl. any EQUALS condition.
+    let rbacGranted = false;
+    const actions = splitActions(action);
+    for (const a of actions) {
+      if (ability && ability.can(a, subject)) {
+        rbacGranted = true;
+        break;
+      }
+    }
+
+    // Axis 2: confidentiality clearance (ordinal). Unlabeled -> 'normal' by default.
+    const clearanceOk = rankOfLabel(label) <= clearanceForRole(role);
+
+    const granted = rbacGranted && clearanceOk;
+    return { granted, attributes: granted ? ['*'] : [] };
+  }
+}
+
+export default AccessControl;

--- a/server/lib/CaslAccessControl.parity.golden.json
+++ b/server/lib/CaslAccessControl.parity.golden.json
@@ -1,0 +1,486 @@
+{
+  "citizen|access|Patient": {
+    "granted": true,
+    "attributes": [
+      "*"
+    ]
+  },
+  "citizen|read|Patient": {
+    "granted": false,
+    "attributes": []
+  },
+  "citizen|correct|Patient": {
+    "granted": false,
+    "attributes": []
+  },
+  "citizen|access|Organization": {
+    "granted": true,
+    "attributes": [
+      "*"
+    ]
+  },
+  "citizen|read|Organization": {
+    "granted": false,
+    "attributes": []
+  },
+  "citizen|correct|Organization": {
+    "granted": false,
+    "attributes": []
+  },
+  "citizen|access|Observation": {
+    "granted": false,
+    "attributes": []
+  },
+  "citizen|read|Observation": {
+    "granted": false,
+    "attributes": []
+  },
+  "citizen|correct|Observation": {
+    "granted": false,
+    "attributes": []
+  },
+  "citizen|access|Consent": {
+    "granted": false,
+    "attributes": []
+  },
+  "citizen|read|Consent": {
+    "granted": false,
+    "attributes": []
+  },
+  "citizen|correct|Consent": {
+    "granted": false,
+    "attributes": []
+  },
+  "citizen|access|VisionPrescription": {
+    "granted": false,
+    "attributes": []
+  },
+  "citizen|read|VisionPrescription": {
+    "granted": false,
+    "attributes": []
+  },
+  "citizen|correct|VisionPrescription": {
+    "granted": false,
+    "attributes": []
+  },
+  "patient|access|Patient": {
+    "granted": true,
+    "attributes": [
+      "*"
+    ]
+  },
+  "patient|read|Patient": {
+    "granted": false,
+    "attributes": []
+  },
+  "patient|correct|Patient": {
+    "granted": false,
+    "attributes": []
+  },
+  "patient|access|Organization": {
+    "granted": false,
+    "attributes": []
+  },
+  "patient|read|Organization": {
+    "granted": false,
+    "attributes": []
+  },
+  "patient|correct|Organization": {
+    "granted": false,
+    "attributes": []
+  },
+  "patient|access|Observation": {
+    "granted": true,
+    "attributes": [
+      "*"
+    ]
+  },
+  "patient|read|Observation": {
+    "granted": false,
+    "attributes": []
+  },
+  "patient|correct|Observation": {
+    "granted": false,
+    "attributes": []
+  },
+  "patient|access|Consent": {
+    "granted": false,
+    "attributes": []
+  },
+  "patient|read|Consent": {
+    "granted": false,
+    "attributes": []
+  },
+  "patient|correct|Consent": {
+    "granted": false,
+    "attributes": []
+  },
+  "patient|access|VisionPrescription": {
+    "granted": false,
+    "attributes": []
+  },
+  "patient|read|VisionPrescription": {
+    "granted": false,
+    "attributes": []
+  },
+  "patient|correct|VisionPrescription": {
+    "granted": false,
+    "attributes": []
+  },
+  "healthcare provider|access|Patient": {
+    "granted": true,
+    "attributes": [
+      "*"
+    ]
+  },
+  "healthcare provider|read|Patient": {
+    "granted": false,
+    "attributes": []
+  },
+  "healthcare provider|correct|Patient": {
+    "granted": true,
+    "attributes": [
+      "*"
+    ]
+  },
+  "healthcare provider|access|Organization": {
+    "granted": true,
+    "attributes": [
+      "*"
+    ]
+  },
+  "healthcare provider|read|Organization": {
+    "granted": false,
+    "attributes": []
+  },
+  "healthcare provider|correct|Organization": {
+    "granted": true,
+    "attributes": [
+      "*"
+    ]
+  },
+  "healthcare provider|access|Observation": {
+    "granted": true,
+    "attributes": [
+      "*"
+    ]
+  },
+  "healthcare provider|read|Observation": {
+    "granted": false,
+    "attributes": []
+  },
+  "healthcare provider|correct|Observation": {
+    "granted": false,
+    "attributes": []
+  },
+  "healthcare provider|access|Consent": {
+    "granted": false,
+    "attributes": []
+  },
+  "healthcare provider|read|Consent": {
+    "granted": false,
+    "attributes": []
+  },
+  "healthcare provider|correct|Consent": {
+    "granted": false,
+    "attributes": []
+  },
+  "healthcare provider|access|VisionPrescription": {
+    "granted": false,
+    "attributes": []
+  },
+  "healthcare provider|read|VisionPrescription": {
+    "granted": false,
+    "attributes": []
+  },
+  "healthcare provider|correct|VisionPrescription": {
+    "granted": false,
+    "attributes": []
+  },
+  "healthcare practitioner|access|Patient": {
+    "granted": true,
+    "attributes": [
+      "*"
+    ]
+  },
+  "healthcare practitioner|read|Patient": {
+    "granted": false,
+    "attributes": []
+  },
+  "healthcare practitioner|correct|Patient": {
+    "granted": false,
+    "attributes": []
+  },
+  "healthcare practitioner|access|Organization": {
+    "granted": false,
+    "attributes": []
+  },
+  "healthcare practitioner|read|Organization": {
+    "granted": false,
+    "attributes": []
+  },
+  "healthcare practitioner|correct|Organization": {
+    "granted": false,
+    "attributes": []
+  },
+  "healthcare practitioner|access|Observation": {
+    "granted": true,
+    "attributes": [
+      "*"
+    ]
+  },
+  "healthcare practitioner|read|Observation": {
+    "granted": false,
+    "attributes": []
+  },
+  "healthcare practitioner|correct|Observation": {
+    "granted": false,
+    "attributes": []
+  },
+  "healthcare practitioner|access|Consent": {
+    "granted": false,
+    "attributes": []
+  },
+  "healthcare practitioner|read|Consent": {
+    "granted": false,
+    "attributes": []
+  },
+  "healthcare practitioner|correct|Consent": {
+    "granted": false,
+    "attributes": []
+  },
+  "healthcare practitioner|access|VisionPrescription": {
+    "granted": false,
+    "attributes": []
+  },
+  "healthcare practitioner|read|VisionPrescription": {
+    "granted": false,
+    "attributes": []
+  },
+  "healthcare practitioner|correct|VisionPrescription": {
+    "granted": false,
+    "attributes": []
+  },
+  "SYSTEM|access|Patient": {
+    "granted": true,
+    "attributes": [
+      "*"
+    ]
+  },
+  "SYSTEM|read|Patient": {
+    "granted": false,
+    "attributes": []
+  },
+  "SYSTEM|correct|Patient": {
+    "granted": false,
+    "attributes": []
+  },
+  "SYSTEM|access|Organization": {
+    "granted": true,
+    "attributes": [
+      "*"
+    ]
+  },
+  "SYSTEM|read|Organization": {
+    "granted": false,
+    "attributes": []
+  },
+  "SYSTEM|correct|Organization": {
+    "granted": false,
+    "attributes": []
+  },
+  "SYSTEM|access|Observation": {
+    "granted": true,
+    "attributes": [
+      "*"
+    ]
+  },
+  "SYSTEM|read|Observation": {
+    "granted": false,
+    "attributes": []
+  },
+  "SYSTEM|correct|Observation": {
+    "granted": false,
+    "attributes": []
+  },
+  "SYSTEM|access|Consent": {
+    "granted": true,
+    "attributes": [
+      "*"
+    ]
+  },
+  "SYSTEM|read|Consent": {
+    "granted": false,
+    "attributes": []
+  },
+  "SYSTEM|correct|Consent": {
+    "granted": false,
+    "attributes": []
+  },
+  "SYSTEM|access|VisionPrescription": {
+    "granted": false,
+    "attributes": []
+  },
+  "SYSTEM|read|VisionPrescription": {
+    "granted": false,
+    "attributes": []
+  },
+  "SYSTEM|correct|VisionPrescription": {
+    "granted": false,
+    "attributes": []
+  },
+  "system|access|Patient": {
+    "granted": true,
+    "attributes": [
+      "*"
+    ]
+  },
+  "system|read|Patient": {
+    "granted": false,
+    "attributes": []
+  },
+  "system|correct|Patient": {
+    "granted": true,
+    "attributes": [
+      "*"
+    ]
+  },
+  "system|access|Organization": {
+    "granted": false,
+    "attributes": []
+  },
+  "system|read|Organization": {
+    "granted": false,
+    "attributes": []
+  },
+  "system|correct|Organization": {
+    "granted": false,
+    "attributes": []
+  },
+  "system|access|Observation": {
+    "granted": false,
+    "attributes": []
+  },
+  "system|read|Observation": {
+    "granted": false,
+    "attributes": []
+  },
+  "system|correct|Observation": {
+    "granted": false,
+    "attributes": []
+  },
+  "system|access|Consent": {
+    "granted": false,
+    "attributes": []
+  },
+  "system|read|Consent": {
+    "granted": false,
+    "attributes": []
+  },
+  "system|correct|Consent": {
+    "granted": false,
+    "attributes": []
+  },
+  "system|access|VisionPrescription": {
+    "granted": false,
+    "attributes": []
+  },
+  "system|read|VisionPrescription": {
+    "granted": false,
+    "attributes": []
+  },
+  "system|correct|VisionPrescription": {
+    "granted": false,
+    "attributes": []
+  },
+  "PAT|access|Patient": {
+    "threw": "Role not found: \"PAT\""
+  },
+  "PAT|read|Patient": {
+    "threw": "Role not found: \"PAT\""
+  },
+  "PAT|correct|Patient": {
+    "threw": "Role not found: \"PAT\""
+  },
+  "PAT|access|Organization": {
+    "threw": "Role not found: \"PAT\""
+  },
+  "PAT|read|Organization": {
+    "threw": "Role not found: \"PAT\""
+  },
+  "PAT|correct|Organization": {
+    "threw": "Role not found: \"PAT\""
+  },
+  "PAT|access|Observation": {
+    "threw": "Role not found: \"PAT\""
+  },
+  "PAT|read|Observation": {
+    "threw": "Role not found: \"PAT\""
+  },
+  "PAT|correct|Observation": {
+    "threw": "Role not found: \"PAT\""
+  },
+  "PAT|access|Consent": {
+    "threw": "Role not found: \"PAT\""
+  },
+  "PAT|read|Consent": {
+    "threw": "Role not found: \"PAT\""
+  },
+  "PAT|correct|Consent": {
+    "threw": "Role not found: \"PAT\""
+  },
+  "PAT|access|VisionPrescription": {
+    "threw": "Role not found: \"PAT\""
+  },
+  "PAT|read|VisionPrescription": {
+    "threw": "Role not found: \"PAT\""
+  },
+  "PAT|correct|VisionPrescription": {
+    "threw": "Role not found: \"PAT\""
+  },
+  "ghost|access|Patient": {
+    "threw": "Role not found: \"ghost\""
+  },
+  "ghost|read|Patient": {
+    "threw": "Role not found: \"ghost\""
+  },
+  "ghost|correct|Patient": {
+    "threw": "Role not found: \"ghost\""
+  },
+  "ghost|access|Organization": {
+    "threw": "Role not found: \"ghost\""
+  },
+  "ghost|read|Organization": {
+    "threw": "Role not found: \"ghost\""
+  },
+  "ghost|correct|Organization": {
+    "threw": "Role not found: \"ghost\""
+  },
+  "ghost|access|Observation": {
+    "threw": "Role not found: \"ghost\""
+  },
+  "ghost|read|Observation": {
+    "threw": "Role not found: \"ghost\""
+  },
+  "ghost|correct|Observation": {
+    "threw": "Role not found: \"ghost\""
+  },
+  "ghost|access|Consent": {
+    "threw": "Role not found: \"ghost\""
+  },
+  "ghost|read|Consent": {
+    "threw": "Role not found: \"ghost\""
+  },
+  "ghost|correct|Consent": {
+    "threw": "Role not found: \"ghost\""
+  },
+  "ghost|access|VisionPrescription": {
+    "threw": "Role not found: \"ghost\""
+  },
+  "ghost|read|VisionPrescription": {
+    "threw": "Role not found: \"ghost\""
+  },
+  "ghost|correct|VisionPrescription": {
+    "threw": "Role not found: \"ghost\""
+  }
+}

--- a/server/lib/CaslAccessControl.parity.test.mjs
+++ b/server/lib/CaslAccessControl.parity.test.mjs
@@ -1,0 +1,188 @@
+// server/lib/CaslAccessControl.parity.test.mjs
+//
+// Fast (no Meteor / no Mongo) characterization tests for the role-acl -> CASL
+// migration. Run with:  node --test server/lib/CaslAccessControl.parity.test.mjs
+//
+// Three concerns:
+//   1. RBAC parity  — over an unrestricted-label sweep (where the new clearance
+//      gate never bites), the CASL facade must return EXACTLY the golden values
+//      captured from role-acl (granted, attributes, throw). Proves the coat-check
+//      allow-list is preserved bit-for-bit. The golden fixture
+//      (CaslAccessControl.parity.golden.json) was generated from role-acl while it
+//      was still installed; if role-acl is STILL importable we also assert it
+//      still matches the golden (drift guard), otherwise that sub-check is skipped.
+//   2. Decision matrix — the NEW confidentiality enforcement (role x record-label).
+//   3. Quirks — bare grant() doesn't register; unknown role throws; comma-split;
+//      object-form honors conditions.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import { AccessControl, AccessControlError } from './CaslAccessControl.js';
+import { clearanceForRole, rankOfLabel, labelFromContext } from './PermissionModel.js';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const GOLDEN = JSON.parse(readFileSync(join(HERE, 'CaslAccessControl.parity.golden.json'), 'utf8'));
+
+// role-acl may already be removed; import it lazily for the optional drift guard.
+let RoleAcl = null;
+try {
+  const m = await import('role-acl');
+  RoleAcl = m.AccessControl || m.default?.AccessControl || m.default;
+} catch { /* removed — golden-only mode */ }
+
+// ----------------------------------------------------------------------------
+// Shared grant set — fed IDENTICALLY to both engines. Mirrors the structure of
+// FhirAuth.initializeAccessControl(): consent-derived grants (the 7 defaults) +
+// a representative slice of the hardcoded grants + the bare PAT grant. MUST stay
+// in sync with the generator used to produce the golden fixture.
+// ----------------------------------------------------------------------------
+function applyGrants(acl) {
+  acl.grant('citizen').execute('access').on('Organization', ['*']);
+  acl.grant('citizen').execute('access').on('Patient', ['*']);
+  acl.grant('citizen').execute('access').on('Practitioner', ['*']);
+  acl.grant('healthcare provider').execute('access, correct').on('Organization', ['*']);
+  acl.grant('healthcare provider').execute('access, correct').on('Patient', ['*']);
+  acl.grant('patient').execute('access').on('Patient', ['*']);
+  acl.grant('system').execute('access, correct').on('Patient', ['*']);
+  ['PractitionerRole', 'Location', 'HealthcareService', 'Endpoint'].forEach((r) =>
+    acl.grant('citizen').execute('access').on(r, ['*']));
+  ['Observation', 'Condition', 'AllergyIntolerance', 'Immunization', 'DocumentReference'].forEach((r) =>
+    acl.grant('patient').execute('access').on(r, ['*']));
+  ['Patient', 'Observation', 'Consent', 'Organization', 'DocumentReference'].forEach((r) =>
+    acl.grant('SYSTEM').execute('access').on(r, ['*']));
+  ['Patient', 'Observation', 'Condition', 'DocumentReference'].forEach((r) => {
+    acl.grant('healthcare practitioner').execute('access').on(r, ['*']);
+    acl.grant('healthcare provider').execute('access').on(r, ['*']);
+  });
+  acl.grant('PAT'); // bare grant, no execute/on -> must NOT register
+  return acl;
+}
+
+function evalSync(acl, role, action, resource, ctx) {
+  try {
+    let q = acl.can(role).execute(action);
+    if (ctx) q = q.with(ctx);
+    const r = q.sync().on(resource);
+    return { granted: r.granted, attributes: r.attributes };
+  } catch (e) {
+    return { threw: e.message };
+  }
+}
+
+const ROLES = ['citizen', 'patient', 'healthcare provider', 'healthcare practitioner', 'SYSTEM', 'system', 'PAT', 'ghost'];
+const RESOURCES = ['Patient', 'Organization', 'Observation', 'Consent', 'VisionPrescription'];
+const ACTIONS = ['access', 'read', 'correct'];
+const UNRESTRICTED = { securityLabel: 'unrestricted' }; // rank U(0) <= every role's clearance
+
+// ----------------------------------------------------------------------------
+// 1. RBAC parity — CASL facade must equal the golden (role-acl) values
+// ----------------------------------------------------------------------------
+test('RBAC allow-list matches golden (role-acl) values', () => {
+  const ca = applyGrants(new AccessControl());
+  for (const role of ROLES) {
+    for (const resource of RESOURCES) {
+      for (const action of ACTIONS) {
+        const key = `${role}|${action}|${resource}`;
+        const actual = evalSync(ca, role, action, resource, UNRESTRICTED);
+        assert.deepEqual(actual, GOLDEN[key], `casl != golden at ${key}\n  golden=${JSON.stringify(GOLDEN[key])}\n  casl  =${JSON.stringify(actual)}`);
+      }
+    }
+  }
+});
+
+test('golden fixture still matches role-acl (drift guard)', { skip: RoleAcl ? false : 'role-acl not installed' }, () => {
+  const ra = applyGrants(new RoleAcl());
+  for (const role of ROLES) {
+    for (const resource of RESOURCES) {
+      for (const action of ACTIONS) {
+        const key = `${role}|${action}|${resource}`;
+        assert.deepEqual(evalSync(ra, role, action, resource, UNRESTRICTED), GOLDEN[key], `role-acl != golden at ${key}`);
+      }
+    }
+  }
+});
+
+// ----------------------------------------------------------------------------
+// 2. Decision matrix — NEW confidentiality enforcement
+// ----------------------------------------------------------------------------
+test('confidentiality clearance gate (role x record-label)', () => {
+  const ca = applyGrants(new AccessControl());
+  const G = (role, resource, label) =>
+    evalSync(ca, role, 'access', resource, label === undefined ? undefined : { securityLabel: label }).granted;
+
+  // citizen (clearance U): only explicitly-unrestricted records of a granted type
+  assert.equal(G('citizen', 'Patient', 'unrestricted'), true);
+  assert.equal(G('citizen', 'Patient', 'normal'), false);
+  assert.equal(G('citizen', 'Patient', undefined), false); // unlabeled defaults to normal
+  assert.equal(G('citizen', 'Patient', 'restricted'), false);
+
+  // patient (clearance N): up to normal, not restricted
+  assert.equal(G('patient', 'Patient', 'normal'), true);
+  assert.equal(G('patient', 'Patient', undefined), true);
+  assert.equal(G('patient', 'Patient', 'restricted'), false);
+  assert.equal(G('patient', 'Patient', 'very restricted'), false);
+
+  // healthcare provider (clearance R): up to restricted, not very-restricted
+  assert.equal(G('healthcare provider', 'Patient', 'restricted'), true);
+  assert.equal(G('healthcare provider', 'Patient', 'very restricted'), false);
+
+  // SYSTEM (clearance V): everything
+  assert.equal(G('SYSTEM', 'Patient', 'very restricted'), true);
+
+  // clearance never grants what RBAC denies
+  assert.equal(G('SYSTEM', 'VisionPrescription', 'unrestricted'), false);
+});
+
+// ----------------------------------------------------------------------------
+// 3. Quirks
+// ----------------------------------------------------------------------------
+test('bare grant() does not register the role (PAT throws)', () => {
+  const ca = applyGrants(new AccessControl());
+  assert.ok(!ca.getRoles().includes('PAT'));
+  const r = evalSync(ca, 'PAT', 'access', 'Patient', null);
+  assert.ok(r.threw && /Role not found: "PAT"/.test(r.threw), JSON.stringify(r));
+});
+
+test('unknown role throws AccessControlError with the role-acl message', () => {
+  const ca = applyGrants(new AccessControl());
+  assert.throws(
+    () => ca.can('ghost').execute('access').sync().on('Patient'),
+    (err) => err instanceof AccessControlError && /Role not found: "ghost"/.test(err.message)
+  );
+});
+
+test('comma-joined grant action matches a single queried action', () => {
+  const ca = applyGrants(new AccessControl());
+  assert.equal(evalSync(ca, 'healthcare provider', 'access', 'Organization', UNRESTRICTED).granted, true);
+  assert.equal(evalSync(ca, 'healthcare provider', 'correct', 'Organization', UNRESTRICTED).granted, true);
+  assert.equal(evalSync(ca, 'healthcare provider', 'delete', 'Organization', UNRESTRICTED).granted, false);
+});
+
+test('valid role / no matching rule returns granted:false (no throw)', () => {
+  const ca = applyGrants(new AccessControl());
+  assert.deepEqual(evalSync(ca, 'patient', 'access', 'VisionPrescription', UNRESTRICTED), { granted: false, attributes: [] });
+});
+
+test('object-form constructor honors EQUALS conditions', () => {
+  const list = [
+    { role: 'healthcare provider', action: 'access', resource: 'Organization', attributes: ['*'],
+      condition: { Fn: 'EQUALS', args: { securityLevel: 'restricted' } } }
+  ];
+  const ca = new AccessControl(list);
+  assert.equal(evalSync(ca, 'healthcare provider', 'access', 'Organization', { confidentiality: 'restricted' }).granted, true);
+  assert.equal(evalSync(ca, 'healthcare provider', 'access', 'Organization', { confidentiality: 'normal' }).granted, false);
+});
+
+test('clearance/label helpers behave as specified', () => {
+  assert.equal(rankOfLabel(undefined), 3);
+  assert.equal(rankOfLabel('unrestricted'), 0);
+  assert.equal(rankOfLabel('R'), 4);
+  assert.equal(clearanceForRole('citizen'), 0);
+  assert.equal(clearanceForRole('totally-unknown-role'), 5);
+  assert.equal(labelFromContext({ securityLevel: 'restricted' }), 'restricted');
+  assert.equal(labelFromContext({ confidentiality: 'normal' }), 'normal');
+});

--- a/server/lib/FhirAuth.js
+++ b/server/lib/FhirAuth.js
@@ -10,7 +10,7 @@ import { get } from 'lodash';
 import jwt from 'jsonwebtoken';
 import base64url from 'base64-url';
 import { RateLimiter } from 'limiter';
-import { AccessControl } from 'role-acl';
+import { AccessControl } from './CaslAccessControl.js';
 
 import { OAuthClients } from '../../imports/collections/OAuthClients.js';
 import { Consents } from '../../imports/lib/schemas/SimpleSchemas/Consents';

--- a/server/lib/PermissionModel.js
+++ b/server/lib/PermissionModel.js
@@ -1,0 +1,168 @@
+// server/lib/PermissionModel.js
+// Phase-1 internal authorization model: a minimal FHIR Permission.rule
+// representation plus the CASL compiler that turns rules into per-role
+// abilities. This is the seam between policy *source* (today: Consent-derived
+// grants + hardcoded grants) and the CASL evaluation engine. Phase 2 will feed
+// the same compiler from stored FHIR Permission resources instead.
+//
+// See .claude plan: "Migrate role-acl -> CASL (Phase 1), with a minimal FHIR
+// Permission internal model". Conditions are evaluated by @ucast/mongo2js
+// (no eval), which is what retires the role-acl -> jsonpath-plus CVE chain.
+
+import { AbilityBuilder, createMongoAbility } from '@casl/ability';
+
+// =============================================================================
+// Confidentiality (HL7 v3 Confidentiality) — the ordinal sensitivity axis
+// CodeSystem: http://terminology.hl7.org/CodeSystem/v3-Confidentiality
+// =============================================================================
+
+// Ordered ranks for the confidentiality scale. Both codes (U/L/M/N/R/V) and
+// their display strings are accepted, since meta.security may carry either.
+export const CONFIDENTIALITY_RANK = {
+  U: 0, unrestricted: 0,
+  L: 1, low: 1,
+  M: 2, moderate: 2,
+  N: 3, normal: 3,
+  R: 4, restricted: 4,
+  V: 5, 'very restricted': 5, 'very-restricted': 5
+};
+
+// When a record has no meta.security label we treat it as 'normal' (N). This
+// matches the historical call-site default (get(record,'meta.security[0].display','normal'))
+// and the existing Mongo pre-filters that only expose 'unrestricted' records to
+// anonymous/citizen roles — so an unlabeled record stays hidden from low-clearance roles.
+export const DEFAULT_RECORD_RANK = CONFIDENTIALITY_RANK.normal; // 3
+
+export function rankOfLabel(label) {
+  if (label === undefined || label === null || label === '') return DEFAULT_RECORD_RANK;
+  const key = String(label).trim();
+  if (key in CONFIDENTIALITY_RANK) return CONFIDENTIALITY_RANK[key];
+  const lower = key.toLowerCase();
+  if (lower in CONFIDENTIALITY_RANK) return CONFIDENTIALITY_RANK[lower];
+  // Unknown label -> default (normal). Don't silently grant by treating it as unrestricted.
+  console.warn('[PermissionModel] Unknown confidentiality label, defaulting to normal:', label);
+  return DEFAULT_RECORD_RANK;
+}
+
+// Role -> maximum confidentiality clearance (rank). Roles NOT listed here are
+// left unrestricted by confidentiality (rank V) so existing access is preserved;
+// only the explicitly-listed roles gain a confidentiality ceiling. This table is
+// the one piece of *policy* (not derivable from code) — see the approved plan.
+export const ROLE_CLEARANCE = {
+  citizen: CONFIDENTIALITY_RANK.U,                  // unrestricted only
+  PAT: CONFIDENTIALITY_RANK.U,                       // (unregistered in practice; kept for completeness)
+  user: CONFIDENTIALITY_RANK.N,                      // normal
+  patient: CONFIDENTIALITY_RANK.N,                   // normal (own records reachable via owner path)
+  'healthcare practitioner': CONFIDENTIALITY_RANK.R, // restricted
+  'healthcare provider': CONFIDENTIALITY_RANK.R,     // restricted
+  SYSTEM: CONFIDENTIALITY_RANK.V,                    // very restricted (full)
+  system: CONFIDENTIALITY_RANK.V,                    // JWT backend services role (lowercase)
+  noauth: CONFIDENTIALITY_RANK.V                     // SafeNoAuth dev bypass (full)
+};
+
+// Unlisted-but-registered roles get no confidentiality restriction, so the
+// migration never *reduces* access for a role we didn't anticipate.
+export const DEFAULT_ROLE_CLEARANCE = CONFIDENTIALITY_RANK.V; // 5
+
+export function clearanceForRole(role) {
+  if (Object.prototype.hasOwnProperty.call(ROLE_CLEARANCE, role)) return ROLE_CLEARANCE[role];
+  return DEFAULT_ROLE_CLEARANCE;
+}
+
+// Pull the confidentiality label out of a permission-check context object,
+// reconciling the historical key drift (securityLabel / securityLevel / confidentiality).
+export function labelFromContext(ctx) {
+  if (!ctx) return undefined;
+  if (ctx.securityLabel != null) return ctx.securityLabel;
+  if (ctx.securityLevel != null) return ctx.securityLevel;
+  if (ctx.confidentiality != null) return ctx.confidentiality;
+  return undefined;
+}
+
+// =============================================================================
+// Permission.rule IR helpers
+// =============================================================================
+
+// role-acl joined multiple action codes into a single comma-delimited string
+// ("access, correct") and matched any element. Preserve that semantics.
+export function splitActions(action) {
+  if (Array.isArray(action)) return action.map(a => String(a).trim()).filter(Boolean);
+  return String(action == null ? '' : action).split(',').map(a => a.trim()).filter(Boolean);
+}
+
+// Subject type detector for CASL: subjects are plain objects { type, confidentiality }
+// (or, defensively, a bare resourceType string).
+export function subjectTypeOf(subject) {
+  if (typeof subject === 'string') return subject;
+  return subject && subject.type;
+}
+
+// Convert a flat role-acl grant record — the shape produced by
+// FhirUtilities.consentIntoAccessControl and by the fluent grant() builder —
+// into a minimal FHIR Permission.rule. Only the fields we use are populated;
+// `_condition`/`_attributes` are internal (underscore-prefixed) carriers, not
+// part of the FHIR element set.
+export function aclRecordToPermissionRule(rec) {
+  const rule = {
+    type: 'permit',
+    data: [{ resourceType: rec.resource }],
+    activity: [{
+      actor: [{ role: rec.role }],
+      action: splitActions(rec.action)
+    }]
+  };
+  if (rec.condition) rule._condition = rec.condition;       // { Fn:'EQUALS', args:{ <key>: <value> } }
+  if (rec.attributes) rule._attributes = rec.attributes;    // projection (unused in P1; always ['*'])
+  return rule;
+}
+
+// Port a role-acl EQUALS condition to a CASL MongoDB-style condition keyed on the
+// canonical `confidentiality` subject field. This deliberately reconciles the old
+// securityLevel/securityLabel key mismatch so conditioned grants actually evaluate.
+function caslConditionFrom(condition) {
+  if (!condition) return undefined;
+  if (condition.Fn === 'EQUALS' && condition.args && typeof condition.args === 'object') {
+    const firstVal = Object.values(condition.args)[0];
+    if (firstVal !== undefined) return { confidentiality: firstVal };
+  }
+  // Unknown function — treat as unconditional (role-acl was permissive here).
+  return undefined;
+}
+
+// Compile minimal Permission.rule[] into a Map<role, MongoAbility>. Phase 1 only
+// emits permit rules, so the combining strategy is implicit deny-unless-permit,
+// which is exactly CASL's default-deny. Confidentiality clearance is applied
+// separately (ordinal compare) by the evaluator, not encoded here.
+export function compilePermissionRules(rules) {
+  const byRole = new Map();
+  for (const rule of (rules || [])) {
+    if (rule.type && rule.type !== 'permit') continue;
+    const condition = caslConditionFrom(rule._condition);
+    for (const data of (rule.data || [])) {
+      const resourceType = data.resourceType;
+      if (!resourceType) continue;
+      for (const activity of (rule.activity || [])) {
+        const actions = (activity.action && activity.action.length) ? activity.action : ['access'];
+        for (const actor of (activity.actor || [])) {
+          const role = actor.role;
+          if (!role) continue;
+          if (!byRole.has(role)) byRole.set(role, []);
+          byRole.get(role).push({ resourceType, actions, condition });
+        }
+      }
+    }
+  }
+
+  const abilities = new Map();
+  for (const [role, entries] of byRole) {
+    const { can, build } = new AbilityBuilder(createMongoAbility);
+    for (const { resourceType, actions, condition } of entries) {
+      for (const action of actions) {
+        if (condition) can(action, resourceType, condition);
+        else can(action, resourceType);
+      }
+    }
+    abilities.set(role, build({ detectSubjectType: subjectTypeOf }));
+  }
+  return abilities;
+}


### PR DESCRIPTION
## Summary

Remediates critical Dependabot alerts, the last of which (**CVE-2024-21534** — eval-based RCE in `jsonpath-plus`, pulled only by the unmaintained `role-acl`) required migrating the FHIR access-control engine from `role-acl` to **CASL** (`@casl/ability`, conditions evaluated by `@ucast/mongo2js` — **no `eval`**).

## What changed

- **`server/lib/CaslAccessControl.js`** — drop-in `AccessControl` facade backed by CASL. Reproduces `role-acl`'s exact surface and verified runtime quirks (unknown-role throw, bare `grant()` not registering a role, comma-split actions, sync vs async return), so the ~8 call sites are unchanged — only the import source swaps.
- **`server/lib/PermissionModel.js`** — minimal FHIR `Permission.rule` internal representation + CASL compiler + HL7 v3 Confidentiality clearance model. This is the seam for a future Phase 2 that sources policy from stored `Permission` resources.
- **Confidentiality labels are now enforced for real** — `role-acl` silently ignored fluent `.when()` conditions. A record's `meta.security` label is compared ordinally against per-role clearance (see `ROLE_CLEARANCE`).
- Import swaps in `FhirAuth.js` and `ConsentEngineHttp.js`; `FhirEndpoints.js:791` now passes the record's real security label (previously sent none).
- **`role-acl` removed** — drops `jsonpath-plus` from the tree entirely.
- Bundled dependency security fixes: overrides for `sha.js` / `shell-quote` / `protobufjs` / `oauth2-server→lodash`, and `meteor-node-stubs` 1.2.21→1.2.27 (bundled `sha.js` 2.4.12).

## Tests

`server/lib/CaslAccessControl.parity.test.mjs` (`npm run test:acl`): a 120-cell RBAC-parity sweep against a `role-acl` golden fixture, a confidentiality decision matrix, and the quirk cases. Green (8 pass, 1 skip — the live `role-acl` drift guard skips now that it's removed).

## Verification

- Parity suite green.
- App boots; `initializeAccessControl()` registers the expected roles (`PAT` correctly excluded) with no errors.
- `GET /baseR4/metadata` → 200 (R4 CapabilityStatement); `GET /baseR4/Patient` → 200.
- `npm ls role-acl jsonpath-plus` → empty.

## Follow-ups (not in this PR)

- Phase 2: source policy from stored FHIR `Permission` resources (the IR seam is in place).
- Confirm/redline the `ROLE_CLEARANCE` table in `PermissionModel.js` — it's the one piece that's policy rather than derived.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
