### PR TITLE
feat(auth): preserve requested route through the sign-in flow (returnTo)

### DIFF
--- a/extensions/API.md
+++ b/extensions/API.md
@@ -73,7 +73,7 @@ log a typo warning but are still stored for forward compatibility.
 | `EulaPage` | `imports/ui/extensible/EulaPage.jsx` | `/eula` | none |
 | `WelcomePage` | `imports/ui/extensible/WelcomePage.jsx` | root `/` fallback + `/welcome-to-node-on-fhir` | none — the root SPLASH PAGE, not the welcome dialog (see § legacy `welcomeComponent`) |
 | `NotFoundPage` | `imports/ui/extensible/NotFoundPage.jsx` | router wildcard `*` (404) | none — keep `id="notFoundPage"` if tests matter to you |
-| `NoAuthorizationPage` | `imports/ui/extensible/NoAuthorizationPage.jsx` | `AuthGuard` when signed out | none — keep `id="notAuthorizedPage"` for ONC suites |
+| `NoAuthorizationPage` | `imports/ui/extensible/NoAuthorizationPage.jsx` | `AuthGuard` when signed out | `{ requestedPath? }` — the blocked route's `pathname+search` (null at `/`); keep `id="notAuthorizedPage"` for ONC suites |
 | `NoSelectedPatientPage` | `imports/ui/extensible/NoSelectedPatientPage.jsx` | `PatientGuard` when no patient selected | none |
 | `NoDataPage` | `imports/ui/extensible/NoDataPage.jsx` | `DataGuard` when `dataCount` is 0 | `{ title, subheader, buttonLabel, noDataImagePath, marginTop, redirectPath, titleVariant }` |
 | `ErrorPage` | `imports/ui/extensible/ErrorPage.jsx` | per-route `ErrorBoundary` on render crash | `{ routePath }` |
@@ -96,6 +96,20 @@ guards render:
 
 Routes opt in via `requireAuth: true` / `requirePatient: true` in
 `workflow.json` or route objects.
+
+#### Auth-flow route preservation (`returnTo`)
+
+When AuthGuard blocks a route, it passes the requested `pathname+search` to
+NoAuthorizationPage as `requestedPath`. The default page (and well-behaved
+overrides) thread it onto the sign-in / sign-up navigations as
+`?returnTo=<encoded internal path>`; LoginPage/RegisterPage navigate there
+after successful auth, falling back to `/` when absent. The value is
+sanitized to INTERNAL paths only (`sanitizeReturnPath` in
+`imports/lib/WorkflowNavigation.js` — open-redirect protection, auth-page
+loop guard); `appendReturnTo(basePath, path)` is the forwarding helper.
+Overrides registered as JSX elements cannot receive the prop (component
+references recommended); the default page self-falls-back to `useLocation()`
+when the prop is absent, so behavior degrades gracefully.
 
 ### Rules of the road
 

--- a/imports/accounts/client/pages/LoginPage.jsx
+++ b/imports/accounts/client/pages/LoginPage.jsx
@@ -2,28 +2,41 @@
 
 import React from 'react';
 import { Meteor } from 'meteor/meteor';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import { Container, Box } from '@mui/material';
 import { LoginForm } from '../components/LoginForm';
