### PR TITLE
Security Patches

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -59,6 +59,7 @@
         "@nivo/line": "^0.84.0",
         "@nivo/sunburst": "^0.84.0",
         "@nivo/treemap": "^0.84.0",
+        "@node-oauth/express-oauth-server": "^4.1.5",
         "@stripe/react-stripe-js": "^3.3.0",
         "@stripe/stripe-js": "^5.5.0",
         "@swc/helpers": "^0.5.17",
@@ -84,7 +85,6 @@
         "d3-shape": "^3.2.0",
         "dayjs": "^1.11.18",
         "express": "^4.19.2",
-        "express-oauth-server": "^2.0.0",
         "extend": "^3.0.2",
         "fhirclient": "^2.5.4",
         "fhirpath": "^4.8.0",
@@ -12876,6 +12876,107 @@
       ],
       "license": "MIT"
     },
+    "node_modules/@node-oauth/express-oauth-server": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@node-oauth/express-oauth-server/-/express-oauth-server-4.1.5.tgz",
+      "integrity": "sha512-kHTnLFXBFbX1zYCarBxrudj4dfQF/I87idR+D0q28pa62F8cRjgW+Y3FgggsCSUjSoo91+Khfc2mvEv8IPoqiw==",
+      "license": "MIT",
+      "dependencies": {
+        "@node-oauth/oauth2-server": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "express": "*"
+      }
+    },
+    "node_modules/@node-oauth/formats": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@node-oauth/formats/-/formats-1.0.0.tgz",
+      "integrity": "sha512-DwSbLtdC8zC5B5gTJkFzJj5s9vr9SGzOgQvV9nH7tUVuMSScg0EswAczhjIapOmH3Y8AyP7C4Jv7b8+QJObWZA==",
+      "license": "MIT"
+    },
+    "node_modules/@node-oauth/oauth2-server": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@node-oauth/oauth2-server/-/oauth2-server-5.3.0.tgz",
+      "integrity": "sha512-gPnLZesfXWleX3Mwq9hch3yY9AiekT+cl+c99BoK7Yf/DQEoxXsvuVDG/D0MrPkFbfiOdR96Z88ZYZJkvQ5lAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@node-oauth/formats": "1.0.0",
+        "basic-auth": "2.0.1",
+        "type-is": "2.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@node-oauth/oauth2-server/node_modules/basic-auth": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
+      "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@node-oauth/oauth2-server/node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@node-oauth/oauth2-server/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@node-oauth/oauth2-server/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@node-oauth/oauth2-server/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/@node-oauth/oauth2-server/node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/@node-on-fhir/accounts-management": {
       "resolved": "npmPackages/accounts-management",
       "link": true
@@ -17166,13 +17267,6 @@
         "baseline-browser-mapping": "dist/cli.js"
       }
     },
