### PR TITLE
fix(onboarding): loud pnpm-free dcmjs postinstall + CI onboarding gate

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -647,6 +647,42 @@ jobs:
           name: accessibility gate (jest-axe)
           command: npm run a11y:ci
 
+  # onboarding: simulates a brand-new developer machine. Fresh checkout, the one
+  # documented pre-step (submodule init), then a plain UNCACHED `npm install`
+  # with no pnpm — the postinstall guard (scripts/postinstall-dcmjs.js) must
+  # produce the dcmjs bundle on its own. The other jobs restore caches and
+  # hand-build the bundle, so they never exercise the path a real
+  # `git clone && npm install && meteor run` takes; this one does.
+  onboarding:
+    docker:
+      - image: cimg/node:20.11.0
+    resource_class: medium
+    steps:
+      - checkout
+      - run:
+          name: Ensure pnpm is absent (prove the pnpm-free path)
+          command: |
+            if command -v pnpm >/dev/null 2>&1; then
+              echo "pnpm found at $(command -v pnpm) — removing so this job proves the pnpm-free path"
+              sudo rm -f "$(command -v pnpm)"
+            fi
+            ! command -v pnpm
+      - run:
+          name: Init dcmjs submodule (the one documented onboarding step)
+          # npm install needs the file:libraries/dcmjs target present before it
+          # can even read the dependency tree — postinstall can't save this.
+          command: git submodule update --init libraries/dcmjs
+      - run:
+          name: Plain npm install (uncached; postinstall must build dcmjs)
+          no_output_timeout: 20m
+          command: npm install
+      - run:
+          name: Assert dcmjs bundle exists and loads
+          command: |
+            test -s libraries/dcmjs/build/dcmjs.js
+            test -s libraries/dcmjs/build/dcmjs.es.js
+            node -e "const d = require('dcmjs'); if (!d || !d.data || !d.data.DicomMessage) throw new Error('dcmjs loaded but data.DicomMessage missing'); console.log('dcmjs OK:', Object.keys(d).join(', '));"
+
 workflows:
   version: 2
   parallel-tests:
@@ -656,6 +692,9 @@ workflows:
 
       # jest-axe accessibility gate over shared primitives (jsdom, no Meteor bundle)
       - accessibility-gate
+
+      # clean-clone onboarding gate: uncached npm install must build dcmjs
+      - onboarding
 
       # Run each test group in parallel
       - test-group:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,9 +164,15 @@ DICOM metadata extraction runs on the **dcmjs rewrite** — our fork at
 dependency. `workzone/dcmjs` is gitignored scratch; the submodule is canonical.
 
 ```bash
-# After fresh clone / submodule update (build/ is gitignored in the submodule):
+# After fresh clone: init the submodule, then plain npm install builds the
+# bundle automatically (scripts/postinstall-dcmjs.js — pnpm-free, uses the
+# rollup reified from the root lockfile, and FAILS the install loudly if the
+# bundle can't be produced). pnpm is only needed for parser development.
+# The CircleCI `onboarding` job gates exactly this clean-clone path.
 git submodule update --init libraries/dcmjs
-npm run dcmjs:build        # pnpm install + rollup build inside the submodule
+npm install                # postinstall builds libraries/dcmjs/build/ (gitignored)
+npm run dcmjs:setup        # same guard, runnable standalone for recovery
+npm run dcmjs:build        # force rebuild via pnpm (parser development)
 npm run dcmjs:watch        # rollup watch mode while developing the parser
 npm run test:dicom         # node --test parity suite (dcmjs vs dicom-parser)
 ```

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test:validator": "node --test imports/lib/FhirValidator.test.mjs",
     "test:dicom": "node --test imports/ui/DICOM/utils/DcmjsMetadata.test.mjs",
     "dcmjs:build": "cd libraries/dcmjs && pnpm install && pnpm run build",
-    "dcmjs:setup": "git submodule update --init libraries/dcmjs && npm run dcmjs:build",
+    "dcmjs:setup": "node scripts/postinstall-dcmjs.js",
     "dcmjs:watch": "cd libraries/dcmjs && pnpm run dev",
     "postinstall": "node scripts/postinstall-dcmjs.js",
     "test:logger": "node --test imports/lib/Logger.test.mjs",

--- a/scripts/postinstall-dcmjs.js
+++ b/scripts/postinstall-dcmjs.js
@@ -1,16 +1,24 @@
 // scripts/postinstall-dcmjs.js
