### PR TITLE
Chronicle boot fixes, patient-fetch restore, Maps CSP auto-allow, import-data resource preview

### DIFF
--- a/client/main.css
+++ b/client/main.css
@@ -1,4 +1,18 @@
-@import "./fonts.css";
+/* fonts.css inlined here (migrated from clinical:fonts@1.2.0) — the bundler
+   emitted `@import "./fonts.css"` as a runtime @import that 404'd to the SPA
+   HTML shell and was rejected for wrong MIME type. Inlining avoids that. */
+.helveticas{
+  font-family: "HelveticaNeue-Light", "Helvetica Neue Light", "Helvetica Neue", Helvetica, "OpenSans", Arial, "Lucida Grande", sans-serif;
+  font-weight: 300;
+}
+.barcode{ font-family: Barcode; letter-spacing: 3px; }
+@font-face{ font-family: Barcode;       src: url('/fonts/3OF9_NEW.TTF') format('truetype'); }
+@font-face{ font-family: OpenSansLight; src: url('/fonts/OpenSans-Light-webfont.ttf') format('truetype'); }
+@font-face{ font-family: OpenSans;      src: url('/fonts/OpenSans-Light-webfont.ttf') format('truetype'); }
+@font-face{ font-family: Blockchain;    src: url('/fonts/echolot.regular.ttf') format('truetype'); }
+.Blockchain, .blockchain{ font-family: "Blockchain"; }
+.OpenSans, .opensans{ font-family: "OpenSans"; }
+.OpenSansLight, .opensans-light{ font-family: "OpenSansLight"; }
 body {
   padding: 0px;
   font-family: Roboto,Helvetica,Arial,sans-serif;

--- a/imports/ui-fhir/documentReferences/DocumentReferenceFormView.jsx
+++ b/imports/ui-fhir/documentReferences/DocumentReferenceFormView.jsx
@@ -1,6 +1,7 @@
 // imports/ui-fhir/documentReferences/DocumentReferenceFormView.jsx
 
 import React from 'react';
+import { useNavigate } from 'react-router-dom';
 
 import {
   Divider,
@@ -17,6 +18,7 @@ import {
 } from '@mui/material';
 
 import SearchIcon from '@mui/icons-material/Search';
+import LanguageIcon from '@mui/icons-material/Language';
 
 import { get } from 'lodash';
 import moment from 'moment';
@@ -57,9 +59,18 @@ const contentTypeOptions = [
 
 function DocumentReferenceFormView({ resource, form, isEditing, onChange, isEmbedded }) {
   var documentReference = form || resource || {};
+  var navigate = useNavigate();
 
   function handleSearchUser() {
     console.log('[DocumentReferenceFormView] Opening patient search dialog...'); // phi-audit: ok
+  }
+
+  // Send the attachment URL to the Data Import REST API tab for fetching
+  // (client-side navigation — no Meteor.absoluteUrl/full reload needed).
+  function handleFetchDocumentUrl() {
+    var documentUrl = get(documentReference, 'content[0].attachment.url', '');
+    if (!documentUrl) { return; }
+    navigate('/import-data?tab=rest-api&url=' + encodeURIComponent(documentUrl));
   }
 
   return (
@@ -263,6 +274,24 @@ function DocumentReferenceFormView({ resource, form, isEditing, onChange, isEmbe
         onChange={(e) => onChange('content[0].attachment.url', e.target.value)}
         helperText="URL where the document can be accessed"
         disabled={!isEditing}
+        InputProps={{
+          endAdornment: (
+            <InputAdornment position="end">
+              <Tooltip title="Fetch in Data Import (REST API tab)">
+                <span>
+                  <IconButton
+                    id="fetchDocumentUrlButton"
+                    edge="end"
+                    onClick={handleFetchDocumentUrl}
+                    disabled={!get(documentReference, 'content[0].attachment.url')}
+                  >
+                    <LanguageIcon />
+                  </IconButton>
+                </span>
+              </Tooltip>
+            </InputAdornment>
+          )
+        }}
       />
 
       <TextField

--- a/npmPackages/data-importer/client/DataImportPage.jsx
+++ b/npmPackages/data-importer/client/DataImportPage.jsx
@@ -79,7 +79,10 @@ function DataImportPage() {
   var dividerColor = isDark ? 'rgba(255,255,255,0.12)' : 'rgba(0,0,0,0.12)';
 
   function handleTabChange(event, newValue) {
-    navigate('?tab=' + TAB_SLUGS[newValue], { replace: true });
+    // Preserve other params (patient, next) across tab switches
+    var params = new URLSearchParams(location.search);
+    params.set('tab', TAB_SLUGS[newValue]);
+    navigate('?' + params.toString(), { replace: true });
   }
 
   return (

--- a/npmPackages/data-importer/client/FileDropTab.jsx
+++ b/npmPackages/data-importer/client/FileDropTab.jsx
@@ -603,6 +603,8 @@ function FileDropTab() {
   // Navigation for post-import redirect
   var useNavigate = Meteor.useNavigate;
   var navigate = useNavigate ? useNavigate() : function() {};
+  var useLocation = Meteor.useLocation;
+  var routerLocation = useLocation ? useLocation() : { search: '' };
 
   // Detect dark mode from app theme
   var isDark = false;
@@ -778,7 +780,18 @@ function FileDropTab() {
     setImportDialogOpen(false);
     setAppleHealthImportOptions(null);
     if(wasCompleted){
-      navigate('/');
+      // ?next=<route-slug> redirects after a completed import (internal
+      // routes only — reject anything that could leave the app).
+      var nextParam = (new URLSearchParams(routerLocation.search).get('next') || '').trim();
+      var isSafeNext = nextParam.length > 0 &&
+        !nextParam.includes('://') &&
+        !nextParam.includes('\\') &&
+        !nextParam.startsWith('//');
+      if (isSafeNext) {
+        navigate('/' + nextParam.replace(/^\/+/, ''));
+      } else {
+        navigate('/');
+      }
     }
   }
 

--- a/npmPackages/data-importer/client/ImportStoreContext.jsx
+++ b/npmPackages/data-importer/client/ImportStoreContext.jsx
@@ -4,11 +4,25 @@
 // Stripped-down version of merkalis ViewerStoreContext — no merkle state.
 
 import React, { createContext, useContext, useReducer } from 'react';
+import { Meteor } from 'meteor/meteor';
+import { get } from 'lodash';
+
+// The configured inbound-fetch interface base
+// (settings.public.interfaces.default.channel.endpoint), falling back to
+// this server's own FHIR base. Visible on /server-configuration?tab=interfaces.
+export function getInboundFetchBase() {
+  return get(Meteor, 'settings.public.interfaces.default.channel.endpoint', '') ||
+    Meteor.absoluteUrl('baseR4');
+}
+
+// Default REST API URL shown in the rest-api tab input.
+var defaultInboundFetchUrl = get(Meteor, 'settings.public.interfaces.default.channel.endpoint', '') ||
+  Meteor.absoluteUrl('baseR4/Patient');
 
 var initialState = {
   // REST API tab
   httpMethod: 'GET',
-  httpUrl: 'http://localhost:3000/baseR4/Patient/8ae88d45-4998-cf3b-6cf4-2d1f9d1324c6',
+  httpUrl: defaultInboundFetchUrl,
   patientJson: '{}',
   responseJson: '',
 

--- a/npmPackages/data-importer/client/RestApiTab.jsx
+++ b/npmPackages/data-importer/client/RestApiTab.jsx
@@ -3,8 +3,9 @@
 // Postman-style REST API interface with request body and response preview.
 // Adapted from merkalis RestApiContent.jsx — uses ImportStoreContext + direct fetch().
 
-import React, { useState, useEffect, useMemo } from 'react';
+import React, { useState, useEffect, useMemo, useRef } from 'react';
 import { Meteor } from 'meteor/meteor';
+import { Session } from 'meteor/session';
 import {
   Box,
   Card,
@@ -21,14 +22,14 @@ import {
   CircularProgress
 } from '@mui/material';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
-import { Send as SendIcon } from '@mui/icons-material';
+import { Send as SendIcon, PlaylistAddCheck as ReviewIcon } from '@mui/icons-material';
 import AceEditor from 'react-ace';
 
 import 'ace-builds/src-noconflict/mode-json';
 import 'ace-builds/src-noconflict/theme-monokai';
 import 'ace-builds/src-noconflict/theme-github';
 
-import { useImportStore } from './ImportStoreContext.jsx';
+import { useImportStore, getInboundFetchBase } from './ImportStoreContext.jsx';
 
 var METHOD_COLORS = {
   GET: '#4caf50',
@@ -45,6 +46,20 @@ function RestApiTab() {
 
   var [requestExpanded, setRequestExpanded] = useState(false);
   var [responseExpanded, setResponseExpanded] = useState(true);
+
+  // URL params: ?patient=<id> auto-builds and runs a $everything fetch;
+  // ?next=<slug> is carried through to the File Drop tab for the
+  // redirect-after-import behavior.
+  var useLocation = Meteor.useLocation;
+  var location = useLocation ? useLocation() : { search: '' };
+  var searchParams = new URLSearchParams(location.search);
+  var patientParam = searchParams.get('patient');
+  var nextParam = searchParams.get('next');
+
+  var useNavigate = Meteor.useNavigate;
+  var navigate = useNavigate ? useNavigate() : function() {};
+
+  var autoFetchFiredRef = useRef(false);
 
   // Detect dark mode from app theme
   var isDark = false;
@@ -68,35 +83,79 @@ function RestApiTab() {
 
   var DynamicFhirViews = Meteor.DynamicFhirViews;
 
-  // HTTP send using direct fetch()
-  function handleSend() {
-    if (!state.httpUrl) return;
+  // Push a fetched FHIR payload into the shared import pipeline so the
+  // File Drop tab's dedup review + ImportDialog can take over (same
+  // contract as FhirDropTab's validate handler).
+  function bridgeToImportPipeline(parsed) {
+    var resources = [];
+    if (parsed && parsed.resourceType === 'Bundle' && Array.isArray(parsed.entry)) {
+      resources = parsed.entry.map(function(entry) { return entry.resource; }).filter(Boolean);
+    } else if (parsed && parsed.resourceType && parsed.resourceType !== 'OperationOutcome') {
+      resources = [parsed];
+    }
+    if (resources.length > 0) {
+      Session.set('importBuffer', resources);
+      Session.set('fileExtension', 'json');
+      dispatch({ type: 'SET_RESOURCE_LIST', payload: { resources: resources, source: 'rest-api' } });
+    }
+  }
+
+  // HTTP send using direct fetch().  GET responses that are paged searchset
+  // Bundles are accumulated by following link[relation=next] (capped) so
+  // $everything results arrive complete.
+  function executeFetch(targetUrl, method) {
+    if (!targetUrl) return;
 
     dispatch({ type: 'SET_LOADING', payload: true });
     dispatch({ type: 'SET_ERROR', payload: null });
 
     var fetchOptions = {
-      method: state.httpMethod,
+      method: method,
       headers: {
         'Accept': 'application/fhir+json, application/json',
         'Content-Type': 'application/fhir+json'
       }
     };
 
-    if (state.httpMethod !== 'GET' && state.httpMethod !== 'DELETE' && state.patientJson !== '{}') {
+    if (method !== 'GET' && method !== 'DELETE' && state.patientJson !== '{}') {
       fetchOptions.body = state.patientJson;
     }
 
-    fetch(state.httpUrl, fetchOptions)
+    fetch(targetUrl, fetchOptions)
       .then(function(response) {
         return response.text().then(function(text) {
           return { status: response.status, text: text };
         });
       })
-      .then(function(result) {
+      .then(async function(result) {
         // Try to pretty-print JSON response
         try {
           var parsed = JSON.parse(result.text);
+
+          if (method === 'GET' && parsed.resourceType === 'Bundle') {
+            var entries = Array.isArray(parsed.entry) ? parsed.entry.slice() : [];
+            var nextLink = (parsed.link || []).find(function(l) { return l.relation === 'next'; });
+            var pagesFetched = 1;
+            var MAX_PAGES = 25;
+            while (nextLink && nextLink.url && pagesFetched < MAX_PAGES) {
+              var pageResponse = await fetch(nextLink.url, { headers: fetchOptions.headers });
+              var pageBundle = await pageResponse.json();
+              if (Array.isArray(pageBundle.entry)) {
+                entries = entries.concat(pageBundle.entry);
+              }
+              nextLink = (pageBundle.link || []).find(function(l) { return l.relation === 'next'; });
+              pagesFetched++;
+            }
+            if (pagesFetched > 1) {
+              console.log('[RestApiTab] Accumulated ' + entries.length + ' entries across ' + pagesFetched + ' pages');
+              parsed = Object.assign({}, parsed, { entry: entries, link: [], total: entries.length });
+            }
+          }
+
+          if (method === 'GET' && result.status >= 200 && result.status < 300) {
+            bridgeToImportPipeline(parsed);
+          }
+
           dispatch({ type: 'SET_RESPONSE_JSON', payload: JSON.stringify(parsed, null, 2) });
         } catch (e) {
           dispatch({ type: 'SET_RESPONSE_JSON', payload: result.text });
@@ -109,6 +168,32 @@ function RestApiTab() {
         dispatch({ type: 'SET_RESPONSE_JSON', payload: JSON.stringify({ error: err.message }, null, 2) });
         dispatch({ type: 'SET_LOADING', payload: false });
       });
+  }
+
+  function handleSend() {
+    executeFetch(state.httpUrl, state.httpMethod);
+  }
+
+  // ?patient=<id> → build the $everything URL from the configured inbound
+  // fetch interface and run it immediately (once per mount).
+  useEffect(function() {
+    if (!patientParam || autoFetchFiredRef.current) { return; }
+    autoFetchFiredRef.current = true;
+    var base = getInboundFetchBase().replace(/\/+$/, '');
+    var url = base + '/Patient/' + encodeURIComponent(patientParam) + '/$everything?_count=200';
+    console.log('[RestApiTab] Auto-fetching patient from URL param:', url);
+    dispatch({ type: 'SET_HTTP_METHOD', payload: 'GET' });
+    dispatch({ type: 'SET_HTTP_URL', payload: url });
+    executeFetch(url, 'GET');
+  }, [patientParam]);
+
+  // Jump to the File Drop tab (dedup review + Load Data), carrying ?next=
+  // so the post-import redirect still works.
+  function handleReviewImport() {
+    var target = '?tab=file-drop';
+    if (patientParam) { target += '&patient=' + encodeURIComponent(patientParam); }
+    if (nextParam) { target += '&next=' + encodeURIComponent(nextParam); }
+    navigate(target);
   }
 
   function handleMethodChange(e) {
@@ -217,6 +302,20 @@ function RestApiTab() {
               Send
             </Button>
           </Box>
+
+          {state.resourceListSource === 'rest-api' && state.resourceList.length > 0 && (
+            <Box sx={{ display: 'flex', justifyContent: 'flex-end', mb: 1 }}>
+              <Button
+                id="reviewAndImportButton"
+                variant="outlined"
+                color="success"
+                onClick={handleReviewImport}
+                startIcon={<ReviewIcon />}
+              >
+                Review &amp; Import ({state.resourceList.length} resources)
+              </Button>
+            </Box>
+          )}
 
           {/* Request Body */}
           <Accordion

--- a/npmPackages/data-importer/client/RestApiTab.jsx
+++ b/npmPackages/data-importer/client/RestApiTab.jsx
@@ -62,12 +62,14 @@ function RestApiTab() {
   var searchParams = new URLSearchParams(location.search);
   var patientParam = searchParams.get('patient');
   var nextParam = searchParams.get('next');
+  var urlParam = searchParams.get('url');
 
   var useNavigate = Meteor.useNavigate;
   var navigate = useNavigate ? useNavigate() : function() {};
 
   var autoFetchFiredRef = useRef(false);
   var autoSwitchOnBridgeRef = useRef(false);
+  var lastAutoFetchedUrlRef = useRef(null);
 
   // Detect dark mode from app theme
   var isDark = false;
@@ -90,6 +92,7 @@ function RestApiTab() {
   }, [isDark, dispatch]);
 
   var DynamicFhirViews = Meteor.DynamicFhirViews;
+  var DynamicFhirDetail = Meteor.DynamicFhirDetail;
 
   // Push a fetched FHIR payload into the shared import pipeline so the
   // File Drop tab's dedup review + ImportDialog can take over (same
@@ -187,6 +190,20 @@ function RestApiTab() {
     executeFetch(state.httpUrl, state.httpMethod);
   }
 
+  // ?url=<fhir-url> → fetch that URL directly (e.g. a DocumentReference
+  // attachment pointing at a Bundle). Takes precedence over ?patient=, and
+  // re-fires when the param changes (in-place navigation from a Detail form).
+  useEffect(function() {
+    if (!urlParam || lastAutoFetchedUrlRef.current === urlParam) { return; }
+    lastAutoFetchedUrlRef.current = urlParam;
+    autoFetchFiredRef.current = true;
+    autoSwitchOnBridgeRef.current = true;
+    console.log('[RestApiTab] Auto-fetching from URL param:', urlParam);
+    dispatch({ type: 'SET_HTTP_METHOD', payload: 'GET' });
+    dispatch({ type: 'SET_HTTP_URL', payload: urlParam });
+    executeFetch(urlParam, 'GET');
+  }, [urlParam]);
+
   // ?patient=<id> → build the $everything URL from the configured inbound
   // fetch interface and run it immediately (once per mount).
   useEffect(function() {
@@ -211,8 +228,13 @@ function RestApiTab() {
   }
 
   // Selecting a resource in the list loads it into the Request Body editor
-  // (same behavior as File Drop's resource list).
+  // and the Response Preview panel; re-clicking the same row deselects,
+  // restoring the default first-bundle-entry preview.
   function handleSelectResource(index, resource) {
+    if (state.selectedResourceIndex === index) {
+      dispatch({ type: 'SET_SELECTED_RESOURCE_INDEX', payload: -1 });
+      return;
+    }
     dispatch({ type: 'SET_SELECTED_RESOURCE_INDEX', payload: index });
     dispatch({ type: 'SET_PATIENT_JSON', payload: JSON.stringify(resource, null, 2) });
   }
@@ -245,6 +267,10 @@ function RestApiTab() {
       return null;
     }
   }, [state.responseJson]);
+
+  // Resource selected via the > arrow in the resource list; takes precedence
+  // over the first-bundle-entry response preview.
+  var selectedResource = (state.selectedResourceIndex >= 0 && state.resourceList[state.selectedResourceIndex]) || null;
 
   return (
     <Box sx={{
@@ -480,7 +506,9 @@ function RestApiTab() {
           }}
         />
         <CardContent sx={{ flex: 1, overflow: 'auto', minHeight: 0 }}>
-          {parsedResponse && DynamicFhirViews ? (
+          {selectedResource && DynamicFhirDetail ? (
+            <DynamicFhirDetail fhirResource={selectedResource} />
+          ) : parsedResponse && DynamicFhirViews ? (
             <DynamicFhirViews
               fhirResource={parsedResponse}
               embedded={true}

--- a/npmPackages/data-importer/client/RestApiTab.jsx
+++ b/npmPackages/data-importer/client/RestApiTab.jsx
@@ -19,7 +19,9 @@ import {
   MenuItem,
   TextField,
   Button,
-  CircularProgress
+  CircularProgress,
+  ToggleButton,
+  ToggleButtonGroup
 } from '@mui/material';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import { Send as SendIcon, PlaylistAddCheck as ReviewIcon } from '@mui/icons-material';
@@ -30,6 +32,7 @@ import 'ace-builds/src-noconflict/theme-monokai';
 import 'ace-builds/src-noconflict/theme-github';
 
 import { useImportStore, getInboundFetchBase } from './ImportStoreContext.jsx';
+import ResourceListAccordion from './ResourceListAccordion.jsx';
 
 var METHOD_COLORS = {
   GET: '#4caf50',
@@ -47,6 +50,10 @@ function RestApiTab() {
   var [requestExpanded, setRequestExpanded] = useState(false);
   var [responseExpanded, setResponseExpanded] = useState(true);
 
+  // 'console' = postman-style Request/Response accordions;
+  // 'resources' = the shared Resource List (same component as File Drop)
+  var [viewMode, setViewMode] = useState('console');
+
   // URL params: ?patient=<id> auto-builds and runs a $everything fetch;
   // ?next=<slug> is carried through to the File Drop tab for the
   // redirect-after-import behavior.
@@ -60,6 +67,7 @@ function RestApiTab() {
   var navigate = useNavigate ? useNavigate() : function() {};
 
   var autoFetchFiredRef = useRef(false);
+  var autoSwitchOnBridgeRef = useRef(false);
 
   // Detect dark mode from app theme
   var isDark = false;
@@ -97,6 +105,11 @@ function RestApiTab() {
       Session.set('importBuffer', resources);
       Session.set('fileExtension', 'json');
       dispatch({ type: 'SET_RESOURCE_LIST', payload: { resources: resources, source: 'rest-api' } });
+      // The ?patient auto-fetch lands straight on the resource list view
+      if (autoSwitchOnBridgeRef.current) {
+        autoSwitchOnBridgeRef.current = false;
+        setViewMode('resources');
+      }
     }
   }
 
@@ -179,6 +192,7 @@ function RestApiTab() {
   useEffect(function() {
     if (!patientParam || autoFetchFiredRef.current) { return; }
     autoFetchFiredRef.current = true;
+    autoSwitchOnBridgeRef.current = true;
     var base = getInboundFetchBase().replace(/\/+$/, '');
     var url = base + '/Patient/' + encodeURIComponent(patientParam) + '/$everything?_count=200';
     console.log('[RestApiTab] Auto-fetching patient from URL param:', url);
@@ -194,6 +208,13 @@ function RestApiTab() {
     if (patientParam) { target += '&patient=' + encodeURIComponent(patientParam); }
     if (nextParam) { target += '&next=' + encodeURIComponent(nextParam); }
     navigate(target);
+  }
+
+  // Selecting a resource in the list loads it into the Request Body editor
+  // (same behavior as File Drop's resource list).
+  function handleSelectResource(index, resource) {
+    dispatch({ type: 'SET_SELECTED_RESOURCE_INDEX', payload: index });
+    dispatch({ type: 'SET_PATIENT_JSON', payload: JSON.stringify(resource, null, 2) });
   }
 
   function handleMethodChange(e) {
@@ -245,11 +266,29 @@ function RestApiTab() {
       }}>
         <CardHeader
           title="REST API"
+          action={
+            <ToggleButtonGroup
+              value={viewMode}
+              exclusive
+              size="small"
+              onChange={function(event, newMode) {
+                if (newMode !== null) { setViewMode(newMode); }
+              }}
+            >
+              <ToggleButton id="restApiConsoleViewToggle" value="console">
+                Request / Response
+              </ToggleButton>
+              <ToggleButton id="restApiResourcesViewToggle" value="resources" disabled={state.resourceList.length === 0}>
+                Resource List{state.resourceList.length > 0 ? ' (' + state.resourceList.length + ')' : ''}
+              </ToggleButton>
+            </ToggleButtonGroup>
+          }
           sx={{
             borderBottom: 1,
             borderColor: dividerColor,
             flexShrink: 0,
-            '& .MuiCardHeader-title': { fontSize: '1.1rem' }
+            '& .MuiCardHeader-title': { fontSize: '1.1rem' },
+            '& .MuiCardHeader-action': { alignSelf: 'center', m: 0 }
           }}
         />
         <CardContent sx={{ flex: 1, display: 'flex', flexDirection: 'column', minHeight: 0, overflow: 'hidden', p: 2 }}>
@@ -317,6 +356,16 @@ function RestApiTab() {
             </Box>
           )}
 
+          {viewMode === 'resources' ? (
+            <Box sx={{ flex: 1, minHeight: 0, overflow: 'auto', mt: 1 }}>
+              <ResourceListAccordion
+                resources={state.resourceList}
+                selectedIndex={state.selectedResourceIndex}
+                onSelectResource={handleSelectResource}
+              />
+            </Box>
+          ) : (
+          <>
           {/* Request Body */}
           <Accordion
             expanded={requestExpanded}
@@ -324,7 +373,11 @@ function RestApiTab() {
             disableGutters
             sx={{
               mt: 1, bgcolor: cardBgColor, '&:before': { display: 'none' },
-              ...(requestExpanded && { flex: 1, display: 'flex', flexDirection: 'column' })
+              ...(requestExpanded && { flex: 1, display: 'flex', flexDirection: 'column', minHeight: 0 }),
+              '& .MuiCollapse-entered': { flex: 1, minHeight: 0 },
+              '& .MuiCollapse-entered .MuiCollapse-wrapper': { height: '100%' },
+              '& .MuiCollapse-entered .MuiCollapse-wrapperInner': { height: '100%' },
+              '& .MuiCollapse-entered .MuiAccordion-region': { height: '100%', display: 'flex', flexDirection: 'column' }
             }}
           >
             <AccordionSummary expandIcon={<ExpandMoreIcon />}>
@@ -332,7 +385,7 @@ function RestApiTab() {
                 Request Body
               </Typography>
             </AccordionSummary>
-            <AccordionDetails sx={{ p: 0, flex: 1, display: 'flex', flexDirection: 'column' }}>
+            <AccordionDetails sx={{ p: 0, flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column' }}>
               <Box sx={{ flex: 1, minHeight: 200, display: 'flex', flexDirection: 'column' }}>
                 <AceEditor
                   mode="json"
@@ -366,14 +419,21 @@ function RestApiTab() {
             expanded={responseExpanded}
             onChange={function(e, isExpanded) { setResponseExpanded(isExpanded); }}
             disableGutters
-            sx={{ mt: 1, flex: 1, display: 'flex', flexDirection: 'column', bgcolor: cardBgColor, '&:before': { display: 'none' } }}
+            sx={{
+              mt: 1, bgcolor: cardBgColor, '&:before': { display: 'none' },
+              ...(responseExpanded && { flex: 1, display: 'flex', flexDirection: 'column', minHeight: 0 }),
+              '& .MuiCollapse-entered': { flex: 1, minHeight: 0 },
+              '& .MuiCollapse-entered .MuiCollapse-wrapper': { height: '100%' },
+              '& .MuiCollapse-entered .MuiCollapse-wrapperInner': { height: '100%' },
+              '& .MuiCollapse-entered .MuiAccordion-region': { height: '100%', display: 'flex', flexDirection: 'column' }
+            }}
           >
             <AccordionSummary expandIcon={<ExpandMoreIcon />}>
               <Typography variant="caption" sx={{ color: textSecondary }}>
                 Response Body
               </Typography>
             </AccordionSummary>
-            <AccordionDetails sx={{ p: 0, flex: 1, display: 'flex', flexDirection: 'column' }}>
+            <AccordionDetails sx={{ p: 0, flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column' }}>
               <AceEditor
                 mode="json"
                 theme={state.isDark ? 'monokai' : 'github'}
@@ -399,6 +459,8 @@ function RestApiTab() {
               />
             </AccordionDetails>
           </Accordion>
+          </>
+          )}
         </CardContent>
       </Card>
 

--- a/npmPackages/pacio-core/client/components/FhirFetchPanel.jsx
+++ b/npmPackages/pacio-core/client/components/FhirFetchPanel.jsx
@@ -39,7 +39,12 @@ export function FhirFetchPanel() {
   const cardTextColor = isDark ? 'rgba(255, 255, 255, 0.87)' : 'rgba(0, 0, 0, 0.87)';
 
   const [patientId, setPatientId] = useState('patient-betsysmith-johnson01');
-  const [fhirServerUrl, setFhirServerUrl] = useState('https://gw.interop.community/paciosandbox/open');
+  // Default to the configured inbound-fetch interface
+  // (settings.public.interfaces.default — see /server-configuration?tab=interfaces)
+  const [fhirServerUrl, setFhirServerUrl] = useState(
+    get(Meteor, 'settings.public.interfaces.default.channel.endpoint', '') ||
+    Meteor.absoluteUrl('baseR4')
+  );
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState(null);
   const [success, setSuccess] = useState(null);

--- a/npmPackages/pacio-core/client/components/RemotePatientBrowser.jsx
+++ b/npmPackages/pacio-core/client/components/RemotePatientBrowser.jsx
@@ -1,0 +1,247 @@
+// /packages/pacio-core/client/components/RemotePatientBrowser.jsx
+//
+// Browses the /Patient list of a remote FHIR server (the configured
+// inbound-fetch interface) so the user can pick a patient without knowing
+// its id.  Selecting a row hands off to the data-importer pipeline:
+//   /import-data?tab=rest-api&patient=<id>&next=pacio-dashboard
+// which auto-runs $everything, offers dedup review, and redirects to the
+// pacio dashboard after import.
+
+import React, { useState, useEffect, useRef } from 'react';
+import {
+  Box,
+  Card,
+  CardHeader,
+  CardContent,
+  TextField,
+  Button,
+  Typography,
+  Alert,
+  CircularProgress,
+  Table,
+  TableHead,
+  TableBody,
+  TableRow,
+  TableCell,
+  TableContainer,
+  InputAdornment
+} from '@mui/material';
+import SearchIcon from '@mui/icons-material/Search';
+import { Meteor } from 'meteor/meteor';
+import { get } from 'lodash';
+
+const log = (Meteor.Logger ? Meteor.Logger.for('RemotePatientBrowser') : console);
+
+// Inbound-fetch interface base (settings.public.interfaces.default);
+// visible on /server-configuration?tab=interfaces.
+function getInboundFetchBase() {
+  return get(Meteor, 'settings.public.interfaces.default.channel.endpoint', '') ||
+    Meteor.absoluteUrl('baseR4');
+}
+
+function patientDisplayName(patient) {
+  const text = get(patient, 'name.0.text', '');
+  if (text) { return text; }
+  const given = get(patient, 'name.0.given', []).join(' ');
+  const family = get(patient, 'name.0.family', '');
+  return (given + ' ' + family).trim() || get(patient, 'id', '');
+}
+
+export function RemotePatientBrowser() {
+  const useNavigate = Meteor.useNavigate;
+  const navigate = useNavigate ? useNavigate() : function() {};
+
+  const [fhirServerUrl, setFhirServerUrl] = useState(getInboundFetchBase());
+  const [searchText, setSearchText] = useState('');
+  const [patients, setPatients] = useState([]);
+  const [nextUrl, setNextUrl] = useState(null);
+  const [total, setTotal] = useState(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState(null);
+  const [hasFetched, setHasFetched] = useState(false);
+
+  function fetchPage(url, append) {
+    setIsLoading(true);
+    setError(null);
+    fetch(url, { headers: { 'Accept': 'application/fhir+json, application/json' } })
+      .then(function(response) {
+        if (!response.ok) {
+          throw new Error('HTTP ' + response.status + ' from ' + url);
+        }
+        return response.json();
+      })
+      .then(function(bundle) {
+        const found = get(bundle, 'entry', [])
+          .map(function(entry) { return entry.resource; })
+          .filter(function(resource) { return resource && resource.resourceType === 'Patient'; });
+        setPatients(function(prev) { return append ? prev.concat(found) : found; });
+        const next = (get(bundle, 'link', []) || []).find(function(link) { return link.relation === 'next'; });
+        setNextUrl(next ? next.url : null);
+        setTotal(typeof bundle.total === 'number' ? bundle.total : null);
+        setIsLoading(false);
+        setHasFetched(true);
+      })
+      .catch(function(err) {
+        log.error('Remote patient search failed', { url: url, error: err.message });
+        setError(err.message);
+        setIsLoading(false);
+        setHasFetched(true);
+      });
+  }
+
+  function buildSearchUrl() {
+    let url = fhirServerUrl.replace(/\/+$/, '') + '/Patient?_count=50';
+    if (searchText.trim()) {
+      url += '&name=' + encodeURIComponent(searchText.trim());
+    }
+    return url;
+  }
+
+  const initialFetchRef = useRef(false);
+  useEffect(function() {
+    if (initialFetchRef.current) { return; }
+    initialFetchRef.current = true;
+    if (fhirServerUrl) {
+      fetchPage(buildSearchUrl(), false);
+    }
+  }, []);
+
+  function handleSearch() {
+    fetchPage(buildSearchUrl(), false);
+  }
+
+  function handleLoadMore() {
+    if (nextUrl) {
+      fetchPage(nextUrl, true);
+    }
+  }
+
+  function handleSelect(patient) {
+    const patientId = get(patient, 'id');
+    if (!patientId) {
+      log.warn('Selected remote patient has no id', { patient: patient });
+      return;
+    }
+    navigate('/import-data?tab=rest-api&patient=' + encodeURIComponent(patientId) + '&next=pacio-dashboard');
+  }
+
+  return (
+    <Card id="remotePatientBrowser">
+      <CardHeader
+        title="Remote Patients"
+        subheader="Select a patient to fetch and import their record"
+      />
+      <CardContent>
+        <TextField
+          id="remoteFhirServerUrlInput"
+          fullWidth
+          label="FHIR Server URL"
+          value={fhirServerUrl}
+          onChange={function(event) { setFhirServerUrl(event.target.value); }}
+          helperText="settings.public.interfaces.default.channel.endpoint — see /server-configuration?tab=interfaces"
+          sx={{ mb: 2, '& .MuiInputBase-input': { fontFamily: 'monospace', fontSize: '0.875rem' } }}
+        />
+
+        <Box sx={{ display: 'flex', gap: 1, mb: 2, alignItems: 'center' }}>
+          <TextField
+            id="remotePatientSearchInput"
+            fullWidth
+            size="small"
+            placeholder="Search by name..."
+            value={searchText}
+            onChange={function(event) { setSearchText(event.target.value); }}
+            onKeyDown={function(event) { if (event.key === 'Enter') { handleSearch(); } }}
+            InputProps={{
+              startAdornment: (
+                <InputAdornment position="start">
+                  <SearchIcon fontSize="small" />
+                </InputAdornment>
+              )
+            }}
+          />
+          <Button
+            id="remotePatientSearchButton"
+            variant="contained"
+            onClick={handleSearch}
+            disabled={isLoading || !fhirServerUrl}
+          >
+            Search
+          </Button>
+        </Box>
+
+        {error && (
+          <Alert severity="error" sx={{ mb: 2 }}>
+            Could not reach the remote FHIR server: {error}
+          </Alert>
+        )}
+
+        {isLoading && patients.length === 0 ? (
+          <Box sx={{ display: 'flex', justifyContent: 'center', p: 4 }}>
+            <CircularProgress />
+          </Box>
+        ) : (
+          <TableContainer>
+            <Table id="remotePatientsTable" size="small">
+              <TableHead>
+                <TableRow>
+                  <TableCell>Name</TableCell>
+                  <TableCell>Gender</TableCell>
+                  <TableCell>Birth Date</TableCell>
+                  <TableCell>Patient ID</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {patients.map(function(patient) {
+                  return (
+                    <TableRow
+                      key={get(patient, 'id')}
+                      onClick={function() { handleSelect(patient); }}
+                      sx={{ cursor: 'pointer', '&:hover': { backgroundColor: 'action.hover' } }}
+                    >
+                      <TableCell>{patientDisplayName(patient)}</TableCell>
+                      <TableCell>{get(patient, 'gender', '')}</TableCell>
+                      <TableCell>{get(patient, 'birthDate', '')}</TableCell>
+                      <TableCell sx={{ fontFamily: 'monospace', fontSize: '0.8125rem' }}>
+                        {get(patient, 'id', '')}
+                      </TableCell>
+                    </TableRow>
+                  );
+                })}
+                {hasFetched && !isLoading && patients.length === 0 && !error && (
+                  <TableRow>
+                    <TableCell colSpan={4}>
+                      <Typography variant="body2" color="text.secondary" sx={{ py: 2, textAlign: 'center' }}>
+                        No patients found on the remote server.
+                      </Typography>
+                    </TableCell>
+                  </TableRow>
+                )}
+              </TableBody>
+            </Table>
+          </TableContainer>
+        )}
+
+        <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mt: 2 }}>
+          <Typography variant="caption" color="text.secondary">
+            {patients.length > 0 ? (
+              'Showing ' + patients.length + (total !== null ? ' of ' + total : '') + ' patients'
+            ) : ''}
+          </Typography>
+          {nextUrl && (
+            <Button
+              id="remotePatientsLoadMoreButton"
+              variant="text"
+              onClick={handleLoadMore}
+              disabled={isLoading}
+              startIcon={isLoading ? <CircularProgress size={14} /> : null}
+            >
+              Load More
+            </Button>
+          )}
+        </Box>
+      </CardContent>
+    </Card>
+  );
+}
+
+export default RemotePatientBrowser;

--- a/npmPackages/pacio-core/client/components/RemotePatientBrowser.jsx
+++ b/npmPackages/pacio-core/client/components/RemotePatientBrowser.jsx
@@ -152,11 +152,6 @@ export function RemotePatientBrowser(props) {
             <Typography component="span" variant="body2" sx={{ fontFamily: 'monospace' }}>
               {fhirServerUrl}
             </Typography>
-            {' '}— configured as the Inbound Fetch interface on the{' '}
-            <Typography component="span" variant="body2" sx={{ fontFamily: 'monospace' }}>
-              /server-configuration?tab=interfaces
-            </Typography>
-            {' '}panel.
           </Alert>
         )}
 

--- a/npmPackages/pacio-core/client/components/RemotePatientBrowser.jsx
+++ b/npmPackages/pacio-core/client/components/RemotePatientBrowser.jsx
@@ -47,7 +47,11 @@ function patientDisplayName(patient) {
   return (given + ' ' + family).trim() || get(patient, 'id', '');
 }
 
-export function RemotePatientBrowser() {
+export function RemotePatientBrowser(props) {
+  // ?url-editable=true exposes the FHIR Server URL input; default is a
+  // read-only Info Alert showing the configured inbound-fetch interface.
+  const urlEditable = props.urlEditable === true;
+
   const useNavigate = Meteor.useNavigate;
   const navigate = useNavigate ? useNavigate() : function() {};
 
@@ -132,15 +136,29 @@ export function RemotePatientBrowser() {
         subheader="Select a patient to fetch and import their record"
       />
       <CardContent>
-        <TextField
-          id="remoteFhirServerUrlInput"
-          fullWidth
-          label="FHIR Server URL"
-          value={fhirServerUrl}
-          onChange={function(event) { setFhirServerUrl(event.target.value); }}
-          helperText="settings.public.interfaces.default.channel.endpoint — see /server-configuration?tab=interfaces"
-          sx={{ mb: 2, '& .MuiInputBase-input': { fontFamily: 'monospace', fontSize: '0.875rem' } }}
-        />
+        {urlEditable ? (
+          <TextField
+            id="remoteFhirServerUrlInput"
+            fullWidth
+            label="FHIR Server URL"
+            value={fhirServerUrl}
+            onChange={function(event) { setFhirServerUrl(event.target.value); }}
+            helperText="settings.public.interfaces.default.channel.endpoint — see /server-configuration?tab=interfaces"
+            sx={{ mb: 2, '& .MuiInputBase-input': { fontFamily: 'monospace', fontSize: '0.875rem' } }}
+          />
+        ) : (
+          <Alert id="remoteFhirServerUrlAlert" severity="info" sx={{ mb: 2 }}>
+            Fetching patients from{' '}
+            <Typography component="span" variant="body2" sx={{ fontFamily: 'monospace' }}>
+              {fhirServerUrl}
+            </Typography>
+            {' '}— configured as the Inbound Fetch interface on the{' '}
+            <Typography component="span" variant="body2" sx={{ fontFamily: 'monospace' }}>
+              /server-configuration?tab=interfaces
+            </Typography>
+            {' '}panel.
+          </Alert>
+        )}
 
         <Box sx={{ display: 'flex', gap: 1, mb: 2, alignItems: 'center' }}>
           <TextField

--- a/npmPackages/pacio-core/client/pages/PatientFetchPage.jsx
+++ b/npmPackages/pacio-core/client/pages/PatientFetchPage.jsx
@@ -24,12 +24,14 @@
 import React from 'react';
 import {
   Box,
+  Button,
   Container,
   Typography
 } from '@mui/material';
 import { Meteor } from 'meteor/meteor';
 
 import { FhirFetchPanel } from '../components/FhirFetchPanel';
+import { RemotePatientBrowser } from '../components/RemotePatientBrowser';
 
 export function PatientFetchPage(props) {
   // Get Honeycomb theme for dark mode support
@@ -39,21 +41,42 @@ export function PatientFetchPage(props) {
 
   const cardTextColor = isDark ? 'rgba(255, 255, 255, 0.87)' : 'rgba(0, 0, 0, 0.87)';
 
+  // ?view=select (default) browses the remote server's patients;
+  // ?view=identifier is the manual URL + patient-id $everything form.
+  const useLocation = Meteor.useLocation;
+  const location = useLocation ? useLocation() : { search: '' };
+  const useNavigate = Meteor.useNavigate;
+  const navigate = useNavigate ? useNavigate() : function() {};
+  const view = new URLSearchParams(location.search).get('view') || 'select';
+
   return (
     <Box sx={{ minHeight: '100vh' }}>
       <Container maxWidth="xl" sx={{ pt: 4, pb: 4 }}>
-        <Box sx={{ mb: 4 }}>
-          <Typography variant="h4" component="h1" gutterBottom sx={{ color: cardTextColor }}>
-            Patient Fetch
-          </Typography>
-          <Typography variant="body1" paragraph sx={{
-            color: isDark ? 'rgba(255, 255, 255, 0.6)' : 'rgba(0, 0, 0, 0.6)'
-          }}>
-            Fetch all patient data using the FHIR $everything operation
-          </Typography>
+        <Box sx={{ mb: 4, display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', flexWrap: 'wrap', gap: 2 }}>
+          <Box>
+            <Typography variant="h4" component="h1" gutterBottom sx={{ color: cardTextColor }}>
+              Patient Fetch
+            </Typography>
+            <Typography variant="body1" paragraph sx={{
+              color: isDark ? 'rgba(255, 255, 255, 0.6)' : 'rgba(0, 0, 0, 0.6)'
+            }}>
+              {view === 'identifier'
+                ? 'Fetch all patient data using the FHIR $everything operation'
+                : 'Browse a remote FHIR server and select a patient to import'}
+            </Typography>
+          </Box>
+          <Button
+            id="patientFetchViewToggle"
+            variant="text"
+            onClick={function() {
+              navigate('/patient-fetch?view=' + (view === 'identifier' ? 'select' : 'identifier'), { replace: true });
+            }}
+          >
+            {view === 'identifier' ? 'Browse patients' : 'Enter patient ID manually'}
+          </Button>
         </Box>
 
-        <FhirFetchPanel />
+        {view === 'identifier' ? <FhirFetchPanel /> : <RemotePatientBrowser />}
       </Container>
     </Box>
   );

--- a/npmPackages/pacio-core/client/pages/PatientFetchPage.jsx
+++ b/npmPackages/pacio-core/client/pages/PatientFetchPage.jsx
@@ -47,7 +47,11 @@ export function PatientFetchPage(props) {
   const location = useLocation ? useLocation() : { search: '' };
   const useNavigate = Meteor.useNavigate;
   const navigate = useNavigate ? useNavigate() : function() {};
-  const view = new URLSearchParams(location.search).get('view') || 'select';
+  const searchParams = new URLSearchParams(location.search);
+  const view = searchParams.get('view') || 'select';
+  // ?url-editable=true exposes the FHIR Server URL input on the select view;
+  // by default the configured interface is shown in a read-only Info Alert.
+  const urlEditable = searchParams.get('url-editable') === 'true';
 
   return (
     <Box sx={{ minHeight: '100vh' }}>
@@ -76,7 +80,7 @@ export function PatientFetchPage(props) {
           </Button>
         </Box>
 
-        {view === 'identifier' ? <FhirFetchPanel /> : <RemotePatientBrowser />}
+        {view === 'identifier' ? <FhirFetchPanel /> : <RemotePatientBrowser urlEditable={urlEditable} />}
       </Container>
     </Box>
   );

--- a/npmPackages/provider-directory/client/FooterButtons.jsx
+++ b/npmPackages/provider-directory/client/FooterButtons.jsx
@@ -20,15 +20,16 @@ import moment from 'moment';
 
 //========================================================================================================
 
+// MUI v4 → v5: makeStyles/withStyles moved to @mui/styles; fade→alpha,
+// createMuiTheme→createTheme, MuiThemeProvider→ThemeProvider (aliased so the
+// v4-style body below keeps working without a rewrite).
 import {
-  fade,
-  ThemeProvider,
-  MuiThemeProvider,
-  withStyles,
-  makeStyles,
-  createMuiTheme,
+  alpha as fade,
+  ThemeProvider as MuiThemeProvider,
+  createTheme as createMuiTheme,
   useTheme
 } from '@mui/material/styles';
+import { withStyles, makeStyles } from '@mui/styles';
 
   // Global Theming 
   // This is necessary for the Material UI component render layer

--- a/npmPackages/provider-directory/client/PreferencesDialog.jsx
+++ b/npmPackages/provider-directory/client/PreferencesDialog.jsx
@@ -2,7 +2,7 @@
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { useTracker } from 'meteor/react-meteor-data';
-import { makeStyles, withStyles } from '@mui/material/styles';
+import { makeStyles, withStyles } from '@mui/styles';
 import { useHistory } from "react-router-dom";
 
 import { 

--- a/npmPackages/provider-directory/client/PreferencesPage.jsx
+++ b/npmPackages/provider-directory/client/PreferencesPage.jsx
@@ -18,7 +18,7 @@ import {
   Image,
   Typography
 } from '@mui/material';
-import { makeStyles } from '@mui/material/styles';
+import { makeStyles } from '@mui/styles';
 
 import { get } from 'lodash';
 import { PageCanvas, StyledCard } from './_compat/fhirStarter';

--- a/npmPackages/provider-directory/client/ProviderDirectory.jsx
+++ b/npmPackages/provider-directory/client/ProviderDirectory.jsx
@@ -29,9 +29,19 @@ import {
   InputAdornment,
   IconButton
 } from '@mui/material';
-import { makeStyles } from '@mui/material/styles';
+import { makeStyles } from '@mui/styles';
 
 import { get, indexOf } from 'lodash';
+
+// These collections were Atmosphere globals under the old package; import the
+// host collections explicitly (same pattern as the other /imports host collections).
+import { ServerStats } from '/imports/lib/schemas/SimpleSchemas/ServerStats';
+import { Organizations } from '/imports/lib/schemas/SimpleSchemas/Organizations';
+import { Practitioners } from '/imports/lib/schemas/SimpleSchemas/Practitioners';
+import { Locations } from '/imports/lib/schemas/SimpleSchemas/Locations';
+import { Endpoints } from '/imports/lib/schemas/SimpleSchemas/Endpoints';
+import { HealthcareServices } from '/imports/lib/schemas/SimpleSchemas/HealthcareServices';
+import { InsurancePlans } from '/imports/lib/schemas/SimpleSchemas/InsurancePlans';
 
 import { DynamicSpacer, PageCanvas, StyledCard } from './_compat/fhirStarter';
 

--- a/npmPackages/provider-directory/client/SearchCodeSystemDialog.jsx
+++ b/npmPackages/provider-directory/client/SearchCodeSystemDialog.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { useTracker } from 'meteor/react-meteor-data';
-import { makeStyles, withStyles } from '@mui/material/styles';
+import { makeStyles, withStyles } from '@mui/styles';
 
 import { 
   Card,

--- a/npmPackages/provider-directory/client/SearchLibraryOfMedicineDialog.jsx
+++ b/npmPackages/provider-directory/client/SearchLibraryOfMedicineDialog.jsx
@@ -12,7 +12,7 @@
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { useTracker } from 'meteor/react-meteor-data';
-import { makeStyles, withStyles } from '@mui/material/styles';
+import { makeStyles, withStyles } from '@mui/styles';
 
 import { 
   Card,

--- a/npmPackages/provider-directory/client/SearchResourceTypesDialog.jsx
+++ b/npmPackages/provider-directory/client/SearchResourceTypesDialog.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { useTracker } from 'meteor/react-meteor-data';
-import { makeStyles, withStyles } from '@mui/material/styles';
+import { makeStyles, withStyles } from '@mui/styles';
 
 import { 
   Card,

--- a/npmPackages/provider-directory/client/SearchStatesDialog.jsx
+++ b/npmPackages/provider-directory/client/SearchStatesDialog.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { useTracker } from 'meteor/react-meteor-data';
-import { makeStyles, withStyles } from '@mui/material/styles';
+import { makeStyles, withStyles } from '@mui/styles';
 
 import { 
   Card,

--- a/npmPackages/provider-directory/client/SearchValueSetsDialog.jsx
+++ b/npmPackages/provider-directory/client/SearchValueSetsDialog.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { useTracker } from 'meteor/react-meteor-data';
-import { makeStyles, withStyles } from '@mui/material/styles';
+import { makeStyles, withStyles } from '@mui/styles';
 
 import { 
   Card,

--- a/npmPackages/provider-directory/client/ServerStatsPage.jsx
+++ b/npmPackages/provider-directory/client/ServerStatsPage.jsx
@@ -19,10 +19,13 @@ import {
   Image,
   Typography
 } from '@mui/material';
-import { makeStyles } from '@mui/material/styles';
+import { makeStyles } from '@mui/styles';
 
 import { get } from 'lodash';
 import { PageCanvas, StyledCard } from './_compat/fhirStarter';
+
+// ServerStats was an Atmosphere global under the old package; import the host collection.
+import { ServerStats } from '/imports/lib/schemas/SimpleSchemas/ServerStats';
 
 import { Icon } from 'react-icons-kit';
 import { github } from 'react-icons-kit/fa/github';

--- a/npmPackages/request-for-corrections/server/startup.js
+++ b/npmPackages/request-for-corrections/server/startup.js
@@ -2,6 +2,8 @@
 
 import { Meteor } from 'meteor/meteor';
 import { get } from 'lodash';
+import { CorrectionTasks } from '../lib/collections/CorrectionTasks';
+import { CorrectionCommunications } from '../lib/collections/CorrectionCommunications';
 
 // Server startup configuration
 Meteor.startup(async function() {
@@ -19,11 +21,10 @@ Meteor.startup(async function() {
     requireApprovalForAmendments: get(Meteor.settings, 'private.requestForCorrections.requireApprovalForAmendments', true)
   });
 
-  // Initialize indexes for better performance
-  const { CorrectionTasks } = await import('../lib/collections/CorrectionTasks');
-  const { CorrectionCommunications } = await import('../lib/collections/CorrectionCommunications');
-  
   // Create indexes for efficient querying
+  // (CorrectionTasks / CorrectionCommunications are imported statically at the
+  // top of this file — importing them dynamically here returned a
+  // temporal-dead-zone binding under Rspack and crashed boot.)
   if (CorrectionTasks && CorrectionTasks.rawCollection) {
     await CorrectionTasks.rawCollection().createIndex({ 'subject.reference': 1, status: 1 });
     await CorrectionTasks.rawCollection().createIndex({ businessStatus: 1 });

--- a/server/VaultServer.js
+++ b/server/VaultServer.js
@@ -71,8 +71,16 @@ Meteor.startup(function(){
   var browserPolicyConfig = get(Meteor, 'settings.private.browserPolicy');
   var corsEnv = process.env.CORS;
 
-  if(browserPolicyConfig || corsEnv){
-    log.info('Configuring content-security-policy (browserPolicy setting and/or CORS env var detected).');
+  // Supplying a Google Maps API key (env var or settings) means the app
+  // intends to load the Maps JS SDK, so allowlist its origins in the CSP
+  // without requiring every settings file to repeat a browserPolicy block.
+  var googleMapsApiKey = process.env.GOOGLE_MAPS_API_KEY ||
+    get(Meteor, 'settings.private.google.maps.apiKey') ||
+    get(Meteor, 'settings.private.google.mapsApiKey') ||
+    get(Meteor, 'settings.private.googleMapsApiKey');
+
+  if(browserPolicyConfig || corsEnv || googleMapsApiKey){
+    log.info('Configuring content-security-policy (browserPolicy setting, CORS env var, and/or Google Maps API key detected).');
 
     // import { BrowserPolicy } from 'meteor/browser-policy-common';
     import('meteor/browser-policy-common').then(({ BrowserPolicy }) => {
@@ -154,6 +162,21 @@ Meteor.startup(function(){
           BrowserPolicy.content.allowConnectOrigin(corsDomain);
           BrowserPolicy.content.allowImageOrigin(corsDomain);
         });
+      }
+
+      // ---------------------------------------------------------------
+      // Google Maps.  The Maps JS SDK loads scripts from maps.googleapis.com,
+      // tiles/sprites from maps.gstatic.com, and makes XHR calls back to
+      // maps.googleapis.com.  Allow those origins whenever a Maps API key
+      // is configured (GOOGLE_MAPS_API_KEY env var or settings.private.google.*).
+      // ---------------------------------------------------------------
+      if(googleMapsApiKey){
+        log.info('Google Maps API key detected; allowing maps.googleapis.com and maps.gstatic.com in content-security-policy.');
+        BrowserPolicy.content.allowOriginForAll('maps.googleapis.com');
+        BrowserPolicy.content.allowOriginForAll('maps.gstatic.com');
+        BrowserPolicy.content.allowConnectOrigin('maps.googleapis.com');
+        BrowserPolicy.content.allowImageOrigin('maps.googleapis.com');
+        BrowserPolicy.content.allowImageOrigin('maps.gstatic.com');
       }
 
       // ---------------------------------------------------------------


### PR DESCRIPTION
## Summary

Chronicle/welcome-page boot fixes, the July 5 patient-fetch remote browser restored from the feature branches, a CSP fix so Google Maps loads on any deployment, and import-data resource preview + DocumentReference fetch hand-off.

### Chronicle boot fixes
- **provider-directory**: MUI v4 to v5 migration + import host collections so Chronicle boots (38ed834f)
- **request-for-corrections**: static-import collections in startup (d3ea04df)
- **css**: inline fonts.css into main.css to avoid a runtime @import 404 (95de8bce)

### Patient-fetch remote browser (restored)
The /patient-fetch remote-patient browser shipped July 5 on dcmjs-integration / reference-ranges but never reached main, so branches cut from main regressed to the manual-ID-only page. Cherry-picked here (2dcaaad3, 11bf6be5), plus one polish commit (f68f4139):

- `RemotePatientBrowser` — browse/search patients on the configured Inbound Fetch interface (`settings.public.interfaces.default.channel.endpoint`, falling back to this server's own baseR4) and hand selected records to the import-data pipeline
- View toggle between remote browser and manual patient-ID entry, URL-editable fetch param, greedy-height editors on the rest-api tab
- Trimmed the interfaces-panel pointer from the fetch alert (f68f4139)

Note for the eventual dcmjs-integration / reference-ranges merges: the two cherry-picked patches are identical there, so git will dedupe them cleanly unless the touched files drift first.

### Google Maps CSP auto-allow (a40592bd)
The browser-policy package applies its restrictive default CSP whenever `settings.private.browserPolicy` is absent — every settings file without an explicit allowlist blocked maps.googleapis.com (LocationMap on the pacio dashboard). Now, configuring a Maps API key (`GOOGLE_MAPS_API_KEY` env var or `settings.private.google.*`) enables the BrowserPolicy path and allowlists maps.googleapis.com / maps.gstatic.com for scripts, connect, and images. Deployments no longer need to repeat a browserPolicy block per settings file just for Maps.

### Import-data: resource preview + DocumentReference fetch hand-off (ebda313d)
- **Resource-list preview**: on the rest-api tab, the `>` arrow on a resource row now renders that resource in the Response Preview panel via `Meteor.DynamicFhirDetail`, which auto-routes by resourceType to the registered Honeycomb Detail component (62 registered). Re-clicking the same row deselects back to the default first-bundle-entry preview; the arrow still loads the resource JSON into the Request Body editor.
- **DocumentReference URL hand-off**: `DocumentReferenceFormView` gets a globe end-adornment on the Document URL field that navigates to `/import-data?tab=rest-api&url=<attachment url>`. RestApiTab honors the new `?url=` param — sets GET + the URL and fetches immediately, taking precedence over `?patient=`. The auto-fetch is keyed on the param value, so in-place navigation (already on the rest-api tab) re-fires for each new URL.

## Test plan
- [ ] Boot with a Maps key set and confirm the CSP header includes maps.googleapis.com (log line: "Google Maps API key detected...") and LocationMap renders
- [ ] Boot without a Maps key or browserPolicy settings and confirm behavior is unchanged (browser-policy default CSP)
- [ ] /patient-fetch shows the Remote Patients browser with the endpoint banner (no interfaces-panel pointer); manual-ID toggle still works
- [ ] Import hand-off from remote browser lands records in the import-data pipeline
- [ ] Rest-api tab: `>` arrow opens the clicked resource in Response Preview (e.g. Condition, DocumentReference); re-click deselects; new Send resets selection
- [ ] DocumentReference detail: globe on Document URL jumps to the rest-api tab and fetches the attachment URL (e.g. a ToC Bundle); clicking a different DocumentReference's globe afterwards fetches the new URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)
