### PR TITLE
feat(workflows): resolve serverEntry from each package's own workflow.json

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,8 +75,40 @@ organizational (git/licensing posture) and does not affect loading — `npmPacka
 Licensing posture: AGPL main app / MIT-or-Apache workflow packages / UNLICENSED
 extensions. To add a private package, give it its own git repo under
 `extensions/<name>/` (it stays out of the monorepo); to add a package that ships
-with honeycomb, put it under `npmPackages/<name>/` and commit it normally. Either
-way, register it in `workflows/workflows.json` and run `npm install` to symlink it.
+with honeycomb, put it under `npmPackages/<name>/` and commit it normally. Run
+`npm install` to symlink either into `node_modules/`.
+
+### Registration: central manifest vs. self-declaring extensions
+
+There are two ways a package is activated, and **the central manifest is
+reserved for `@node-on-fhir` (distribution) packages only** — do NOT bloat
+`workflows/workflows.json` with private namespaces (`@orbital/*`,
+`@awatson1978/*`, `@merkalis/*`, …):
+
+- **`@node-on-fhir/*` packages that ship with honeycomb** → register in
+  `workflows/workflows.json` (entry, `serverEntry`, `hooksEntry`, `enabled`).
+- **Private extensions (any other namespace)** → stay OUT of the manifest.
+  Activate them via the `EXTRA_WORKFLOWS` env var, and let each package
+  **self-declare its server entry in its own `workflow.json`**.
+
+#### serverEntry resolution (the `./server` vs `./server/methods` gotcha)
+
+The workflow parser (`workflows/rspack.workflowParser.js`) resolves each
+package's `serverEntry` with precedence:
+
+1. central manifest (`workflows/workflows.json`) — operator override
+2. **the package's own `workflow.json`** — how extensions declare it
+3. built-in default `"./server/methods"` ⚠️
+
+The default `./server/methods` is a trap: it imports only methods and **silently
+skips publications, cron, and collection init** — and it fails outright if the
+package's `package.json` `exports` map gates the `./server/methods` subpath
+(only exposing `./server`), producing `Cannot find module
+'@scope/pkg/server/methods'` at boot. **Every package should declare
+`"serverEntry": "./server"`** (the full entry: collections → methods →
+publications → cron via `server/index.js`) — in its `workflow.json` for
+extensions, or in the manifest for `@node-on-fhir` packages. The parser prints a
+`WARN` when a package falls through to the default.
 
 ### Running with Extra Workflows
 

--- a/workflows/rspack.workflowParser.js
+++ b/workflows/rspack.workflowParser.js
@@ -61,17 +61,59 @@ class WorkflowParserPlugin {
           return;
         }
 
-        // Check if package exists in manifest (for serverEntry) even if disabled
+        // Check if package exists in manifest (for serverEntry) even if disabled.
+        // serverEntry/hooksEntry are left undefined here on purpose and resolved
+        // by the normalization pass below (manifest > package workflow.json >
+        // default). Private extensions (non-@node-on-fhir) stay OUT of the
+        // central manifest and self-declare "serverEntry" in their own
+        // workflow.json.
         const manifestEntry = (manifest.workflows || []).find(w => w.package === pkgName);
         enabledWorkflows.push({
           package: pkgName,
           entry: manifestEntry?.entry || './client.js',
-          serverEntry: manifestEntry?.serverEntry || './server/methods',
-          hooksEntry: manifestEntry?.hooksEntry || null,
+          serverEntry: manifestEntry?.serverEntry,
+          hooksEntry: manifestEntry?.hooksEntry,
           enabled: true,
           settings: manifestEntry?.settings || {}
         });
         console.log('[WorkflowParser] Added from EXTRA_WORKFLOWS:', pkgName);
+      }
+    });
+
+    // Resolve serverEntry / hooksEntry for every workflow, with precedence:
+    //   1. central manifest (workflows/workflows.json — operator override)
+    //   2. the package's OWN workflow.json (self-declared) ← extensions use this
+    //   3. built-in default "./server/methods"
+    // The central manifest is reserved for @node-on-fhir distribution packages;
+    // private extensions (@orbital/*, @awatson1978/*, …) must NOT be listed
+    // there — they declare "serverEntry": "./server" in their workflow.json so
+    // the loader imports the FULL server entry (collections + methods +
+    // publications + cron), not just methods.
+    enabledWorkflows.forEach(function(wf) {
+      let pkgWf = null;
+      const needsLookup = !wf.serverEntry || wf.hooksEntry === undefined || wf.hooksEntry === null;
+      if (needsLookup) {
+        try {
+          const packageDir = path.dirname(require.resolve(wf.package));
+          const wfJsonPath = path.join(packageDir, 'workflow.json');
+          if (fs.existsSync(wfJsonPath)) {
+            pkgWf = JSON.parse(fs.readFileSync(wfJsonPath, 'utf8'));
+          }
+        } catch (e) { /* package or its workflow.json is optional here */ }
+      }
+
+      if (wf.serverEntry) {
+        wf.serverEntrySource = 'manifest';
+      } else if (pkgWf && pkgWf.serverEntry) {
+        wf.serverEntry = pkgWf.serverEntry;
+        wf.serverEntrySource = 'workflow.json';
+      } else {
+        wf.serverEntry = './server/methods';
+        wf.serverEntrySource = 'default';
+      }
+
+      if (wf.hooksEntry === undefined || wf.hooksEntry === null) {
+        wf.hooksEntry = (pkgWf && pkgWf.hooksEntry) ? pkgWf.hooksEntry : null;
       }
     });
 
