### PR TITLE
fix: restore DICOM metadata extraction on main (unblocks clean build)

### DIFF
--- a/imports/ui/DICOM/utils/DcmjsMetadata.js
+++ b/imports/ui/DICOM/utils/DcmjsMetadata.js
@@ -1,0 +1,96 @@
+// imports/ui/DICOM/utils/DcmjsMetadata.js
+// DICOM metadata extraction for the main branch — backed by dicom-parser and
+// the legacy extractors in DicomFhirMapping.js (no dcmjs dependency on main).
+//
+// This provides the extraction/flatten contract that radiology-workflow's
+// TechDashboard upload flow expects. The dcmjs-backed implementation (which
+// adds a dcmjs.fhir mapping path and keeps this dicom-parser route as its
+// safety net) lives on the dcmjs-integration branch and supersedes this file
+// when that branch merges — same filename, same exports, same nested
+// { patient, study, series, instance } contract and flat GridFS shape.
+//
+// Isomorphic: works on client, server, and under node --test (no Meteor
+// imports; Meteor.Logger is feature-detected).
+
+import dicomParser from 'dicom-parser';
+import get from 'lodash/get.js';
+
+import { extractAllDicomMetadata } from './DicomFhirMapping.js';
+
+const log = (typeof Meteor !== 'undefined' && Meteor.Logger)
+  ? Meteor.Logger.for('DcmjsMetadata')
+  : console;
+
+/**
+ * Check for the DICOM Part 10 magic bytes ('DICM' at offset 128).
+ * Useful for content-based classification of dropped files regardless
+ * of their extension.
+ * @param {ArrayBuffer} arrayBuffer
+ * @returns {boolean}
+ */
+export function isDicomPart10(arrayBuffer) {
+  if (!arrayBuffer || !(arrayBuffer instanceof ArrayBuffer) || arrayBuffer.byteLength < 132) {
+    return false;
+  }
+  const magic = new Uint8Array(arrayBuffer, 128, 4);
+  return magic[0] === 0x44 && magic[1] === 0x49 && magic[2] === 0x43 && magic[3] === 0x4d; // 'DICM'
+}
+
+/**
+ * Flatten the nested { patient, study, series, instance } metadata into
+ * the flat object POST /api/dicom/upload expects in its dicomMetadata
+ * form field (DicomEndpoints.js writes these keys into dicom.files
+ * metadata.*).
+ * @param {Object|null} metadata - From extractAllDicomMetadataFromArrayBuffer
+ * @returns {Object|null} - Flat GridFS metadata, or null
+ */
+export function flattenDicomMetadataForGridFS(metadata) {
+  if (!metadata) return null;
+
+  return {
+    studyInstanceUid: get(metadata, 'study.studyInstanceUid'),
+    seriesInstanceUid: get(metadata, 'series.seriesInstanceUid'),
+    sopInstanceUid: get(metadata, 'instance.sopInstanceUid'),
+    sopClassUid: get(metadata, 'instance.sopClassUid'),
+    modality: get(metadata, 'series.modality'),
+    studyDate: get(metadata, 'study.studyDate'),
+    studyDescription: get(metadata, 'study.description'),
+    seriesDescription: get(metadata, 'series.description'),
+    seriesNumber: get(metadata, 'series.number'),
+    instanceNumber: get(metadata, 'instance.number'),
+    dicomPatientName: get(metadata, 'patient.name.text'),
+    dicomPatientId: get(metadata, 'patient.patientId'),
+    dicomPatientBirthDate: get(metadata, 'patient.birthDate'),
+    dicomPatientSex: get(metadata, 'patient.dicomSex'),
+    rows: get(metadata, 'instance.rows'),
+    columns: get(metadata, 'instance.columns'),
+    bitsAllocated: get(metadata, 'instance.bitsAllocated'),
+    transferSyntaxUid: get(metadata, 'instance.transferSyntaxUid'),
+    parser: get(metadata, 'parser')
+  };
+}
+
+/**
+ * One-call parse+extract: parses a DICOM Part 10 buffer with dicom-parser and
+ * reshapes it into honeycomb's nested { patient, study, series, instance }
+ * contract via the legacy DicomFhirMapping extractors. Returns null when the
+ * buffer can't be parsed.
+ * @param {ArrayBuffer} arrayBuffer - File contents
+ * @returns {Object|null} - { patient, study, series, instance } or null
+ */
+export function extractAllDicomMetadataFromArrayBuffer(arrayBuffer) {
+  try {
+    const dataSet = dicomParser.parseDicom(new Uint8Array(arrayBuffer));
+    const metadata = extractAllDicomMetadata(dataSet);
+    // Provenance marker: rides through flattenDicomMetadataForGridFS into
+    // dicom.files metadata.parser, so every stored file records which
+    // parser produced its metadata.
+    if (metadata) { metadata.parser = 'dicom-parser'; }
+    log.info('[DcmjsMetadata] extracted metadata via dicom-parser', { studyInstanceUid: get(metadata, 'study.studyInstanceUid') });
+    return metadata;
+  } catch (parseError) {
+    // dicom-parser throws plain strings, not Error instances
+    log.warn('[DcmjsMetadata] dicom-parser parse failed', { error: String(parseError && parseError.message || parseError) });
+    return null;
+  }
+}