-    "node_modules/basic-auth": {
-      "version": "1.1.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/basic-ftp": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.1.tgz",
@@ -18777,26 +18871,6 @@
       "engines": {
         "iojs": ">= 1.0.0",
         "node": ">= 0.12.0"
-      }
-    },
-    "node_modules/co-bluebird": {
-      "version": "1.1.0",
-      "dependencies": {
-        "bluebird": "^2.10.0",
-        "co-use": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.12.0"
-      }
-    },
-    "node_modules/co-bluebird/node_modules/bluebird": {
-      "version": "2.11.0",
-      "license": "MIT"
-    },
-    "node_modules/co-use": {
-      "version": "1.1.0",
-      "engines": {
-        "node": ">=0.12.0"
       }
     },
     "node_modules/code-block-writer": {
@@ -22951,18 +23025,6 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/express-oauth-server": {
-      "version": "2.0.0",
-      "license": "SEE LICENSE IN LICENSE",
-      "dependencies": {
-        "bluebird": "^3.0.5",
-        "express": "^4.13.3",
-        "oauth2-server": "3.0.0"
-      },
-      "engines": {
-        "node": ">=0.11"
-      }
-    },
     "node_modules/express-rate-limit": {
       "version": "8.5.2",
       "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
@@ -25735,10 +25797,6 @@
     },
     "node_modules/is-function": {
       "version": "1.0.2",
-      "license": "MIT"
-    },
-    "node_modules/is-generator": {
-      "version": "1.0.3",
       "license": "MIT"
     },
     "node_modules/is-generator-fn": {
@@ -35803,43 +35861,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/oauth2-server": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "basic-auth": "1.1.0",
-        "bluebird": "3.5.0",
-        "lodash": "4.17.4",
-        "promisify-any": "2.0.1",
-        "statuses": "1.3.1",
-        "type-is": "1.6.15"
-      },
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
-    "node_modules/oauth2-server/node_modules/bluebird": {
-      "version": "3.5.0",
-      "license": "MIT"
-    },
-    "node_modules/oauth2-server/node_modules/statuses": {
-      "version": "1.3.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/oauth2-server/node_modules/type-is": {
-      "version": "1.6.15",
-      "license": "MIT",
-      "dependencies": {
-        "media-typer": "0.3.0",
-        "mime-types": "~2.1.15"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "license": "MIT",
@@ -37446,21 +37467,6 @@
       "engines": {
         "node": ">= 4"
       }
-    },
-    "node_modules/promisify-any": {
-      "version": "2.0.1",
-      "dependencies": {
-        "bluebird": "^2.10.0",
-        "co-bluebird": "^1.1.0",
-        "is-generator": "^1.0.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/promisify-any/node_modules/bluebird": {
-      "version": "2.11.0",
-      "license": "MIT"
     },
     "node_modules/prop-types": {
       "version": "15.8.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -102,7 +102,7 @@
         "meteor-node-stubs": "1.2.27",
         "moment": "^2.29.4",
         "mongo-query": "^0.5.7",
-        "mongoose": "^8.5.3",
+        "mongoose": "^8.22.1",
         "ndjson-parse": "^1.0.4",
         "node-forge": "^1.4.0",
         "papaparse": "^5.4.1",
@@ -17002,7 +17002,9 @@
       }
     },
     "node_modules/babelfhir-ts/node_modules/tar": {
-      "version": "7.5.7",
+      "version": "7.5.16",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.16.tgz",
+      "integrity": "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
@@ -34703,7 +34705,9 @@
       }
     },
     "node_modules/mongoose": {
-      "version": "8.21.0",
+      "version": "8.24.1",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.24.1.tgz",
+      "integrity": "sha512-UpHBA0l5kHyKJQFjmBaFYQFo5sgz1DK0TRqDkOyBLYbqiIbKKhIvBpHWBXqeo0rgW4kGI1UhhAw+kTQZoj1BdA==",
       "license": "MIT",
       "dependencies": {
         "bson": "^6.10.4",
@@ -37084,7 +37088,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -41626,7 +41632,9 @@
       }
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
       "engines": {
         "node": ">=12"

--- a/package-lock.json
+++ b/package-lock.json
@@ -23533,12 +23533,10 @@
         "node": "^10.12.0 || >=12.0.0"
       }
     },
-    "node_modules/flat-cache/node_modules/flatted": {
-      "version": "3.3.3",
-      "license": "ISC"
-    },
     "node_modules/flatted": {
-      "version": "2.0.2",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "license": "ISC"
     },
     "node_modules/float-tooltip": {
@@ -36940,7 +36938,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.12",
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
       "license": "MIT"
     },
     "node_modules/path-type": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -861,50 +861,6 @@
         "tslib": "2.3.0"
       }
     },