-// Runs during `meteor npm install`. On the dcmjs-integration branch, `dcmjs`
+// Runs during `npm install` / `meteor npm install` (postinstall). `dcmjs`
 // resolves to the libraries/dcmjs git submodule, whose build/ output is
-// gitignored and must be built after checkout — otherwise the bundle fails with
-// "Can't resolve 'dcmjs'". This guard inits + builds the submodule the first
-// time. It is idempotent (skips when the bundle exists) and non-fatal (a build
-// failure warns but never fails the whole install).
+// gitignored — without it the app cannot compile (client code statically
+// imports dcmjs, so rspack fails with "Can't resolve 'dcmjs'"). This guard
+// inits the submodule and builds the bundle:
+//   1. rollup reified from the root package-lock into
+//      libraries/dcmjs/node_modules/.bin — no pnpm required (the same
+//      dependency set CI builds with)
+//   2. pnpm install + build, when pnpm is on PATH (parser-dev machines,
+//      lockfile drift)
+// Idempotent (skips when the bundle exists). A build failure FAILS the
+// install: a silent skip here only resurfaces later as the opaque rspack
+// error on someone else's machine.
 const fs = require('fs');
 const path = require('path');
 const { spawnSync } = require('child_process');
 
 const root = path.join(__dirname, '..');