@@ -142,10 +184,14 @@ class WorkflowParserPlugin {
       seen.add(pkg);
 
       // The serverEntry gotcha: defaulting to ./server/methods silently skips
-      // publications, cron, and collection initialization.
-      if (!wf.serverEntry) {
-        warnings.push(pkg + ': no "serverEntry" in manifest — defaults to "./server/methods", '
-          + 'which skips publications, cron, and collection init. Set "serverEntry": "./server".');
+      // publications, cron, and collection initialization. serverEntrySource is
+      // stamped by the normalization pass in generate(): 'manifest' |
+      // 'workflow.json' | 'default'. Only warn when it genuinely defaulted.
+      if (wf.serverEntrySource === 'default') {
+        warnings.push(pkg + ': no "serverEntry" declared (manifest or workflow.json) — defaults to '
+          + '"./server/methods", which skips publications, cron, and collection init. Add '
+          + '"serverEntry": "./server" to the package\'s workflow.json (extensions), or to the '
+          + 'manifest (@node-on-fhir packages).');
       }
 
       // Locate the installed package to read workflow.json + client.js


### PR DESCRIPTION
## Problem

Booting the app with a large `EXTRA_WORKFLOWS` list of private extensions crashed at server startup:

```
Error: Cannot find module '@orbital/orbital/server/methods'
    at Object../imports/workflows/server-loader.js
```

**Root cause:** the workflow parser (`workflows/rspack.workflowParser.js`) only ever read `serverEntry` from the central manifest (`workflows/workflows.json`). Private extensions activated via `EXTRA_WORKFLOWS` are intentionally **not** in that manifest, so they silently fell through to the built-in default `./server/methods`. That default is a trap:

- it imports **methods only**, silently skipping publications, cron, and collection init (all wired through `server/index.js` = the `./server` entry); and
- it **hard-crashes at boot** when the package's `package.json` `exports` map gates the `/server/methods` subpath (exposing only `./server`), which every `@orbital/*` extension does.

## Fix

Teach the parser to resolve `serverEntry`/`hooksEntry` with precedence:

1. central manifest (`workflows/workflows.json`) — operator override
2. **the package's own `workflow.json`** — how extensions self-declare
3. built-in default `./server/methods` — now emits a `WARN` when hit

A `serverEntrySource` (`'manifest' | 'workflow.json' | 'default'`) is stamped per workflow so validation only warns on a genuine fallthrough (no more false warnings for packages that declared an entry).

## Policy (documented in CLAUDE.md)

- The central manifest is **reserved for `@node-on-fhir` distribution packages**.
- Private extensions (`@orbital/*`, `@awatson1978/*`, …) stay **out** of the manifest and declare `"serverEntry": "./server"` in their **own** `workflow.json`.

The companion `"serverEntry": "./server"` additions to each extension's `workflow.json` live in those extensions' own repos (gitignored nested repos, not part of this monorepo). The extensions' `exports` maps were already correct — they expose `./server` (the full `server/index.js` entry) — and needed no change.

## Verification

- Parser run with the full `EXTRA_WORKFLOWS` list: **"Validated 27 workflow(s): OK"**, zero warnings.
- Regenerated `server-loader.js` imports `@orbital/*/server` (full entry); **all 27 imports resolve, 0 unresolved.**
- `@node-on-fhir/*` packages (which set `serverEntry` in the manifest) are unaffected — manifest still wins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