-    "node_modules/@accounts/server/node_modules/jsonwebtoken": {
-      "version": "8.5.1",
-      "license": "MIT",
-      "dependencies": {
-        "jws": "^3.2.2",
-        "lodash.includes": "^4.3.0",
-        "lodash.isboolean": "^3.0.3",
-        "lodash.isinteger": "^4.0.4",
-        "lodash.isnumber": "^3.0.3",
-        "lodash.isplainobject": "^4.0.6",
-        "lodash.isstring": "^4.0.1",
-        "lodash.once": "^4.0.0",
-        "ms": "^2.1.1",
-        "semver": "^5.6.0"
-      },
-      "engines": {
-        "node": ">=4",
-        "npm": ">=1.4.28"
-      }
-    },
-    "node_modules/@accounts/server/node_modules/jwa": {
-      "version": "1.4.2",
-      "license": "MIT",
-      "dependencies": {
-        "buffer-equal-constant-time": "^1.0.1",
-        "ecdsa-sig-formatter": "1.0.11",
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "node_modules/@accounts/server/node_modules/jws": {
-      "version": "3.2.3",
-      "license": "MIT",
-      "dependencies": {
-        "jwa": "^1.4.2",
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "node_modules/@accounts/server/node_modules/semver": {
-      "version": "5.7.2",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
     "node_modules/@accounts/types": {
       "version": "0.33.2",
       "license": "MIT",
@@ -21310,14 +21266,18 @@
     },
     "node_modules/encoding": {
       "version": "0.1.13",
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "iconv-lite": "^0.6.2"
       }
     },
     "node_modules/encoding/node_modules/iconv-lite": {
       "version": "0.6.3",
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
@@ -26237,21 +26197,6 @@
       "dependencies": {
         "node-fetch": "^1.0.1",
         "whatwg-fetch": ">=0.10.0"
-      }
-    },
-    "node_modules/isomorphic-fetch/node_modules/is-stream": {
-      "version": "1.1.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/isomorphic-fetch/node_modules/node-fetch": {
-      "version": "1.7.3",
-      "license": "MIT",
-      "dependencies": {
-        "encoding": "^0.1.11",
-        "is-stream": "^1.0.1"
       }
     },
     "node_modules/isomorphic-timers-promises": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17260,11 +17260,16 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.9.14",
+      "version": "2.10.37",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.37.tgz",
+      "integrity": "sha512-girxaJ7WZssDOFhzCGZTDKoTa1gk6A1TbflaYTpykLJ4UU9Fz9kx1aREM8JCuoVHbL8X8T/mJg7w2oYSq72Oig==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
-        "baseline-browser-mapping": "dist/cli.js"
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/basic-ftp": {
@@ -17773,7 +17778,9 @@
       "license": "(MIT AND Zlib)"
     },
     "node_modules/browserslist": {
-      "version": "4.28.1",
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
       "dev": true,
       "funding": [
         {
@@ -17791,11 +17798,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.9.0",
-        "caniuse-lite": "^1.0.30001759",
-        "electron-to-chromium": "^1.5.263",
-        "node-releases": "^2.0.27",
-        "update-browserslist-db": "^1.2.0"
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -18368,7 +18375,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001774",
+      "version": "1.0.30001799",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
+      "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
       "dev": true,
       "funding": [
         {
@@ -21265,7 +21274,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.267",
+      "version": "1.5.372",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.372.tgz",
+      "integrity": "sha512-M3yhbAlilnwqC8D21t28UCDGHyitShTmmLRU/H+b74P6Ski16Nb9HONYEaVpMj/pwC7BEo5B95FpjODLCWbtfA==",
       "dev": true,
       "license": "ISC"
     },
@@ -35678,9 +35689,14 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.27",
+      "version": "2.0.47",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.47.tgz",
+      "integrity": "sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/node-stdlib-browser": {
       "version": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -210,6 +210,8 @@
     "react-simple-chatbot": {
       "flatted": "^3.4.2"
     },
+    "jsonwebtoken": "^9.0.2",
+    "node-fetch": "^2.7.0",
     "oauth2-server": {
       "lodash": "^4.17.21"
     }

--- a/package.json
+++ b/package.json
@@ -211,6 +211,7 @@
       "flatted": "^3.4.2"
     },
     "jsonwebtoken": "^9.0.2",
-    "node-fetch": "^2.7.0"
+    "node-fetch": "^2.7.0",
+    "browserslist": "^4.28.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -201,6 +201,15 @@
     "tinyglobby": {
       "picomatch": "^4.0.4"
     },
+    "express": {
+      "path-to-regexp": "^0.1.13"
+    },
+    "flat-cache": {
+      "flatted": "^3.4.2"
+    },
+    "react-simple-chatbot": {
+      "flatted": "^3.4.2"
+    },
     "oauth2-server": {
       "lodash": "^4.17.21"
     }

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "d3-shape": "^3.2.0",
     "dayjs": "^1.11.18",
     "express": "^4.19.2",
-    "express-oauth-server": "^2.0.0",
+    "@node-oauth/express-oauth-server": "^4.1.5",
     "extend": "^3.0.2",
     "fhirclient": "^2.5.4",
     "fhirpath": "^4.8.0",
@@ -211,9 +211,6 @@
       "flatted": "^3.4.2"
     },
     "jsonwebtoken": "^9.0.2",
-    "node-fetch": "^2.7.0",
-    "oauth2-server": {
-      "lodash": "^4.17.21"
-    }
+    "node-fetch": "^2.7.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "meteor-node-stubs": "1.2.27",
     "moment": "^2.29.4",
     "mongo-query": "^0.5.7",
-    "mongoose": "^8.5.3",
+    "mongoose": "^8.22.1",
     "ndjson-parse": "^1.0.4",
     "node-forge": "^1.4.0",
     "papaparse": "^5.4.1",
@@ -192,6 +192,15 @@
     "follow-redirects": "^1.16.0",
     "ip-address": "^10.1.1",
     "tmp": "^0.2.6",
+    "babelfhir-ts": {
+      "tar": "^7.5.16"
+    },
+    "micromatch": {
+      "picomatch": "^2.3.2"
+    },
+    "tinyglobby": {
+      "picomatch": "^4.0.4"
+    },
     "oauth2-server": {
       "lodash": "^4.17.21"
     }

--- a/server/OAuthEndpoints.js
+++ b/server/OAuthEndpoints.js
@@ -22,7 +22,7 @@ import express from 'express';
 
 import bodyParser from 'body-parser';
 import { OAuthClients } from '/imports/collections/OAuthClients';
-import OAuthServer from 'express-oauth-server';
+import OAuthServer from '@node-oauth/express-oauth-server';
 
 import { refreshTokensCollection } from '/imports/collections/refreshTokensCollection';
 import { authCodesCollection } from '/imports/collections/authCodesCollection';

--- a/server/OAuthServer.js
+++ b/server/OAuthServer.js
@@ -3,7 +3,7 @@ import { WebApp } from "meteor/webapp";
 
 import express from 'express';
 import bodyParser from 'body-parser';
-import OAuthServer from 'express-oauth-server';
+import OAuthServer from '@node-oauth/express-oauth-server';
 
 import { refreshTokensCollection } from '/imports/collections/refreshTokensCollection';
 import { authCodesCollection } from '/imports/collections/authCodesCollection';


### PR DESCRIPTION
## Security Patches — HIGH-severity Dependabot paydown

Clears HIGH-severity Dependabot alerts via the lowest-risk levers: same-major direct bumps, **surgical parent-scoped (nested) `overrides`**, and one maintained-fork migration. The guiding principle: most alerts involve a vulnerable major **coexisting** with another major in the tree, so a flat override would force-break the other consumer — nested overrides fix only the offending path.

`npm ls` is clean after each change, and CircleCI passes on a clean install.

### ✅ Fixed (5 commits)

**`402d7cd6` — mongoose / tar / picomatch**
- `mongoose` ^8.5.3 → **^8.22.1** (direct dep, same-major patch)
- `tar`: nested `babelfhir-ts → ^7.5.16` — fixes the **runtime** tar@7.5.7; leaves app-builder-lib's **dev** tar@6.x untouched
- `picomatch`: nested `micromatch → ^2.3.2` + `tinyglobby → ^4.0.4` — avoids breaking micromatch@4 (needs picomatch 2.x)

**`3e95a80c` — path-to-regexp / flatted**
- `path-to-regexp`: nested `express → ^0.1.13` (leaves the 6.x/8.x copies elsewhere)
- `flatted`: nested `flat-cache → ^3.4.2` + `react-simple-chatbot → ^3.4.2` (stable parse/stringify API across majors)

**`88308e7b` — jsonwebtoken / node-fetch**
- `jsonwebtoken` flat **^9.0.2** — forces `@accounts/server`'s nested 8.5.1 up to 9 (root already on 9)
- `node-fetch` flat **^2.7.0** — removes the 1.7.3 copy (dead-weight via `material-ui-rc-color-picker → @material-ui/core@1 → fbjs`); only 1.7.3 + 2.7.0 existed, so it's safe

**`4c909237` — oauth2-server → maintained fork**
- Replaces the abandoned `express-oauth-server@2` (pulled unpatched `oauth2-server@3`, two `fix:none` HIGHs) with `@node-oauth/express-oauth-server@4` (uses `@node-oauth/oauth2-server@5`)
- Drop-in: only the dep + two `import OAuthServer` lines change (`server/OAuthServer.js`, `server/OAuthEndpoints.js`); construct smoke-test passes; `.authorize()/.token()` wiring was commented out and the legacy `authCodeGrant` path was already inert, so no behavioral regression

**`ff789090` — browserslist guard (build-stability, not a CVE)**
- `autoprefixer@10.5.2` (current latest) declares the non-existent `browserslist@^4.28.4`, breaking any **re-resolving** install (`meteor npm install`) with `ETARGET`. Faithful lockfile installs (`npm ci`/CI) are unaffected.
- Flat `browserslist: ^4.28.2` override rewrites the bad spec to the real latest, so re-resolving installs survive the broken upstream release.

### 🚩 Remaining HIGH — deferred for owner review (not in this PR)

| Alert | Why deferred |
|---|---|
| **xlsx** (×2) | `fix:none` — SheetJS ships fixes only via their CDN, not npm; needs a deliberate CDN-tarball pin |
| **langsmith** | Root override won't apply — resolves through the `extensions/mcp` workspace + Meteor `.npm` vendoring; must bump `@langchain/*` inside that nested repo |
| **@ranfdev/deepobj** | Same override-resistance via the `genome-central-redux` extension |
| **minimatch** | 15+ parents across 4 majors (mostly dev tooling) — too sprawling for clean overrides |
| **braces** 2.x | Via `chokidar@2` (dev watcher); 2→3 would break it |
| **d3-color** 2.x | Via the `@nivo` runtime charts; forcing ESM v3 is risky |
| remaining majors | kad-dht 12→16, js-cookie 2→3 break their stacks |

### Install notes
- **Use `npm ci --legacy-peer-deps`** (faithful lockfile install) rather than `meteor npm install` (which re-resolves and can pull broken upstream releases like autoprefixer@10.5.2). CI green on clean install is authoritative.
- This repo installs with `--legacy-peer-deps` (pre-existing `extensions/mcp` peer constraints).

🤖 Generated with [Claude Code](https://claude.com/claude-code)