-const bundle = path.join(root, 'libraries', 'dcmjs', 'build', 'dcmjs.js');
+const dcmjsDir = path.join(root, 'libraries', 'dcmjs');
+const bundle = path.join(dcmjsDir, 'build', 'dcmjs.js');
 const gitPath = path.join(root, '.git');
 
 if (fs.existsSync(bundle)) {
@@ -19,22 +27,85 @@ if (fs.existsSync(bundle)) {
 }
 
 if (!fs.existsSync(gitPath)) {
-  // Not a git checkout (e.g. a tarball download) — we can't init a submodule.
+  // Not a git checkout (e.g. a tarball download or deploy bundle) — we can't
+  // init a submodule, and deploy contexts don't compile the client here.
   console.log('[postinstall-dcmjs] no .git found — skipping submodule build; run `meteor npm run dcmjs:setup` if you need DICOM parsing');
   process.exit(0);
 }
 
-console.log('[postinstall-dcmjs] building dcmjs submodule (init + pnpm build)…');
 // Fixed argv, no user input — no shell, no injection surface.
-const result = spawnSync('npm', ['run', 'dcmjs:setup'], { cwd: root, stdio: 'inherit' });
-
-if (result.status !== 0) {
-  console.warn('[postinstall-dcmjs] dcmjs build did not complete; run `meteor npm run dcmjs:setup` manually before starting the app');
+function run(cmd, args, cwd) {
+  console.log('[postinstall-dcmjs] $ ' + cmd + ' ' + args.join(' '));
+  const result = spawnSync(cmd, args, { cwd: cwd, stdio: 'inherit' });
   if (result.error) {
-    console.warn('[postinstall-dcmjs]', result.error.message);
+    console.warn('[postinstall-dcmjs] ' + cmd + ' failed to start: ' + result.error.message);
   }
-  // Do not fail the install.
-  process.exit(0);
+  return result.status === 0;
 }
 
-console.log('[postinstall-dcmjs] dcmjs submodule built');
+function pnpmAvailable() {
+  const probe = spawnSync('pnpm', ['--version'], { stdio: 'ignore' });
+  return !probe.error && probe.status === 0;
+}
+
+function failLoudly(reason) {
+  const bar = '='.repeat(74);
+  console.error([
+    '',
+    '[postinstall-dcmjs] ' + bar,
+    '[postinstall-dcmjs] FAILED: ' + reason,
+    '[postinstall-dcmjs]',
+    '[postinstall-dcmjs] libraries/dcmjs/build/dcmjs.js is missing. The app CANNOT compile',
+    '[postinstall-dcmjs] without it — client code statically imports dcmjs, so the next',
+    '[postinstall-dcmjs] `meteor run` dies with: Module not found: Can\'t resolve \'dcmjs\'.',
+    '[postinstall-dcmjs]',
+    '[postinstall-dcmjs] To fix, run:',
+    '[postinstall-dcmjs]     meteor npm run dcmjs:setup',
+    '[postinstall-dcmjs] or, equivalently:',
+    '[postinstall-dcmjs]     git submodule update --init libraries/dcmjs',
+    '[postinstall-dcmjs]     (cd libraries/dcmjs && npx rollup -c)',
+    '[postinstall-dcmjs] ' + bar,
+    ''
+  ].join('\n'));
+  process.exit(1);
+}
+
+if (!fs.existsSync(path.join(dcmjsDir, 'package.json'))) {
+  console.log('[postinstall-dcmjs] libraries/dcmjs is empty — initializing submodule');
+  if (!run('git', ['submodule', 'update', '--init', 'libraries/dcmjs'], root)) {
+    failLoudly('git submodule update --init libraries/dcmjs did not complete');
+  }
+} else {
+  console.log('[postinstall-dcmjs] submodule present — building bundle');
+}
+
+// Attempt 1: the pnpm-free path. npm install reifies the submodule's devDeps
+// from the root package-lock (libraries/dcmjs/node_modules/* entries), so
+// rollup's bin shim is already on disk. Invoked by absolute path — no npx, no
+// PATH assumptions — so it behaves identically under npm and meteor npm.
+let built = false;
+const rollupBin = path.join(dcmjsDir, 'node_modules', '.bin', 'rollup');
+if (fs.existsSync(rollupBin)) {
+  console.log('[postinstall-dcmjs] building with lockfile-reified rollup (no pnpm required)');
+  built = run(rollupBin, ['-c'], dcmjsDir);
+} else {
+  console.log('[postinstall-dcmjs] no reified rollup at libraries/dcmjs/node_modules/.bin/rollup');
+}
+
+// Attempt 2: pnpm, when present (parser-dev machines; also covers the case
+// where the root lockfile has drifted from the submodule's devDeps).
+if (!built) {
+  if (pnpmAvailable()) {
+    console.log('[postinstall-dcmjs] falling back to pnpm install + build');
+    built = run('pnpm', ['install'], dcmjsDir) && run('pnpm', ['run', 'build'], dcmjsDir);
+  } else {
+    console.log('[postinstall-dcmjs] pnpm not on PATH — no fallback build available');
+  }
+}
+
+// The bundle on disk is the single source of truth, not the exit codes above.
+if (!built || !fs.existsSync(bundle)) {
+  failLoudly('dcmjs bundle build did not produce build/dcmjs.js');
+}
+
+console.log('[postinstall-dcmjs] dcmjs bundle built: ' + path.relative(root, bundle));


### PR DESCRIPTION
## Problem

A fresh `git clone && npm install && meteor run` of main dies at compile with `Module not found: Can't resolve 'dcmjs'` — while CircleCI stays green.

Root cause:
- `dcmjs` is the `file:libraries/dcmjs` submodule; its `main`/`module`/`exports` point into `build/`, which is **gitignored** — every machine must build it.
- The old postinstall guard required **pnpm** (`pnpm install && pnpm run build`) and on any failure printed a warning and **exited 0** — install "succeeded", the failure resurfaced later as the opaque rspack error.
- CI hand-curates the path (explicit submodule init + `npx rollup -c` with lockfile-reified devDeps), so no job ever exercised what a new dev machine actually does.

## Fix

1. **`scripts/postinstall-dcmjs.js`** — inits the submodule if empty, then builds with the rollup reified from the root `package-lock.json` into `libraries/dcmjs/node_modules/.bin` (invoked by absolute path: no pnpm, no npx, no PATH assumptions — identical under `npm install` and `meteor npm install`). pnpm remains as a fallback for parser-dev machines. If no path produces the bundle, the install now **fails loudly** with an actionable banner instead of deferring the failure to compile time.
2. **CI `onboarding` job** — simulates a brand-new dev machine: fresh checkout, submodule init (the one documented pre-step), then a plain **uncached** `npm install` on an image with pnpm explicitly removed; asserts `build/dcmjs.js` / `build/dcmjs.es.js` exist and `require('dcmjs').data.DicomMessage` loads. Green CI now actually certifies the clean-clone path.
3. `dcmjs:setup` now runs the guard (recovery works without pnpm); CLAUDE.md updated.

## Verification (local, in a clean worktree of main)

- Failure path: no reified rollup + pnpm masked off PATH → banner + exit **1** ✔
- pnpm fallback: built the bundle end-to-end via pnpm ✔
- Primary path: plain `npm install` → postinstall logged `building with lockfile-reified rollup (no pnpm required)` → bundle built, `require('dcmjs')` exposes `data.DicomMessage` ✔
- Idempotency: re-run skips with "bundle present" ✔
- `package-lock.json` untouched (a local darwin rewrite was discarded, not committed)

The authoritative check is the **`onboarding` job on this PR** — if it surfaces additional fresh-install breakage, that's the job doing its job.

## Immediate unblock for anyone hitting this today

```bash
git submodule update --init libraries/dcmjs
(cd libraries/dcmjs && npx rollup -c)
# restart meteor
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