### PR DESCRIPTION
## Problem

A clean clone of `main` fails to bundle:

```
ERROR in ./npmPackages/radiology-workflow/client/TechDashboard.jsx
  × Module not found: Can't resolve '/imports/ui/DICOM/utils/DcmjsMetadata'
    in '.../npmPackages/radiology-workflow/client'
```

`radiology-workflow`'s `TechDashboard.jsx` imports `extractAllDicomMetadataFromArrayBuffer` and `flattenDicomMetadataForGridFS` from `/imports/ui/DICOM/utils/DcmjsMetadata` — but that module only exists on the `dcmjs-integration` branch. PR #156 merged `radiology-workflow` into `main` **without** the file it depends on, so `main` cannot build (and neither can any branch cut from it).

## Fix

Add a **dcmjs-free** `imports/ui/DICOM/utils/DcmjsMetadata.js` on `main`, implementing the exact contract `TechDashboard` imports using tooling already present on `main`:

- `extractAllDicomMetadataFromArrayBuffer(arrayBuffer)` — `dicomParser.parseDicom` + the existing legacy `extractAllDicomMetadata` from `DicomFhirMapping.js`, stamping `metadata.parser = 'dicom-parser'`.
- `flattenDicomMetadataForGridFS(metadata)` — pure-lodash flatten into the flat GridFS shape `POST /api/dicom/upload` persists (identical to the dcmjs-integration version).
- `isDicomPart10(arrayBuffer)` — content-based DICOM detection (bonus, self-contained).

This is the same dicom-parser path the dcmjs-integration implementation already uses as its fallback — just without the dcmjs library, which `main` deliberately does not carry.

## Why this scope

- **No new dependency**: `dicom-parser` is already used by 7 files on `main`; `extractAllDicomMetadata` already lives in `DicomFhirMapping.js`.
- **No submodule / no postinstall / no package.json change** — `main` stays dcmjs-free.
- Produces the same nested `{ patient, study, series, instance }` contract and flat metadata the upload flow expects.
- A repo-wide scan confirms this was the **only** missing `/imports/...` module across the workflow packages (`radiology-workflow`, `fhircast`, `record-lifecycle`, `us-core`, `admin-tools`, `data-importer`, `international-patient-summary`).

## Verification

- New module + full dependency graph (`dicom-parser` + `DicomFhirMapping.js`) resolve under `node`; both required exports present.
- Clean clone → `meteor npm install` → run no longer errors on the `DcmjsMetadata` import.

## Forward-compatibility

When `dcmjs-integration` merges into `main`, its richer dcmjs-backed `DcmjsMetadata.js` occupies the same path with the same exports. Expect a trivial add/add conflict on this file — resolve by taking the dcmjs-integration version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