+import WorkflowNavigation from '/imports/lib/WorkflowNavigation.js';
+const { sanitizeReturnPath, appendReturnTo } = WorkflowNavigation;
 
 export function LoginPage() {
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+
+  // Route preservation: AuthGuard/NoAuthorizationPage thread the blocked
+  // route here as ?returnTo=<encoded internal path>. searchParams.get()
+  // already decoded once — sanitize the decoded value (internal paths only;
+  // invalid/absent falls back to the home route).
+  const returnTo = sanitizeReturnPath(searchParams.get('returnTo'));
 
   // Get Honeycomb theme for dark mode support
   const useAppTheme = Meteor.useTheme;
   const appTheme = useAppTheme ? useAppTheme() : { theme: 'light' };
   const isDark = appTheme.theme === 'dark';
 
-  const handleSuccess = () => {
-    // Redirect to home or intended page after successful login
-    navigate('/');
+  const handleSuccess = function() {
+    // Redirect to the originally requested page after successful login,
+    // or home when none was preserved
+    navigate(returnTo || '/');
   };
 
-  const handleSignupClick = () => {
-    navigate('/register');
+  const handleSignupClick = function() {
+    // Forward returnTo so the route survives a signin <-> signup bounce
+    navigate(appendReturnTo('/register', returnTo));
   };
 
-  const handleForgotPasswordClick = () => {
+  const handleForgotPasswordClick = function() {
+    // returnTo intentionally NOT forwarded: the reset flow round-trips
+    // through email -> /reset-password/:token, so the param is lost anyway
     navigate('/forgot-password');
   };
 

--- a/imports/accounts/client/pages/RegisterPage.jsx
+++ b/imports/accounts/client/pages/RegisterPage.jsx
@@ -2,25 +2,35 @@
 
 import React from 'react';
 import { Meteor } from 'meteor/meteor';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import { Container, Box } from '@mui/material';
 import { SignupForm } from '../components/SignupForm';
+import WorkflowNavigation from '/imports/lib/WorkflowNavigation.js';
+const { sanitizeReturnPath, appendReturnTo } = WorkflowNavigation;
 
 export function RegisterPage() {
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+
+  // Route preservation: ?returnTo=<encoded internal path> threaded from
+  // AuthGuard/NoAuthorizationPage (or forwarded from LoginPage). Sanitized
+  // decoded value; invalid/absent falls back to the home route.
+  const returnTo = sanitizeReturnPath(searchParams.get('returnTo'));
 
   // Get Honeycomb theme for dark mode support
   const useAppTheme = Meteor.useTheme;
   const appTheme = useAppTheme ? useAppTheme() : { theme: 'light' };
   const isDark = appTheme.theme === 'dark';
 
-  const handleSuccess = () => {
-    // Redirect to home after successful registration
-    navigate('/');
+  const handleSuccess = function() {
+    // Redirect to the originally requested page after successful
+    // registration, or home when none was preserved
+    navigate(returnTo || '/');
   };
 
-  const handleLoginClick = () => {
-    navigate('/login');
+  const handleLoginClick = function() {
+    // Forward returnTo so the route survives a signup <-> signin bounce
+    navigate(appendReturnTo('/login', returnTo));
   };
 
   return (

--- a/imports/lib/WorkflowNavigation.js
+++ b/imports/lib/WorkflowNavigation.js
@@ -15,6 +15,13 @@
 //              through multiple functions.
 //   previous - hop-local came-from; drives Back buttons only. Not handled
 //              here (each page reads it directly).
+//   returnTo - auth-flow: "after sign-in/sign-up completes, navigate here".
+//              Unlike next/home (bare slugs), the value is a FULL internal
+//              path with optional query string, percent-encoded
+//              (e.g. returnTo=%2Fdicom-studies%3Ftab%3Drecent). Single-hop:
+//              originated by AuthGuard/NoAuthorizationPage, forwarded only
+//              between /signin <-> /signup, consumed at login/registration
+//              success. Internal paths only (sanitizeReturnPath).
 //
 // Termination resolution order: ?next= -> ?home= -> settings default route
 // -> the page's own legacy fallback.
@@ -96,4 +103,51 @@ function forwardHome(targetPath, search) {
   return targetPath + separator + 'home=' + encodeURIComponent(homePath.slice(1));
 }
 
-module.exports = { sanitizeRouteSlug, paramPathFromSearch, resolveWorkflowExit, forwardHome };
+// Returns a cleaned INTERNAL app path ('/x' or '/x?a=b') or null. Unlike
+// sanitizeRouteSlug this accepts a query string (the whole point is
+// preserving the requested route's params through the auth flow), but stays
+// deliberately conservative everywhere else: internal absolute paths only —
+// reject scheme/protocol-relative escapes, backslashes, and hash fragments
+// (the app doesn't hash-route). '://' is rejected ANYWHERE in the value, so a
+// URL embedded in the query (?next=https://evil.com) drops the whole path and
+// the user simply lands on the default route. Auth pages themselves are
+// rejected (loop guard) — a returnTo pointing back at signin/signup is
+// treated as absent.
+function sanitizeReturnPath(rawValue) {
+  const path = (typeof rawValue === 'string' ? rawValue : '').trim();
+  if (!path) {
+    return null;
+  }
+  if (path.charAt(0) !== '/' || path.startsWith('//')) {
+    return null;
+  }
+  if (path.includes('://') || path.includes('\\') || path.includes('#')) {
+    return null;
+  }
+  if (path === '/') {
+    return null;
+  }
+  const pathname = path.split('?')[0];
+  const authPages = ['/signin', '/sign-in', '/login', '/signup', '/register'];
+  if (authPages.indexOf(pathname) !== -1) {
+    return null;
+  }
+  return path;
+}
+
+// Hop primitive for the auth flow (forwardHome's sibling): append
+// ?returnTo=<encoded internal path> onto basePath. No-op when returnPath is
+// absent/invalid, and idempotent when basePath already carries a returnTo.
+function appendReturnTo(basePath, returnPath) {
+  const cleanPath = sanitizeReturnPath(returnPath);
+  if (!cleanPath) {
+    return basePath;
+  }
+  if (/[?&]returnTo=/.test(basePath)) {
+    return basePath;
+  }
+  const separator = basePath.includes('?') ? '&' : '?';
+  return basePath + separator + 'returnTo=' + encodeURIComponent(cleanPath);
+}
+
+module.exports = { sanitizeRouteSlug, paramPathFromSearch, resolveWorkflowExit, forwardHome, sanitizeReturnPath, appendReturnTo };

--- a/imports/lib/WorkflowNavigation.test.mjs
+++ b/imports/lib/WorkflowNavigation.test.mjs
@@ -4,7 +4,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import WorkflowNavigation from './WorkflowNavigation.js';
 
-const { sanitizeRouteSlug, paramPathFromSearch, resolveWorkflowExit, forwardHome } = WorkflowNavigation;
+const { sanitizeRouteSlug, paramPathFromSearch, resolveWorkflowExit, forwardHome, sanitizeReturnPath, appendReturnTo } = WorkflowNavigation;
 
 // ---------------------------------------------------------------- sanitize
 
@@ -132,4 +132,84 @@ test('forwardHome round-trips through its own output', function() {
   const hop1Search = hop1.split('?')[1];
   const hop2 = forwardHome('/radiology/tech', '?' + hop1Search);
   assert.equal(hop2, '/radiology/tech?home=pacio-dashboard');
+});
+
+// ------------------------------------------------------ sanitizeReturnPath
+
+test('sanitizeReturnPath accepts internal paths with and without query strings', function() {
+  assert.equal(sanitizeReturnPath('/dicom-studies'), '/dicom-studies');
+  assert.equal(sanitizeReturnPath('/dicom-studies?tab=recent'), '/dicom-studies?tab=recent');
+  assert.equal(sanitizeReturnPath('/radiology/reading?a=1&b=2'), '/radiology/reading?a=1&b=2');
+  assert.equal(sanitizeReturnPath('  /x?a=1  '), '/x?a=1');
+});
+
+test('sanitizeReturnPath rejects empty and non-string values', function() {
+  assert.equal(sanitizeReturnPath(''), null);
+  assert.equal(sanitizeReturnPath('   '), null);
+  assert.equal(sanitizeReturnPath(null), null);
+  assert.equal(sanitizeReturnPath(undefined), null);
+  assert.equal(sanitizeReturnPath(42), null);
+});
+
+test('sanitizeReturnPath rejects the bare root (default already lands there)', function() {
+  assert.equal(sanitizeReturnPath('/'), null);
+});
+
+test('sanitizeReturnPath rejects open-redirect shapes', function() {
+  assert.equal(sanitizeReturnPath('https://evil.com'), null);
+  assert.equal(sanitizeReturnPath('//evil.com'), null);
+  assert.equal(sanitizeReturnPath('//evil.com/x'), null);
+  assert.equal(sanitizeReturnPath('/\\evil'), null);
+  assert.equal(sanitizeReturnPath('a\\b'), null);
+  assert.equal(sanitizeReturnPath('relative/path'), null);
+  assert.equal(sanitizeReturnPath('https%3A%2F%2Fevil.com'), null);
+  assert.equal(sanitizeReturnPath('/x?next=https://evil.com'), null);
+});
+
+test('sanitizeReturnPath rejects hash fragments (no hash routing)', function() {
+  assert.equal(sanitizeReturnPath('/x#frag'), null);
+});
+
+test('sanitizeReturnPath rejects auth pages themselves (loop guard)', function() {
+  assert.equal(sanitizeReturnPath('/signin'), null);
+  assert.equal(sanitizeReturnPath('/sign-in'), null);
+  assert.equal(sanitizeReturnPath('/login'), null);
+  assert.equal(sanitizeReturnPath('/signup'), null);
+  assert.equal(sanitizeReturnPath('/register'), null);
+  assert.equal(sanitizeReturnPath('/signin?returnTo=%2Fx'), null);
+});
+
+// --------------------------------------------------------- appendReturnTo
+
+test('appendReturnTo appends the encoded internal path', function() {
+  assert.equal(
+    appendReturnTo('/signin', '/dicom-studies?tab=recent'),
+    '/signin?returnTo=' + encodeURIComponent('/dicom-studies?tab=recent')
+  );
+});
+
+test('appendReturnTo uses & when the base already has a query', function() {
+  assert.equal(
+    appendReturnTo('/signin?foo=1', '/x'),
+    '/signin?foo=1&returnTo=' + encodeURIComponent('/x')
+  );
+});
+
+test('appendReturnTo is a no-op for absent or invalid return paths', function() {
+  assert.equal(appendReturnTo('/signin', null), '/signin');
+  assert.equal(appendReturnTo('/signin', ''), '/signin');
+  assert.equal(appendReturnTo('/signin', 'https://evil.com'), '/signin');
+  assert.equal(appendReturnTo('/signin', '/'), '/signin');
+});
+
+test('appendReturnTo is idempotent when the base already carries returnTo', function() {
+  const once = appendReturnTo('/signin', '/x?a=1');
+  assert.equal(appendReturnTo(once, '/y'), once);
+});
+
+test('appendReturnTo round-trips through URLSearchParams decode + sanitize', function() {
+  const requested = '/security/two-factor?foo=bar&baz=2';
+  const url = appendReturnTo('/signin', requested);
+  const decoded = new URLSearchParams(url.split('?')[1]).get('returnTo');
+  assert.equal(sanitizeReturnPath(decoded), requested);
 });

--- a/imports/ui/extensible/NoAuthorizationPage.jsx
+++ b/imports/ui/extensible/NoAuthorizationPage.jsx
@@ -10,7 +10,9 @@
 // Nightwatch suites select on it.
 
 import React, { useState, useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router-dom';
+import WorkflowNavigation from '/imports/lib/WorkflowNavigation.js';
+const { appendReturnTo } = WorkflowNavigation;
 import { get } from 'lodash';
 import { Meteor } from 'meteor/meteor';
 
@@ -66,7 +68,19 @@ const defaultInspirationalQuotes = [
 
 export default function NoAuthorizationPage(props) {
   const navigate = useNavigate();
+  const location = useLocation();
   const muiTheme = useMuiTheme();
+
+  // Route preservation: AuthGuard passes the blocked route as `requestedPath`
+  // (pathname+search); when rendered standalone (or by a legacy JSX-element
+  // override that can't take props) fall back to reading the live location —
+  // the guard renders in place, so they agree. Threaded onto the sign-in /
+  // sign-up navigations as ?returnTo=<encoded internal path> and consumed by
+  // Login/Register pages after successful auth.
+  const selfPath = location.pathname === '/' ? null : location.pathname + location.search;
+  const requestedPath = get(props, 'requestedPath') || selfPath;
+  const signInPath = appendReturnTo('/signin', requestedPath);
+  const signUpPath = appendReturnTo('/signup', requestedPath);
 
   // Get Honeycomb theme for dark mode support
   const useAppTheme = Meteor.useTheme;
@@ -112,7 +126,11 @@ export default function NoAuthorizationPage(props) {
   const upLg = useMediaQuery('(min-width:1920px)'); // >= 1920px
 
   const handleSignIn = function() {
-    navigate('/signin');
+    navigate(signInPath);
+  };
+
+  const handleSignUp = function() {
+    navigate(signUpPath);
   };
 
   // Safely get values from settings
@@ -268,7 +286,7 @@ export default function NoAuthorizationPage(props) {
                 fullWidth
                 variant="outlined"
                 size="medium"
-                onClick={function() { navigate('/signin') }}
+                onClick={handleSignIn}
                 sx={{ mb: 1 }}
               >
                 Sign in to another account
@@ -277,7 +295,7 @@ export default function NoAuthorizationPage(props) {
                 fullWidth
                 variant="outlined"
                 size="medium"
-                onClick={function() { navigate('/signup') }}
+                onClick={handleSignUp}
               >
                 Create a new account
               </Button>
@@ -475,7 +493,7 @@ export default function NoAuthorizationPage(props) {
                 fullWidth
                 variant="outlined"
                 size="medium"
-                onClick={function() { navigate('/signin') }}
+                onClick={handleSignIn}
                 sx={{ mb: 1 }}
               >
                 Sign in to another account
@@ -484,7 +502,7 @@ export default function NoAuthorizationPage(props) {
                 fullWidth
                 variant="outlined"
                 size="medium"
-                onClick={function() { navigate('/signup') }}
+                onClick={handleSignUp}
               >
                 Create a new account
               </Button>
@@ -694,7 +712,7 @@ export default function NoAuthorizationPage(props) {
               fullWidth
               variant="outlined"
               size="medium"
-              onClick={function() { navigate('/signin') }}
+              onClick={handleSignIn}
               sx={{ mb: 1 }}
             >
               Sign in to another account
@@ -703,7 +721,7 @@ export default function NoAuthorizationPage(props) {
               fullWidth
               variant="outlined"
               size="medium"
-              onClick={function() { navigate('/signup') }}
+              onClick={handleSignUp}
             >
               Create a new account
             </Button>

--- a/imports/ui/guards/AuthGuard.jsx
+++ b/imports/ui/guards/AuthGuard.jsx
@@ -6,11 +6,18 @@
 // components: { NoAuthorizationPage: ... }). While the login handshake is in
 // flight it renders LoadingPage (overridable via components: { LoadingPage }).
 //
+// Route preservation: the guard renders IN PLACE (the browser URL is still
+// the blocked route), so it captures pathname+search and passes it to the
+// fallback as `requestedPath`. NoAuthorizationPage threads it to
+// /signin | /signup as ?returnTo=<encoded>, and Login/Register pages navigate
+// there after successful auth (see imports/lib/WorkflowNavigation.js).
+//
 // Formerly imports/ui/components/AuthenticatedRoute.jsx; also absorbs the
 // legacy NotSignedInWrapper (imports/ui/NotSignedInWrapper.jsx) — both old
 // paths re-export this component as deprecated aliases.
 
 import React from 'react';
+import { useLocation } from 'react-router-dom';
 import { useTracker } from 'meteor/react-meteor-data';
 import { Meteor } from 'meteor/meteor';
 import { get } from 'lodash';
@@ -21,6 +28,7 @@ import LoadingPage from '../extensible/LoadingPage';
 export function AuthGuard({ children }) {
   const NoAuthComponent = useOverridableComponent('NoAuthorizationPage', NoAuthorizationPage);
   const LoadingComponent = useOverridableComponent('LoadingPage', LoadingPage);
+  const location = useLocation();
 
   const { user, loggingIn } = useTracker(() => {
     return {
@@ -28,6 +36,10 @@ export function AuthGuard({ children }) {
       loggingIn: Meteor.loggingIn()
     };
   }, []);
+
+  // The blocked route (guard renders in place, so this IS the requested URL).
+  // Root is suppressed — returning to '/' is already the default.
+  const requestedPath = location.pathname === '/' ? null : location.pathname + location.search;
 
   // Still checking authentication status
   if (loggingIn) {
@@ -41,7 +53,7 @@ export function AuthGuard({ children }) {
       console.log('[AuthGuard] NotAuthorized UI bypassed due to Meteor.settings.public.NotAuthorizedUiBypass = true');
       return children;
     }
-    return <NoAuthComponent />;
+    return <NoAuthComponent requestedPath={requestedPath} />;
   }
 
   // User is authenticated, render the protected component


### PR DESCRIPTION
## Summary

Preserves the requested route — **URL params included** — through the authentication flow. Previously: hit a `requireAuth` route while signed out → NoAuthorizationPage → `/signin` → land on `/`, original destination lost. Now the blocked route rides through the whole journey and you land where you were headed once authenticated.

> Stacked on #169 (uses `AuthGuard` / `NoAuthorizationPage` from the extension-API refactor). GitHub will retarget to `main` when #169 merges.

### How it works

```
/security/two-factor?foo=bar   (blocked — guard renders in place, URL preserved)
        │  AuthGuard captures pathname+search → requestedPath prop
        ▼
NoAuthorizationPage            (threads it onto every sign-in/sign-up nav)
        │  navigate('/signin?returnTo=%2Fsecurity%2Ftwo-factor%3Ffoo%3Dbar')
        ▼
LoginPage ⇄ RegisterPage       (returnTo forwarded across the signin↔signup cross-links)
        │  on auth success: navigate(returnTo || '/')
        ▼
/security/two-factor?foo=bar   ✓ params intact
```

- **`imports/lib/WorkflowNavigation.js`** — two new exports beside the `next`/`home` contract (whose bare-slug sanitizer rejects `?` and can't carry query params):
  - `sanitizeReturnPath()` — internal paths only: rejects absolute URLs, protocol-relative `//host`, backslashes, hash fragments, `://` anywhere in the value (kills URLs embedded in the query), and the auth pages themselves (loop guard).
  - `appendReturnTo()` — `forwardHome`'s sibling: encoded, idempotent, no-op on invalid input.
- **`AuthGuard`** passes `requestedPath` (null at `/`) to whatever NoAuthorizationPage override wins the components-map slot.
- **`NoAuthorizationPage`** — ten scattered inline `navigate('/signin'|'/signup')` handlers across the three breakpoint layouts collapsed into shared `handleSignIn`/`handleSignUp`; self-falls-back to `useLocation()` when the prop is absent (standalone renders, legacy JSX-element overrides).
- **`LoginPage.handleSuccess`** is the single consumption point — all four LoginForm success paths (normal login, 2FA, inline registration, dev auto-login) inherit the redirect. `RegisterPage` mirrors it for sign-up.
- **Not forwarded** to `/forgot-password` (the reset flow round-trips through email, so the param is lost anyway — commented in code).
- **Docs**: `extensions/API.md` — NoAuthorizationPage props contract (`{ requestedPath? }`) + "Auth-flow route preservation" note.

### Default behavior unchanged

No `returnTo` → sign-in lands on `/` exactly as today. Invalid/malicious `returnTo` → treated as absent.

## Verification

- **Unit**: `npm run test:workflow-navigation` — 31/31 (14 new: accepts internal paths w/ query strings; rejects open-redirect shapes incl. encoded schemes and embedded `://`; loop guard; encoding round-trip through `URLSearchParams`; idempotence).
- **Live end-to-end** (Meteor + Playwright, DEV_AUTO_LOGIN): signed out at `/security/two-factor?foo=bar` → guard renders with URL intact → "Create a new account" → `/signup?returnTo=%2Fsecurity%2Ftwo-factor%3Ffoo%3Dbar` → its Sign In link → `/login?returnTo=...` (survives the bounce) → auth completes → **lands on `/security/two-factor?foo=bar`**. Identical result via the account-card path.
- **Security probes**: `?returnTo=https%3A%2F%2Fevil.com` and `?returnTo=%2F%2Fevil.com` both land on `/`, never leave the origin.
- **Regression**: direct `/signin` → lands on `/`; `#notAuthorizedPage` ONC selector untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
