### PR TITLE
Security remediation campaign (pre-certification audit) — staging

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -746,6 +746,9 @@ jobs:
           name: Endpoint smoke tests
           command: ./scripts/endpoint-smoke-test.sh
       - run:
+          name: OAuth client_assertion signature verification (CR-1)
+          command: npm run test:oauth-assertion
+      - run:
           name: RPC method tests (conformance sweep FULL + method suites)
           command: RPC_SWEEP=all npm run test:rpc-methods
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -752,6 +752,9 @@ jobs:
           name: Patient-compartment authorization (CR-3)
           command: npm run test:patient-compartment
       - run:
+          name: Write-sanitization / meta.security governance (CR-4)
+          command: npm run test:write-sanitization
+      - run:
           name: RPC method tests (conformance sweep FULL + method suites)
           command: RPC_SWEEP=all npm run test:rpc-methods
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -758,6 +758,9 @@ jobs:
           name: Secure production config assertion (CR-2)
           command: npm run test:secure-config
       - run:
+          name: Outbound URL SSRF guard (CR-10)
+          command: npm run test:outbound-url-guard
+      - run:
           name: RPC method tests (conformance sweep FULL + method suites)
           command: RPC_SWEEP=all npm run test:rpc-methods
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -749,6 +749,9 @@ jobs:
           name: OAuth client_assertion signature verification (CR-1)
           command: npm run test:oauth-assertion
       - run:
+          name: Patient-compartment authorization (CR-3)
+          command: npm run test:patient-compartment
+      - run:
           name: RPC method tests (conformance sweep FULL + method suites)
           command: RPC_SWEEP=all npm run test:rpc-methods
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -755,6 +755,9 @@ jobs:
           name: Write-sanitization / meta.security governance (CR-4)
           command: npm run test:write-sanitization
       - run:
+          name: Secure production config assertion (CR-2)
+          command: npm run test:secure-config
+      - run:
           name: RPC method tests (conformance sweep FULL + method suites)
           command: RPC_SWEEP=all npm run test:rpc-methods
 

--- a/.claude/rules/conventions/file-naming.md
+++ b/.claude/rules/conventions/file-naming.md
@@ -1,0 +1,38 @@
+# File Naming Conventions
+
+## The rule (make the implicit explicit)
+
+This repo has a real, consistent file-naming rule that was never written down —
+which meant every new file re-litigated it. It is:
+
+| Style | Use when the module's primary export is… | Examples |
+|-------|------------------------------------------|----------|
+| **PascalCase** | a class, singleton, or namespace object (a "thing") | `FhirAuth.js`, `Logger.js`, `CaslAccessControl.js`, `BaseModel.js`, `FhirUtilities.js`, `GridFSManager.js` |
+| **camelCase** | a bare function or small set of functions (an "action") | `warnOnce.js`, `rpcClient.js`, `loggerRedact.js`, `sexForClinicalUse.js`, `globalCollections.js`, `verifyClientAssertion.js` |
+| **PascalCase** | a React component | `PatientSidebar.jsx`, `ObservationsPage.jsx` |
+
+**Test the export, not the topic.** `verifyClientAssertion.js` exports the
+function `verifyClientAssertionSignature()` → camelCase. Renaming it to
+`VerifyClientAssertion.js` would *mislead*, because PascalCase in this repo
+signals "this is a class/namespace you instantiate or reach into," which a
+pure function is not.
+
+## Why not "PascalCase everything" or "kebab-case everything"
+
+Both are defensible in the abstract, but this repo already made its choice at
+scale (~85% PascalCase modules / a principled camelCase minority for
+function-utilities). The camelCase-vs-PascalCase split *carries information*
+(thing vs action) that a uniform scheme would erase. kebab-case has almost no
+precedent in `server/` (only `verify-methods.js`) and would be the largest
+churn for the least signal. Changing the scheme is a repo-wide decision, not a
+per-file one — don't half-migrate.
+
+## Scope note
+
+This documents the go-forward rule for NEW files. Existing files that don't fit
+are migrated opportunistically when touched, never in a dedicated churn PR.
+
+## Related
+
+- Test files follow their own placement rule: `.claude/rules/testing/test-organization.md`
+- File-header convention (path/name as first commented line): root `CLAUDE.md` § Coding Style

--- a/.claude/rules/testing/test-organization.md
+++ b/.claude/rules/testing/test-organization.md
@@ -1,0 +1,63 @@
+# Test File Organization
+
+## The tier model — placement is determined by what a test NEEDS to run
+
+| Tier | What it tests | Needs | Location | Runner |
+|------|---------------|-------|----------|--------|
+| **Unit** | one pure module in isolation | nothing (no server, no Mongo, no browser) | **`tests/unit/` mirroring source** | `node --test` |
+| **Integration** | a booted server over its real transport | running app + ephemeral Mongo | `tests/rpc/` (methods/, lib/, conformance) | `node --test tests/rpc/` |
+| **E2E** | full browser + UI flows | running app + Chrome | `tests/nightwatch/` | Nightwatch |
+| **Certification** | ONC (g)(10) behavioral evidence | per-suite | `certification/tdd/` | node --test |
+
+## Go-forward rule for unit tests: `tests/unit/` mirrors the source tree
+
+A fast, pure `node --test` unit test lives under `tests/unit/` at the path
+mirroring its subject:
+
+```
+server/lib/verifyClientAssertion.js
+  → tests/unit/server/lib/verifyClientAssertion.test.mjs
+
+imports/lib/Logger.js
+  → tests/unit/imports/lib/Logger.test.mjs
+```
+
+The test imports its subject by relative path across the tree
+(`../../../../server/lib/verifyClientAssertion.js`). Bare-specifier deps
+(`jsonwebtoken`, etc.) resolve from the root `node_modules` as usual.
+
+**Why separate-tree over colocated** (the decision, 2026-07-24): keeping source
+directories free of interleaved `*.test.mjs` files as the fast-test tier grows,
+at the cost of the test no longer sitting beside its subject. A deliberate
+trade — chosen so `ls server/lib/` stays readable.
+
+## CI wiring
+
+Each unit test gets a `test:<name>` script in `package.json` pointing at its
+`tests/unit/...` path, run in a CI job that has `node_modules`:
+
+- **Dependency-free** unit tests (no npm imports, only node builtins) → the
+  `lib-unit-tests` job (bare checkout, no `npm install`).
+- **Tests importing npm packages** (e.g. `jsonwebtoken`) → a job that has run
+  `npm install`, e.g. `rpc-method-tests`. `verifyClientAssertion.test.mjs`
+  imports `jsonwebtoken`, so it runs there via `npm run test:oauth-assertion`.
+
+⚠️ Do not add an npm-importing unit test to `lib-unit-tests` — it fails with
+"Cannot find module" on the bare checkout (`lib-test-tier` constraint).
+
+## Migration status (honest accounting)
+
+`tests/unit/` is the go-forward home. ~63 existing unit tests are still
+**colocated** next to their source (`imports/lib/Logger.test.mjs`,
+`server/lib/CaslAccessControl.parity.test.mjs`, …) from the prior convention.
+They are migrated into `tests/unit/` opportunistically (updating their
+`test:*` script path when moved), NOT in a big-bang PR mixed into feature or
+security work. Until migrated, both layouts coexist — the `test:*` scripts in
+`package.json` are the source of truth for where each test actually lives.
+
+## Related
+
+- Integration-test harness: `docs/RPC-TESTING.md`, `tests/rpc/lib/rpcClient.mjs`
+- E2E patterns: `.claude/rules/testing/crud-patterns.md`, `stability.md`
+- File naming: `.claude/rules/conventions/file-naming.md`
+- lib-test-tier constraint (bare checkout, no npm install): memory `lib-test-tier-constraints`

--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,11 @@ settings.*.json
 # These MUST contain no real secrets — secret values are empty, filled via env or a
 # local (gitignored) settings.*.json copy at runtime.
 !settings.*.template.json
+# accounts.multiuser.settings.json doesn't match the settings.*.json basename
+# glob — it was force-tracked with a live admin password until CR-6/HI-9
+# (2026-07-24). Its scrubbed .template.json copy doesn't match this pattern
+# and tracks normally.
+accounts.*.settings.json
 
 screenshots/*
 screenshots/*/*

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -10,6 +10,32 @@
 # Extend the default ruleset; entries below only ADD allowlist carve-outs.
 useDefault = true
 
+# Custom rules for KNOWN-LEAKED low-entropy literals (CR-5 / HI-9, remediated
+# 2026-07-24). The default entropy-based rules can't catch these; these rules
+# make their reappearance in any tracked file a CI failure. The two July-1
+# audit-record docs quote the literals as findings-of-record and are
+# per-rule allowlisted; nothing else may contain them.
+
+[[rules]]
+id = "honeycomb-known-leaked-pacio-token"
+description = "Known-leaked pacio account-server token literal (CR-5) — rotate, never recommit"
+regex = '''pacio-secret-token-change-in-production'''
+[rules.allowlist]
+paths = [
+  '''docs/security/2026-07-01-honeycomb-security-audit\.md''',
+  '''docs/superpowers/plans/2026-07-01-security-remediation-core\.md''',
+]
+
+[[rules]]
+id = "honeycomb-known-leaked-admin-password"
+description = "Known-leaked admin password literal (HI-9) — rotate, never recommit"
+regex = '''changeme123'''
+[rules.allowlist]
+paths = [
+  '''docs/security/2026-07-01-honeycomb-security-audit\.md''',
+  '''docs/superpowers/plans/2026-07-01-security-remediation-core\.md''',
+]
+
 [allowlist]
 description = "Triaged false positives (2026-07-23)"
 

--- a/deprecated/pacio-core/configs/settings.medical-home.json
+++ b/deprecated/pacio-core/configs/settings.medical-home.json
@@ -370,7 +370,7 @@
         "requireSignature": false
       }
     },
-    "accountServerTokenSecret": "pacio-secret-token-change-in-production",
+    "accountServerTokenSecret": "",
     "google": {
       "mapsApiKey": "YOUR_GOOGLE_MAPS_API_KEY_HERE"
     }

--- a/deprecated/pacio-core/configs/settings.pacio-core.2026.json
+++ b/deprecated/pacio-core/configs/settings.pacio-core.2026.json
@@ -380,7 +380,7 @@
       "custodianOrganization": "Organization/PFEIG-Org-01",
       "auditAdiAccess": true
     },
-    "accountServerTokenSecret": "pacio-secret-token-change-in-production",
+    "accountServerTokenSecret": "",
     "google": {
       "mapsApiKey": "YOUR_GOOGLE_MAPS_API_KEY_HERE"
     }

--- a/deprecated/pacio-core/configs/settings.pacio-core.bluecyan.json
+++ b/deprecated/pacio-core/configs/settings.pacio-core.bluecyan.json
@@ -333,7 +333,7 @@
         "requireSignature": false
       }
     },
-    "accountServerTokenSecret": "pacio-secret-token-change-in-production",
+    "accountServerTokenSecret": "",
     "google": {
       "mapsApiKey": "YOUR_GOOGLE_MAPS_API_KEY_HERE"
     }

--- a/deprecated/pacio-core/configs/settings.pacio-core.json
+++ b/deprecated/pacio-core/configs/settings.pacio-core.json
@@ -378,7 +378,7 @@
         "requireSignature": false
       }
     },
-    "accountServerTokenSecret": "pacio-secret-token-change-in-production",
+    "accountServerTokenSecret": "",
     "google": {
       "mapsApiKey": "YOUR_GOOGLE_MAPS_API_KEY_HERE"
     }

--- a/docs/july-next-five-moves.md
+++ b/docs/july-next-five-moves.md
@@ -1,0 +1,102 @@
+# July Next Five Moves
+
+> Action checklist from the 2026-07-23 architectural assessment (post
+> feat/json-rpc merge). Ranked by risk-reduction per hour. Companion context:
+> `fable/OPUS_NOF_ARCHITECTURE_ASSESSMENT.md` (2026-07-01 baseline),
+> `fable/FABLE-TECH-DEBT-PAYDOWN.md` (June paydown ledger).
+>
+> **Status 2026-07-24**: moves 1–4 are DONE (verified against main at
+> `2815170a`). The codebase has crossed from "convention-enforced" to
+> "construction-enforced" on the high-risk surfaces: the endpoint layer is
+> CI-gated, the auth holes are closed, and the safety nets fail the build.
+> What remains is move 5 (the client-layer structural refactor — now the
+> ranked #1) and the move-4 residuals.
+
+---
+
+## 1. ~~Gate the endpoint layer in CI~~ ✅ DONE 2026-07-23
+
+- [x] Curl-based smoke battery against a booted server:
+      `scripts/endpoint-smoke-test.sh` covers `/api/rpc` (rpc.discover +
+      authed method), `/baseR4/metadata`, and the OAuth bad-credential
+      rejection path (commit `23790f01`)
+- [x] Wired into `.circleci/config.yml` — runs in the parallel-tests workflow
+      and in the dedicated RPC job
+- [x] Bonus: full OpenRPC-driven conformance sweep + method suites in
+      `tests/rpc/` with a ratchet baseline (`7c1fc913`); all 22 sweep
+      internal errors burned down to an empty baseline (`c31496f8`)
+- Issue #171 (meteortesting:mocha under rspack) was routed around, not fixed —
+  the mocha suites in `tests/mocha/` still run 0 tests, but the endpoint layer
+  no longer depends on them for coverage.
+
+## 2. ~~Close the two auth-surface holes~~ ✅ DONE 2026-07-23
+
+- [x] `test.*` methods gated behind
+      `Meteor.isDevelopment || process.env.ENABLE_TEST_METHODS === 'true'`
+      (`server/main.js:665`, commit `b558ad58`) — production builds log that
+      the methods were NOT registered
+- [x] The fossil `jwt.decode()` block on the SMART session-token path was
+      **deleted** rather than upgraded (`server/lib/FhirAuth.js:339` comment
+      documents why — no signing key existed for that path; commit `43996554`)
+
+## 3. ~~Wire the existing safety nets into CI~~ ✅ DONE 2026-07-23
+
+All landed in `bf6a12c4` ("plug in the safety nets"):
+
+- [x] `scripts/audit-global-collections.js` → `npm run audit:collections` in CI
+- [x] `imports/lib/WorkflowRegistry.test.mjs` → `npm run test:workflow-registry`
+      CI step
+- [x] Workflow parser unit test written: `workflows/rspack.workflowParser.test.mjs`
+- [x] gitleaks secret-scanning job (dedicated container, `.gitleaks.toml`
+      allowlist) on every pipeline; committed UMLS key removed and triaged
+      (`e2e29510`)
+
+## 4. ~~Land feat/json-rpc to main~~ ✅ DONE 2026-07-23
+
+Merged (378 commits). Open residuals that ride on it:
+
+- [ ] Sweep remaining raw `Meteor.methods` registrations toward ServerMethods
+      (~40 files across `server/`, `imports/`, and package server entries by
+      current grep; the original "16" counted `server/` + `imports/api/` only)
+- [ ] RPC pipeline residuals: in-memory per-process rate limiting (no-op on
+      multi-instance Galaxy, buckets never evicted → slow leak under IP churn);
+      `invoke()` bypasses rate limiting and defaults to null identity
+      (role-gated methods can't be orchestrated server-to-server); schema
+      validation is opt-in per method
+
+## 5. ResourceTable / GenericFhirDetail structural work — **now the #1 move**
+
+The highest-leverage remaining refactor: ~269 copy-paste files
+(70 Page / 69 Table / 68 Detail / 62 Preview) in `imports/ui-fhir/`.
+Plan already written: `docs/superpowers/plans/2026-07-01-dynamicfhir-enhancement.md`.
+The RPC campaign proved the loop-based migration playbook at exactly this scale.
+
+- [ ] Task 1: `GenericFhirDetail` fallback component
+- [ ] Task 2: generated component manifest
+      (`scripts/generate-fhir-component-manifest.js`)
+- [ ] Task 3: `imports/ui-fields/` primitives (1 of 7 built — ReferenceRange)
+- [ ] Task 4: `ResourceTable` shell + `Column` + `columnPreferences`
+- [ ] While touching files: fix the 26 `Session.get`-in-dep-array offenders
+      (list in the 2026-07-04 status note; e.g. `conditions/ConditionsPage.jsx:134`,
+      `encounters/EncountersPage.jsx:123`, `procedures/ProceduresPage.jsx:136`)
+
+---
+
+## Parking lot (real, but below the fold)
+
+- Split `server/FhirEndpoints.js` (3,081 lines) / `server/OAuthEndpoints.js`
+  (2,433) — includes de-duplicating the shadowed route registrations
+  (two `_history/:versionId` GETs, two PATCH, two DELETE). The smoke battery
+  now guards the behavior, but the structural split remains.
+- Retire `deprecated/` (56 dead Atmosphere packages, 6,519 tracked files, 1.6 GB)
+- Delete `imports/components/*\ copy.jsx` (3 stray files)
+- Fix stale `--extra-packages 'clinical:pacio-core, clinical:us-core'` in npm
+  scripts (`medical-home`, `base-ehr`, `medical-home-autologin`)
+- E2E: convert `pause()`-driven timing to explicit waits (patients suite:
+  38 pauses vs 23 waits)
+- Package data bloat: quality-measures 163 MB, synthea 112 MB, pacio-core
+  109 MB inside the repo
+- Gradual typing (`checkJs`/JSDoc; TS types from R4B JSON Schemas) — still
+  unstarted from the 2026-07-01 recommendations
+- Fix issue #171 properly (meteortesting:mocha runs 0 tests under rspack) or
+  retire the `tests/mocha/` suites in favor of the `tests/rpc/` harness

--- a/docs/july-tech-debt-analysis.md
+++ b/docs/july-tech-debt-analysis.md
@@ -1,0 +1,221 @@
+# July Tech-Debt Analysis
+
+> Snapshot of remaining technical debt from the 2026-07-23 architectural
+> assessment, taken immediately after the feat/json-rpc merge to main.
+> This is the *analysis* record — what the debt is, where it lives, and why it
+> matters. The ranked action checklist lives in
+> [july-next-five-moves.md](july-next-five-moves.md). Baselines:
+> `fable/OPUS_NOF_ARCHITECTURE_ASSESSMENT.md` (2026-07-01) and
+> `fable/FABLE-TECH-DEBT-PAYDOWN.md` (June ledger, largely completed).
+>
+> Context: the June–July refactorings genuinely landed — Atmosphere migration
+> complete, ServerMethods pipeline shipped and hardened (167 files), structured
+> logging + PHI redaction shipped, build reproducibility CI-gated. What follows
+> is what those campaigns did *not* reach.
+>
+> **Update 2026-07-24**: checklist moves 1–3 have since landed (endpoint smoke
+> battery + RPC conformance sweep in CI, `test.*` methods gated, fossil
+> `jwt.decode` path deleted, contract audit / registry tests / parser tests /
+> gitleaks all failing the build now). §4's "endpoint layer runs 0 automated
+> tests" and §5's "built but unplugged" are therefore RESOLVED as written;
+> §1 (client layer), §2 (server monoliths), §3 (RPC residuals), and §6–7
+> remain accurate. This snapshot is kept as the analysis record — current
+> status lives in [july-next-five-moves.md](july-next-five-moves.md).
+
+---
+
+## 1. Client/component layer — the un-refactored half
+
+The July 1 component review's cheap wins all landed (dead router deleted,
+ErrorBoundary at route seams, CustomThemeProvider extracted from App.jsx, the
+ObservationsPage exemplar). The structural work did not.
+
+### 1a. Copy-paste resource UIs (C-5) — untouched, the big one
+
+**70 Page / 69 Table / 68 Detail / 62 Preview files (~269 total)** in
+`imports/ui-fhir/`, near-identical triplets per FHIR resource. The DynamicFhir
+dispatch registries exist (`imports/lib/DynamicFhirDetail.js`,
+`DynamicFhirViews.js`, 62 registered detail + preview components each), but the
+`docs/superpowers/plans/2026-07-01-dynamicfhir-enhancement.md` plan is unbuilt:
+
+| Planned piece | Status |
+|---|---|
+| Task 1 — `GenericFhirDetail` fallback | not built |
+| Task 2 — generated component manifest | not built (registries hand-maintained) |
+| Task 3 — `imports/ui-fields/` primitives | 1 of 7 built (`ReferenceRange.jsx`) |
+| Task 4 — `ResourceTable` shell + `Column` + `columnPreferences` | not built |
+
+**Why it matters**: one table-behavior fix = 69 forks. This is the highest-
+leverage remaining refactor, and the RPC call-site campaign proved the
+loop-based playbook at exactly this scale (498 sites).
+
+### 1b. `Session.get` in useTracker dep arrays — 26 live correctness bugs
+
+The exact 26-file list from the 2026-07-04 status note remains unremediated
+(e.g. `imports/ui-fhir/conditions/ConditionsPage.jsx:134`,
+`encounters/EncountersPage.jsx:123`, `procedures/ProceduresPage.jsx:136`,
+`allergyIntolerances/AllergyIntolerancesPage.jsx:192`). This is a stale-
+subscription-on-patient-switch bug class, not a style issue. ObservationsPage
+is the fixed exemplar to copy.
+
+### 1c. God components — persist, one grew
+
+- `imports/ui/GettingStartedPage.jsx` — **6,113 lines** (grew from 6,107)
+- `imports/ui-vault-server/ServerConfigurationPage.jsx` — 2,427 (grew from 2,196)
+- `imports/ui/App.jsx` — ~1,964 (the only one that shrank, via
+  CustomThemeProvider extraction)
+- `imports/patient/PatientSidebar.jsx` — 1,743; `imports/patient/AutoDashboard.jsx` — 1,695
+
+### 1d. Session-as-store, code splitting, memoization — flat
+
+- ~2,389 `Session.get/set` calls across `.jsx` (essentially unchanged);
+  `imports/lib/SessionKeys.js` imported in only 5 files. Contract is advisory —
+  no lint rule forbids raw string keys.
+- `React.lazy`: 4 call sites in a ~194K-LOC JSX tree; every FHIR page eagerly
+  imported. No route-level splitting.
+- Memoization: 19 `useMemo` / 26 `useCallback` / 2 `React.memo` across
+  `imports/` — negligible.
+
+---
+
+## 2. Server monoliths
+
+`server/FhirEndpoints.js` (**3,081 lines**) and `server/OAuthEndpoints.js`
+(**2,433 lines**) remain single files on raw `WebApp.handlers`:
+
+- Auth preamble (`parseUserAuthorization` → `isAuthorized` →
+  `isResourceScopeAuthorized`) copy-pasted inline across ~10 handlers rather
+  than factored into middleware.
+- **Duplicate route registrations** — two `_history/:versionId` GETs
+  (FhirEndpoints.js:537, :580), two PATCH (:2076, :2177), two DELETE (:2188,
+  :2232). Shadowed handlers: ambiguous which one actually serves a request.
+- Error handling ad-hoc per handler (manual OperationOutcome construction),
+  not centralized.
+
+The ServerMethods pipeline is the proven recipe for splitting these; they are
+the obvious next patients.
+
+---
+
+## 3. RPC pipeline residuals (small but real)
+
+The pipeline itself is the strongest part of the server (~950 LOC total,
+correct auth→authorize→validate→rate-limit→audit→dispatch ordering, alias
+hardening landed). Remaining gaps:
+
+- **Rate limiting is in-memory and per-process** (`imports/lib/ServerMethods.js`
+  rateBuckets) — a no-op across multi-instance Galaxy deploys, and buckets are
+  never evicted → slow memory leak under IP churn.
+- **Schema validation is opt-in** — AJV fires only when a method declares
+  `schema`/`schemaObject`; unschema'd methods receive unvalidated params. No
+  `check()` anywhere in the RPC path.
+- **`invoke()` (server→server) bypasses rate limiting and defaults to null
+  identity** — role-gated methods silently can't be orchestrated in-process
+  without explicit context.
+- **`rpc.discover` is public by design** — 440 methods + schemas enumerable
+  anonymously. Defensible, but an information-disclosure surface to revisit.
+- 16 files still register via raw `Meteor.methods` outside the pipeline —
+  including the unauthenticated `test.*` methods in `server/main.js:659-708`
+  (tracked as move #2 in the checklist).
+
+---
+
+## 4. Testing posture — inverted by strategy, not by neglect
+
+> Framing corrected 2026-07-24 (originally "the shape is the debt" — wrong).
+
+The **61 Nightwatch E2E files** (48 CRUD resource suites) on a thin **~34-file**
+`node --test` unit base is a deliberate rewrite-era posture, and it worked:
+the behavioral E2E bank carried the codebase intact through three architectural
+rewrites (Meteor v2→v3 async, Atmosphere→NPM workflows, DDP→JSON-RPC) that
+would have obsoleted any implementation-coupled unit-test base. The Inferno
+(g)(10) suite is the second independent anchor — a third-party integration
+harness testing the FHIR/SMART surface against the spec. Two points on the
+wall at all times; both attached to behavior contracts that survive interior
+rewrites. (The one test-breakage class during the RPC migration — the
+`callAsync` monkeypatch pattern — was tests coupling to transport internals,
+i.e. the exception proving the behavioral rule.)
+
+The correct sequencing is also already underway: fast deterministic tests are
+being backfilled exactly where the architecture has **stabilized** — the
+OpenRPC conformance sweep + method suites (`tests/rpc/`), the workflow-parser
+test, the `test:lib` tier. Writing those before the surfaces settled would
+have been waste.
+
+The residual debt lives *inside* the E2E layer, orthogonal to its size:
+
+- **`pause()`-driven E2E timing**: patients suite has 38 `pause()` vs 23
+  explicit waits; observations 27 vs 18. The dominant flake source and
+  wall-clock cost — and the CI feedback loop is as slow as its slowest anchor.
+- **Keep the bank behavioral**: tests that reach into transport/implementation
+  (the monkeypatch class) forfeit the rewrite-survival property; the latent
+  `substances` instance is still uncorrected (not in CI).
+- ~~Endpoint layer runs 0 automated tests~~ — RESOLVED (smoke battery +
+  conformance sweep in CI; see header note). `tests/mocha/` still runs 0 tests
+  under rspack (issue #171) and should be fixed or retired.
+- Certification artifacts (`certification/`) are primarily a manual evidence
+  binder (63 Gherkin features, PDFs, Inferno reports); executable cert tests
+  live in `npmPackages/*/tests/nightwatch/` and are partial.
+- As further surfaces stabilize post-refactor (next: the ResourceTable /
+  GenericFhirDetail shell), backfill fast tests there in the same pattern.
+
+---
+
+## 5. Enforcement gaps — built but unplugged
+
+The recurring theme (same as the 2026-07-01 review's organizing insight —
+consistency by convention, not construction):
+
+- `scripts/audit-global-collections.js` exits 1 on contract drift — **not in CI**.
+- `imports/lib/WorkflowRegistry.test.mjs` exists — **not in CI**.
+- `workflows/rspack.workflowParser.js` (674 load-bearing lines, the spine of
+  the plugin system) — **zero tests**; also `generate()` runs twice per build
+  (config top-level + beforeCompile hook).
+- **No secret-scanning gate** (gitleaks/trufflehog) despite the July 1 audit
+  finding force-committed secrets. CodeQL covers SAST only.
+- Gradual typing (`checkJs`/JSDoc, TS types generated from the R4B JSON
+  Schemas) — unstarted.
+
+---
+
+## 6. Repo and package hygiene
+
+- `deprecated/` — 56 dead Atmosphere packages, **6,519 tracked files, 1.6 GB**
+  of repo weight.
+- Three stray `* copy.jsx` files in `imports/components/`
+  (SearchCodeSystemDialog, SearchResourceTypesDialog, SearchValueSetsDialog).
+- Stale npm scripts: `medical-home`, `base-ehr`, `medical-home-autologin` still
+  pass `--extra-packages 'clinical:pacio-core, clinical:us-core'` — Atmosphere
+  references to now-migrated packages.
+- Package data bloat inside the repo: quality-measures **163 MB**, synthea
+  **112 MB**, pacio-core **109 MB**, immunization-registry **87 MB** (bundled
+  terminology/sample data).
+- Dual-mechanism residue: WorkflowRegistry singleton fields duplicated in the
+  components map; serverEntry declarable in both manifest and package
+  workflow.json (precedence resolves it, but two sources of truth);
+  provider-directory registers routes dynamically in client.js while the
+  manifest idiom is declarative; `example-workflow` referenced by docs/skills
+  as the template but absent from `npmPackages/`.
+- `libraries/dcmjs` submodule points at a personal fork
+  (`awatson1978/dcmjs#development`) — bus-factor/supply-chain note.
+
+---
+
+## 7. Partial ships from the July 1 spec wave
+
+| Spec | Landed | Remaining |
+|---|---|---|
+| ServerMethods / JSON-RPC | pipeline + 498 call sites + hardening | residuals in §3 |
+| Structured logging + PHI redaction | Logger facade, sinks, PHI-safe passes | `[Module]` adoption still uneven in older files |
+| HIPAA audit trail | AuditEvent writes on the non-patient FHIR read path (fire-and-forget) | not systematic across all reads; EventBus tamper-chain design unbuilt |
+| SimpleSchema → JSON Schema | `createFhirCollection`, OAuthClients enforced | bulk of collections unmigrated; validation not attached to most writes |
+| Security remediation (core + MCP) | CORS harmonization, PHI-safe logging, CodeQL ReDoS fixes, dual-acceptance RPC auth | `test.*` methods, `jwt.decode` path, secret-scanning gate, fail-closed config assertions |
+
+---
+
+## Reading this in six months
+
+If the checklist's moves 1–3 are done and this document's §1a (ResourceTable /
+GenericFhirDetail) is underway, the codebase will have crossed from
+"convention-enforced" to "construction-enforced" on every high-risk surface.
+The rest of this file is normal engineering.

--- a/docs/security/2026-07-24-audit-status-diff.md
+++ b/docs/security/2026-07-24-audit-status-diff.md
@@ -1,0 +1,96 @@
+# Security Audit Status Diff — 2026-07-24
+
+> Finding-by-finding re-verification of
+> [2026-07-01-honeycomb-security-audit.md](2026-07-01-honeycomb-security-audit.md)
+> against main at `2815170a`, in preparation for the remediation campaign.
+> Every status below was verified by direct grep/read this session. The
+> original audit is preserved unmodified as the analysis record.
+
+## What changed structurally since 2026-07-01 (affects the remediation plan)
+
+1. **The ServerMethods pipeline landed** (the audit's "synergy note"
+   architecture is no longer planned — it exists). `server/Methods.js`,
+   `SyntheaMethods.js`, `ProxyRelay.js`, `extensions/merkalis/server/methods.js`,
+   and `extensions/ipfs-swarm/server/methods.js` have already been migrated
+   onto it. Method-auth findings are now remediated by
+   `ServerMethods.define(..., {requireAuth: true})`, not hand-rolled
+   `this.userId` checks.
+2. **The reproduction harness changed.** `tests/mocha/` still runs **0 tests**
+   under rspack (issue #171) — do NOT write reproduction tests there. The
+   proven, CI-wired paths are `tests/rpc/` (`node --test` conformance/method
+   suites) and `scripts/endpoint-smoke-test.sh` (curl battery against a booted
+   server, runs in every CI test group).
+3. **A gitleaks CI gate exists** (`.gitleaks.toml`, triaged 2026-07-23) — but
+   it does NOT cover `extensions/*` (gitignored nested repos, absent from the
+   CI checkout) and does not flag the low-entropy committed secrets
+   (`pacio-secret-token-change-in-production`, `changeme123`). CR-5/6/HI-9/10
+   are therefore still fully open despite a green secret-scan job.
+4. **Structured logging + PHI redaction shipped** (the audit's deferred
+   dependency); the July browser-log audit PII-dump tier is fixed.
+5. **`server/core-startup.js` no longer exists** — security-header middleware
+   moved; all `core-startup.js` line refs in the audit are dead. Re-locate
+   before fixing ME-6/CR-2 assertion work.
+6. **File/line drift throughout** — updated anchors are in the table below.
+7. **The care-commons Galaxy config moved**:
+   `npmPackages/care-commons.meteorapp.com/settings/…` (audit) →
+   `extensions/care-commons-sandbox/settings/settings.pacio-core.2026.galaxy.json`
+   (nested repo). Secret-rotation checklist must point at the new path, and
+   fixes there commit to the *nested* repo.
+
+## Finding status table
+
+| ID | Status 2026-07-24 | Evidence / updated anchors |
+|----|-------------------|----------------------------|
+| CR-1 | **OPEN** | `OAuthEndpoints.js:918` TODO still present; `jwt.decode(client_assertion)` at `:884` |
+| CR-2 | **OPEN** | 12 settings files still ship `disableOauth: true`; no startup assertion exists anywhere |
+| CR-3 | **OPEN** | `authQuery` built only in search GET (`:1279`) and POST `_search` (`:2503`). Instance GET `:598`, PUT `:1876`, PATCH `:2076`+`:2177`, DELETE `:2188`+`:2232` unfiltered. ⚠️ PATCH and DELETE are **duplicate shadowed registrations** — fix both copies or de-duplicate first |
+| CR-4 | **OPEN** | `newRecord = req.body` `:1748`; `cloneDeep(req.body)` `:1897`, `:2096`; `meta.security.display` gating `:1280`, `:1602` |
+| CR-5 | **OPEN** | Secret still at `settings/settings.pacio.json:367` + 4 `pacio-core/configs/*.json`. Progress: `*.template.json` files with empty values now exist alongside. Galaxy config moved (see §7 above) |
+| CR-6 | **OPEN** | `settings.pacio.json`, `accounts.multiuser.settings.json` still force-tracked (`git ls-files` confirms) |
+| CR-7 | **LARGELY REMEDIATED** | `methods.js` migrated to ServerMethods, 22× `requireAuth: true`. **Residual**: `server/import/methods.warehouse.js:69` still accepts caller-controlled `options.relayEndpoint` (SSRF/exfil) — verify its auth + add allowlist |
+| CR-8 | **LARGELY REMEDIATED** | 34× `requireAuth: true` in `ipfs-swarm/server/methods.js`. **Residual**: verify the `connectToPeer`/multiaddr SSRF path got host validation, not just auth |
+| CR-9 | **RESOLVED** | `server/Methods.js` is now a ServerMethods stub (`certificates.fetch`) that throws `not operational`; no live URL fetch remains outside the registration flow (= CR-10's scope) |
+| CR-10 | **OPEN** | Recursive AIA/CRL fetch at `OAuthEndpoints.js:258,:273,:494,:500`; no host allowlist |
+| HI-1 | **RESOLVED 2026-07-23** | Fossil `jwt.decode` block *deleted* (`43996554`; see july-fix-now.md #2). **NEW follow-up finding**: FhirAuth login-token hash lookups do NOT enforce token expiry (RpcAuth does) — FHIR REST accepts expired-but-present resume tokens. Mirror RpcAuth's `when` + `Accounts._getTokenLifetimeMs()` check |
+| HI-2 | **OPEN** | Default `'change-me-in-production'` + non-constant-time `===` at `FhirAuth.js:222` |
+| HI-3 | *reported*, unverified | Re-verify before fixing |
+| HI-4 | **RELOCATED** | `simple-auth-methods.js` gone; custom login lives in `imports/startup/server/simple-accounts-startup.js` — re-verify there |
+| HI-5 | **OPEN** | `conditions.all` still `Conditions.find({})` for any logged-in user (comment admits it) |
+| HI-6 | **RESOLVED** | `WebsocketsAccessControl.js` deleted; zero references remain |
+| HI-7 | **OPEN** | `SearchParametersEngine.js:707-716` `buildStringQuery` still `$regex: '^' + searchValue` unescaped (the July "CodeQL ReDoS fixes" were elsewhere) |
+| HI-8 | **OPEN** | `rejectUnauthorized: false` at `provider-directory/server/hooks.js:69` |
+| HI-9 | **OPEN** | `adminPassword: "changeme123"` at `accounts.multiuser.settings.json:72`, still tracked |
+| HI-10 | **OPEN** | RSA PRIVATE KEY still at `extensions/timelines/configs/settings.lcars.json:347`; `AIzaSy…` keys in 5 extension files incl. `care-commons-sandbox` galaxy config. NOT covered by CI gitleaks (extensions absent from checkout) |
+| HI-11 | **OPEN** | `'default-secret'` fallback at `digitalIdGenerator.js:94,109` |
+| HI-12 | **PARTIAL** | `Metadata.js` + `CdsHooksEndpoints.js` wildcard CORS gone (July harmonization). `BulkData.js` still has **5** `Allow-Origin: '*'` sites; `ConsentEngineHttp.js` unverified |
+| HI-13 | **OPEN** | `server/Session.js:77` cookie still `Expires` only — no HttpOnly/Secure/SameSite |
+| HI-14 | **PARTIAL/OPEN** | ProxyRelay migrated to ServerMethods but still gated only by `PROXY_RELAY_ENABLED`; no URL allowlist, no audit write |
+| HI-15 | **OPEN** | `bulkExportOutputStore = new Map()` (`BulkData.js:79`), no TTL sweep; bearer-expiry check added on download path (`:155-161`) is partial progress; `requireAccessToken` conditionality unverified |
+| HI-16 | **OPEN** | `MOBILE_JWT_SECRET || Random.secret()` at `middleware-mobile.js:17` |
+| ME-1 | **OPEN** | No startup assertion; `core-startup.js` relocated — find the new home first |
+| ME-2 | **PARTIAL — synthea portion CLOSED by design decision** | `synthea.clearResearchData`: `requireAuth: false` **blessed 2026-07-24** — the package is sandbox/bootstrap hydration tooling expected to be removed from production builds; the `enableSyntheaDbUtils` settings gate is the operative guard (comment at the define site records this). Related hardening same day: hydration importers (synthea, provider-directory, lantern) now stamp `meta.source` lineage on every insert, and `clearResearchData` accepts an optional `source` param for scoped cleanup. `ConsentEngineMethods.revokeConsent`, data-importer warehouse still unverified |
+| ME-3 | **OPEN** | Raw `parseInt(_count)` no clamp at `FhirEndpoints.js:2286,:2721` |
+| ME-4 | **OPEN** | `Patients.allow({insert: …})` at `leaderboard-starter/lib/collections.js:21`, still registered in `workflows.json` |
+| ME-5 | **PARTIAL** | RPC HTTP path now has per-method rate limiting (in-memory); DDP subs still uncovered |
+| ME-6..9 | unverified | Re-verify (ME-6 line refs dead with core-startup.js) |
+
+## Overlap with already-completed July work (do not redo)
+
+- `test.*` methods gating, endpoint smoke battery, safety-net CI wiring,
+  console/logging sweep, jwt fossil deletion — all ✅ per
+  [july-fix-now.md](../july-fix-now.md).
+- HIPAA audit trail: AuditEvent writes exist on the non-patient FHIR read
+  path (fire-and-forget); not systematic — the audit's (d)(2)/(d)(3) GAP
+  stands, tracked by the audit-trail design doc.
+
+## New findings surfaced since the audit (fold into the campaign)
+
+1. **Expired resume tokens accepted on FHIR REST** (HI-1 follow-up, above).
+2. **`invoke()` bypasses rate limiting / null identity** and **in-memory
+   per-process rate buckets never evicted** (RPC residuals — see
+   july-tech-debt-analysis.md §3).
+3. **`rpc.discover` enumerates 440 methods + schemas anonymously** —
+   public by design, revisit as information disclosure.
+4. **Duplicate shadowed route registrations** in FhirEndpoints (two PATCH,
+   two DELETE, two `_history/:versionId` GETs) are now security-relevant:
+   CR-3 fixes must land in the copy that actually serves traffic.

--- a/docs/security/2026-07-24-audit-status-diff.md
+++ b/docs/security/2026-07-24-audit-status-diff.md
@@ -23,7 +23,8 @@
 3. **A gitleaks CI gate exists** (`.gitleaks.toml`, triaged 2026-07-23) — but
    it does NOT cover `extensions/*` (gitignored nested repos, absent from the
    CI checkout) and does not flag the low-entropy committed secrets
-   (`pacio-secret-token-change-in-production`, `changeme123`). CR-5/6/HI-9/10
+   (the pacio account-server token, the default admin password — literals
+   quoted only in the 2026-07-01 audit record). CR-5/6/HI-9/10
    are therefore still fully open despite a green secret-scan job.
 4. **Structured logging + PHI redaction shipped** (the audit's deferred
    dependency); the July browser-log audit PII-dump tier is fixed.
@@ -59,7 +60,7 @@
 | HI-6 | **RESOLVED** | `WebsocketsAccessControl.js` deleted; zero references remain |
 | HI-7 | **OPEN** | `SearchParametersEngine.js:707-716` `buildStringQuery` still `$regex: '^' + searchValue` unescaped (the July "CodeQL ReDoS fixes" were elsewhere) |
 | HI-8 | **OPEN** | `rejectUnauthorized: false` at `provider-directory/server/hooks.js:69` |
-| HI-9 | **OPEN** | `adminPassword: "changeme123"` at `accounts.multiuser.settings.json:72`, still tracked |
+| HI-9 | **OPEN** | default `adminPassword` literal at `accounts.multiuser.settings.json:72`, still tracked |
 | HI-10 | **OPEN** | RSA PRIVATE KEY still at `extensions/timelines/configs/settings.lcars.json:347`; `AIzaSy…` keys in 5 extension files incl. `care-commons-sandbox` galaxy config. NOT covered by CI gitleaks (extensions absent from checkout) |
 | HI-11 | **OPEN** | `'default-secret'` fallback at `digitalIdGenerator.js:94,109` |
 | HI-12 | **PARTIAL** | `Metadata.js` + `CdsHooksEndpoints.js` wildcard CORS gone (July harmonization). `BulkData.js` still has **5** `Allow-Origin: '*'` sites; `ConsentEngineHttp.js` unverified |

--- a/docs/security/2026-07-24-audit-status-diff.md
+++ b/docs/security/2026-07-24-audit-status-diff.md
@@ -6,6 +6,33 @@
 > Every status below was verified by direct grep/read this session. The
 > original audit is preserved unmodified as the analysis record.
 
+## Campaign progress (branch `fix/security-audit-2026-07`, updated 2026-07-24)
+
+**Every CRITICAL in the core repo is now fixed.** Landed this session:
+CR-1 (JWT verify), CR-2 (secure-config boot assertion), CR-3 (compartment on
+read/DELETE/PATCH/PUT + search unification), CR-4 (meta.security governance),
+CR-5/CR-6 (secrets untracked + gitleaks guards), CR-10 (UDAP SSRF guard). CR-9
+was already resolved pre-campaign. Each fix follows the same shape: a pure,
+unit-tested `server/lib/*.js` helper (genuine CommonJS — see the node-20 lesson)
+wired into the endpoint, reproduce-before-fix, one finding per commit, CI-gated
+in the `rpc-method-tests` job. CR-1/CR-3/CR-4 have node-20 CI green; CR-2/CR-10
+pending at time of writing.
+
+**Remaining:**
+- **CR-7/CR-8 residuals** — merkalis warehouse-relay allowlist + ipfs-swarm
+  multiaddr SSRF. These live in the `extensions/*` **nested repos** and commit
+  there, not this branch. The `outboundUrlGuard` from CR-10 is the reusable
+  pattern. (The method-auth holes were already closed via `requireAuth: true`.)
+- **Human-only** — secret rotation (CR-5/HI-9/HI-10) per `remediation-actions.md`.
+- **High/Medium tier** — HI-1-followup (expired-resume-token on FHIR REST),
+  HI-7 (regex escaping), HI-8 (TLS verify), HI-12 (BulkData CORS), HI-13 (cookie
+  flags), HI-14/15 (egress/bulk-store), etc.
+- **New follow-ups surfaced this session**: PUT ownership-ref validation
+  (subject.reference spoofing on create); DNS-rebinding hardening for the SSRF
+  guard; unifying the two remaining inline compartment blocks (public-read,
+  POST-search/$everything); the deferred live two-patient token-scoped
+  integration tests (post-OpenID).
+
 ## What changed structurally since 2026-07-01 (affects the remediation plan)
 
 1. **The ServerMethods pipeline landed** (the audit's "synergy note"
@@ -42,16 +69,16 @@
 
 | ID | Status 2026-07-24 | Evidence / updated anchors |
 |----|-------------------|----------------------------|
-| CR-1 | **OPEN** | `OAuthEndpoints.js:918` TODO still present; `jwt.decode(client_assertion)` at `:884` |
-| CR-2 | **OPEN** | 12 settings files still ship `disableOauth: true`; no startup assertion exists anywhere |
-| CR-3 | **OPEN** | `authQuery` built only in search GET (`:1279`) and POST `_search` (`:2503`). Instance GET `:598`, PUT `:1876`, PATCH `:2076`+`:2177`, DELETE `:2188`+`:2232` unfiltered. ⚠️ PATCH and DELETE are **duplicate shadowed registrations** — fix both copies or de-duplicate first |
-| CR-4 | **OPEN** | `newRecord = req.body` `:1748`; `cloneDeep(req.body)` `:1897`, `:2096`; `meta.security.display` gating `:1280`, `:1602` |
-| CR-5 | **OPEN** | Secret still at `settings/settings.pacio.json:367` + 4 `pacio-core/configs/*.json`. Progress: `*.template.json` files with empty values now exist alongside. Galaxy config moved (see §7 above) |
-| CR-6 | **OPEN** | `settings.pacio.json`, `accounts.multiuser.settings.json` still force-tracked (`git ls-files` confirms) |
+| CR-1 | **✅ FIXED** (branch `fix/security-audit-2026-07`, commit `1e4ca233`) | JWT signature now verified via shared `server/lib/verifyClientAssertion.js`; both `/oauth/token` JWT paths unified onto it with an asymmetric-alg whitelist. node-20 CI green. |
+| CR-2 | **✅ FIXED** (`70725fed`) | Fail-closed `Meteor.startup` assertion (`server/lib/assertSecureConfig.js`): production refuses to boot with auth disabled UNLESS declared an open sandbox (`settings.private.fhir.openSandbox`). Dev never blocked. |
+| CR-3 | **✅ FIXED** (`38ccdd87` + PUT follow-up `f30572cb`) | `server/lib/patientCompartment.js` enforces the compartment on instance read/DELETE/PATCH **and PUT**; search unified onto the same module. Audit correction: the "shadowed" PATCH/DELETE were if/else branches (real vs 501 stub), not duplicates. |
+| CR-4 | **✅ FIXED** (`41f6bf35`) | `server/lib/writeSanitization.js` governs client `meta.security` on POST/PUT/PATCH (strip on create, preserve server labels on update; privileged writers may label). |
+| CR-5 | **✅ MACHINE-SIDE FIXED** (`88c1f4cc`) | Secret scrubbed from tracked files + `*.template.json` placeholders; gitleaks custom rules block reintroduction. **Human rotation still required** — see `remediation-actions.md` (sandbox-only posture: hygiene backlog, hard gate before first real prod deploy). |
+| CR-6 | **✅ FIXED** (`88c1f4cc`) | `settings.pacio.json` + `accounts.multiuser.settings.json` untracked (`git rm --cached`), `.gitignore` corrected, scrubbed templates track instead. |
 | CR-7 | **LARGELY REMEDIATED** | `methods.js` migrated to ServerMethods, 22× `requireAuth: true`. **Residual**: `server/import/methods.warehouse.js:69` still accepts caller-controlled `options.relayEndpoint` (SSRF/exfil) — verify its auth + add allowlist |
 | CR-8 | **LARGELY REMEDIATED** | 34× `requireAuth: true` in `ipfs-swarm/server/methods.js`. **Residual**: verify the `connectToPeer`/multiaddr SSRF path got host validation, not just auth |
 | CR-9 | **RESOLVED** | `server/Methods.js` is now a ServerMethods stub (`certificates.fetch`) that throws `not operational`; no live URL fetch remains outside the registration flow (= CR-10's scope) |
-| CR-10 | **OPEN** | Recursive AIA/CRL fetch at `OAuthEndpoints.js:258,:273,:494,:500`; no host allowlist |
+| CR-10 | **✅ FIXED** (`85510464`) | `server/lib/outboundUrlGuard.js` SSRF guard wired at the `fetchCertificate`/`fetchRevokationList` entry points (covers both AIA/CRL blocks); blocks IMDS/loopback/private/internal, optional `settings.private.fhir.udapFetchAllowlist`. Residual: literal-host only, no DNS-rebinding protection (documented follow-up). |
 | HI-1 | **RESOLVED 2026-07-23** | Fossil `jwt.decode` block *deleted* (`43996554`; see july-fix-now.md #2). **NEW follow-up finding**: FhirAuth login-token hash lookups do NOT enforce token expiry (RpcAuth does) — FHIR REST accepts expired-but-present resume tokens. Mirror RpcAuth's `when` + `Accounts._getTokenLifetimeMs()` check |
 | HI-2 | **OPEN** | Default `'change-me-in-production'` + non-constant-time `===` at `FhirAuth.js:222` |
 | HI-3 | *reported*, unverified | Re-verify before fixing |
@@ -60,7 +87,7 @@
 | HI-6 | **RESOLVED** | `WebsocketsAccessControl.js` deleted; zero references remain |
 | HI-7 | **OPEN** | `SearchParametersEngine.js:707-716` `buildStringQuery` still `$regex: '^' + searchValue` unescaped (the July "CodeQL ReDoS fixes" were elsewhere) |
 | HI-8 | **OPEN** | `rejectUnauthorized: false` at `provider-directory/server/hooks.js:69` |
-| HI-9 | **OPEN** | default `adminPassword` literal at `accounts.multiuser.settings.json:72`, still tracked |
+| HI-9 | **✅ MACHINE-SIDE FIXED** (`88c1f4cc`) | Default admin password no longer in any tracked file (template carries empty value). **Human rotation still required** where the file was deployed — see `remediation-actions.md`. |
 | HI-10 | **OPEN** | RSA PRIVATE KEY still at `extensions/timelines/configs/settings.lcars.json:347`; `AIzaSy…` keys in 5 extension files incl. `care-commons-sandbox` galaxy config. NOT covered by CI gitleaks (extensions absent from checkout) |
 | HI-11 | **OPEN** | `'default-secret'` fallback at `digitalIdGenerator.js:94,109` |
 | HI-12 | **PARTIAL** | `Metadata.js` + `CdsHooksEndpoints.js` wildcard CORS gone (July harmonization). `BulkData.js` still has **5** `Allow-Origin: '*'` sites; `ConsentEngineHttp.js` unverified |

--- a/docs/security/2026-07-24-remediation-instructions.md
+++ b/docs/security/2026-07-24-remediation-instructions.md
@@ -1,0 +1,98 @@
+# Security Remediation Campaign — Operating Instructions (2026-07-24)
+
+> The launch prompt for the remediation campaign. Supersedes the 2026-07-01
+> draft instructions. Companions:
+> [2026-07-01-honeycomb-security-audit.md](2026-07-01-honeycomb-security-audit.md)
+> (the brief — read in FULL) and
+> [2026-07-24-audit-status-diff.md](2026-07-24-audit-status-diff.md)
+> (verified statuses + updated line anchors — the diff SUPERSEDES the audit
+> where they disagree).
+
+Authorized defensive security remediation of a FHIR EHR we own, ahead of
+BaseEHR certification. Skip findings marked RESOLVED in the diff (CR-9, HI-1,
+HI-6, ME-2-synthea); do not redo docs/july-fix-now.md items.
+
+Fixes for the core app go in the campaign branch. Findings in `extensions/*`
+(CR-7-residual merkalis, CR-8-residual ipfs-swarm, HI-10
+timelines/desktop-*/care-commons-sandbox) are SEPARATE nested git repos —
+commit those inside each package's own repo, never the honeycomb parent.
+
+Work in the audit's "Recommended remediation order", adjusted per the diff:
+order-2 becomes CR-1 + CR-10 (CR-9 closed); order-4 shrinks to the merkalis
+warehouse-relay allowlist + ipfs-swarm SSRF residuals.
+
+This is security-critical: do NOT batch, do NOT loop blindly. For EACH
+finding, one full cycle:
+
+1. **Reproduce**: failing test proving the hole — in `tests/rpc/`
+   (`node --test`) or as a new check in `scripts/endpoint-smoke-test.sh`.
+   NEVER in `tests/mocha/` (runs 0 tests under rspack, issue #171).
+   E.g. CR-3: a patient-scoped token reading another patient's resource by id
+   must return 403, not the record.
+2. **Fix** per the report + the synergy note, which has since LANDED: the
+   ServerMethods pipeline exists — method-auth findings are fixed via
+   `ServerMethods.define(..., { requireAuth: true })`, never hand-rolled
+   `this.userId`. For CR-3/CR-4 apply the EXISTING `authQuery` compartment
+   filter (now `FhirEndpoints.js:1279`) uniformly to instance read (`:598`),
+   PUT (`:1876`), PATCH (`:2076`/`:2177`), DELETE (`:2188`/`:2232`) — BOTH
+   copies of the shadowed duplicate PATCH/DELETE routes, or de-duplicate them
+   first; whitelist/strip `meta.security` + ownership refs on write.
+   ⚠️ meta.source note: hydration importers legitimately write `meta.source`
+   lineage stamps (2026-07-24) — the CR-4 write-path whitelist must allow the
+   server-side stamps while stripping CLIENT-supplied `meta.security` labels.
+   Reuse `server/lib/FhirAuth.js` — do not invent new auth.
+3. **Prove closed**: reproduction passes AND the legitimate path still works
+   (same-patient read succeeds; a valid signed client_assertion still
+   authorizes).
+4. **Commit**, one finding per commit, message naming the id
+   ("fix(security): CR-3 patient-compartment filter on instance
+   read/delete/patch").
+5. **STOP for review after each Critical** before starting the next.
+
+NEW findings to fold into the sequence:
+- Expired-resume-token acceptance on FHIR REST (HI-1 follow-up): mirror
+  RpcAuth's `when` + `Accounts._getTokenLifetimeMs()` expiry check on
+  FhirAuth's two login-token lookup sites.
+- BulkData's 5 remaining wildcard-CORS sites (HI-12 residual).
+
+HUMAN-ONLY — do NOT attempt these; instead write
+`docs/security/remediation-actions.md` describing exactly what the operator
+must do:
+- CR-5/CR-6/HI-9/HI-10: the operator rotates the actual secret values and
+  purges git history (destructive force-push). You MAY: replace committed
+  secret files with `*.template.json` placeholders (the pacio templates
+  already model this), switch code to `process.env` / `settings.private`,
+  fix force-added tracking (`git rm --cached`), and list every secret that
+  needs rotating — noting that the gitleaks CI gate does NOT cover
+  `extensions/*` (absent from CI checkout) and misses low-entropy secrets,
+  so a green scan is NOT evidence of rotation. Do NOT invent replacement
+  secret values or rewrite history.
+
+SPECIAL HANDLING:
+- CR-1 (JWT signature verification): implement the `OAuthEndpoints.js:918`
+  TODO (line moved from :946) with tests — security-critical crypto touching
+  the JWKS/cert path. After it passes, STOP and present the diff for careful
+  review before moving on.
+- CR-2 / config hardening: default `disableOauth` and `disableAccessControl`
+  to false in code; add a `Meteor.startup` assertion that refuses to boot a
+  production profile with either enabled; remove the flags from the 12
+  shipped settings files. `server/core-startup.js` no longer exists — locate
+  the current security-middleware home first. Do not change localhost dev
+  behavior beyond the secure default + an explicit dev opt-in.
+- Blessed design decisions (do not re-litigate): `synthea.*` methods stay
+  `requireAuth: false` behind the `enableSyntheaDbUtils` settings gate — the
+  package is sandbox tooling removed from production builds (recorded at the
+  define site and in the status diff).
+
+RULES: reproduce-before-fix always; never weaken a fix to make a test pass;
+never commit to the honeycomb parent for extension fixes; treat every finding
+as PHI-sensitive; if a fix would change external API behavior (status codes,
+auth requirements clients depend on), stop and ask. Items marked *reported*
+in the audit are single-auditor and unverified — confirm the vulnerability
+exists before fixing it (HI-3, HI-4 relocated to
+`imports/startup/server/simple-accounts-startup.js`, ME-6..9 line refs stale).
+
+Verify continuously: `npm test`, `bash scripts/endpoint-smoke-test.sh`
+against a booted server, and boot with
+`settings/settings.honeycomb.localhost.json` to confirm the app still runs
+after each Critical.

--- a/docs/security/remediation-actions.md
+++ b/docs/security/remediation-actions.md
@@ -1,0 +1,90 @@
+# Human-Only Remediation Actions — Secret Rotation & History Purge
+
+> Companion to the CR-5/CR-6/HI-9/HI-10 remediation commit (2026-07-24).
+> The machine-side work is done: secret settings files are untracked with
+> scrubbed `*.template.json` replacements, the deprecated-estate copies are
+> scrubbed, and gitleaks now has custom rules that fail CI if either
+> known-leaked literal reappears in a tracked file. Everything below requires
+> a human: real credential rotation and destructive history rewrites.
+> Deliberately NO secret values appear in this file — the custom gitleaks
+> rules would flag them; the values are quoted only in the 2026-07-01 audit
+> record.
+>
+> ⚠️ A green gitleaks job is NOT evidence any of this is done: the CI gate
+> scans only the tracked tree of THIS repo — it cannot see `extensions/*`
+> (absent from the CI checkout), other machines' clones, or git history.
+
+## 1. Rotate the pacio account-server token (CR-5) — HIGHEST PRIORITY
+
+The shared `accountServerTokenSecret` gates account-server token auth
+(`server/FhirEndpoints.js:127`, `server/ConsentEngineHttp.js:44`,
+`server/main.js:605`). It was committed to this repo's history and is in a
+**production deploy config**. Anyone with repo access can forge
+account-server tokens against any deployment still using it.
+
+- [ ] Generate a new secret (e.g. `openssl rand -base64 48`) — do NOT commit it
+- [ ] Update every deployment that sets it, especially **care-commons.app**
+      (Galaxy) — the deploy config lives at
+      `extensions/care-commons-sandbox/settings/settings.pacio-core.2026.galaxy.json`
+      (nested repo). Set the new value there (that repo is private, but
+      treat it as settings-not-for-git too: prefer env/Galaxy secrets)
+- [ ] Update local working copies: `settings/settings.pacio.json` (now
+      untracked) and the untracked `npmPackages/pacio-core/configs/settings.*.json`
+      files still carry the old value on disk — replace or blank them
+- [ ] Note: when the setting is absent, the consumers fall back to
+      `Random.secret()` per boot — fail-closed (nothing can authenticate),
+      but multi-instance deployments need an explicit shared value
+
+## 2. Change the admin password (HI-9)
+
+`settings/accounts.multiuser.settings.json` (now untracked) shipped a
+default `adminPassword` in git history.
+
+- [ ] Change the admin account password on ANY deployment ever launched with
+      that settings file
+- [ ] Set a real password only in local/deploy copies, never the template
+
+## 3. Rotate the extension-repo secrets (HI-10) — nested repos
+
+These live in `extensions/*` nested git repos (not this monorepo, not
+covered by CI gitleaks). Rotate the credential FIRST, then clean the repo.
+
+- [ ] **RSA private key** in `extensions/timelines/configs/settings.lcars.json`
+      — regenerate the keypair, update whatever consumed it, scrub the file
+      (template pattern), purge the timelines repo history
+- [ ] **Google Maps API keys** (`AIzaSy…`) in:
+      `extensions/desktop-lunar-colony-sim/package.json` + `settings/settings.lunar-sim.json`,
+      `extensions/timelines/configs/settings.timelines.json`,
+      `extensions/desktop-care-commons/settings/settings.carecommons.galaxy.json`,
+      `extensions/care-commons-sandbox/settings/settings.pacio-core.2026.galaxy.json`
+      — rotate in Google Cloud console (and add referrer/IP restrictions),
+      move to `settings.private.googleMaps.apiKey` / env per the CSP-BYOK
+      pattern, scrub the files
+- [ ] **Stripe `sk_test_…` keys** in several `desktop-*` settings — roll them
+      in the Stripe dashboard (test keys, but still rotate), scrub files
+- [ ] Commit each cleanup inside its own nested repo (never the honeycomb
+      parent); replicate the `.template.json` + gitignore pattern there
+
+## 4. Purge git history (CR-5/CR-6 closure)
+
+The old values remain in this repo's history until rewritten. AFTER
+rotation (order matters — purge without rotation buys nothing):
+
+- [ ] `git filter-repo` (or BFG) to excise
+      `settings/settings.pacio.json`, `settings/accounts.multiuser.settings.json`,
+      and `deprecated/pacio-core/configs/settings.*.json` blobs containing
+      the old token from all history
+- [ ] Coordinate the force-push: all clones re-clone or hard-reset;
+      open PRs will need rebasing
+- [ ] Repeat for the affected extension repos (timelines at minimum — the
+      RSA key)
+- [ ] GitHub support request to drop cached views of the old commits, if
+      desired
+
+## 5. Verify
+
+- [ ] New secrets deployed and old ones confirmed non-functional (an old
+      account-server token must fail auth against care-commons.app)
+- [ ] `git grep` for the old literals across history returns nothing after
+      the rewrite
+- [ ] CI gitleaks job stays green (custom rules guard reintroduction)

--- a/docs/security/remediation-actions.md
+++ b/docs/security/remediation-actions.md
@@ -13,8 +13,15 @@
 > ⚠️ A green gitleaks job is NOT evidence any of this is done: the CI gate
 > scans only the tracked tree of THIS repo — it cannot see `extensions/*`
 > (absent from the CI checkout), other machines' clones, or git history.
+>
+> **Risk calibration (2026-07-24, per project owner)**: the only deployed
+> instance is the care-commons.app SANDBOX — no production PHI deployments
+> exist. The leaked values therefore expose sandbox data only. Treat this
+> list as data-hygiene backlog, not incident response: rotate at convenience,
+> and re-read this list as a HARD prerequisite checklist before any first
+> real production deployment.
 
-## 1. Rotate the pacio account-server token (CR-5) — HIGHEST PRIORITY
+## 1. Rotate the pacio account-server token (CR-5)
 
 The shared `accountServerTokenSecret` gates account-server token auth
 (`server/FhirEndpoints.js:127`, `server/ConsentEngineHttp.js:44`,
@@ -65,10 +72,14 @@ covered by CI gitleaks). Rotate the credential FIRST, then clean the repo.
 - [ ] Commit each cleanup inside its own nested repo (never the honeycomb
       parent); replicate the `.template.json` + gitignore pattern there
 
-## 4. Purge git history (CR-5/CR-6 closure)
+## 4. Purge git history (CR-5/CR-6 closure) — OPTIONAL at current posture
 
-The old values remain in this repo's history until rewritten. AFTER
-rotation (order matters — purge without rotation buys nothing):
+The old values remain in this repo's history until rewritten. With
+sandbox-only exposure, the disruption of a history rewrite (force-push, all
+clones re-cloned, PRs rebased) may not be worth it — a reasonable call is to
+rotate (making the historical values dead) and skip the purge until/unless a
+compliance review requires it. If purging, do it AFTER rotation (order
+matters — purge without rotation buys nothing):
 
 - [ ] `git filter-repo` (or BFG) to excise
       `settings/settings.pacio.json`, `settings/accounts.multiuser.settings.json`,

--- a/npmPackages/provider-directory/server/methods.js
+++ b/npmPackages/provider-directory/server/methods.js
@@ -2,7 +2,7 @@
 import { Meteor } from 'meteor/meteor';
 import { Random } from 'meteor/random';
 import { fetch } from 'meteor/fetch';
-import { get, has } from 'lodash';
+import { get, has, set } from 'lodash';
 
 import forge from 'node-forge';
 
@@ -100,6 +100,23 @@ if(Meteor.isServer){
 // collect the method definitions and register only the names the app does NOT
 // already provide (e.g. generateCertificate, initSearchParameters,
 // sendSoftwareStatement are skipped — the core versions win).
+// FHIR meta.source lineage stamps — every hydration insert tags the dataset it
+// came from, so scoped cleanup tooling can clear one source's records without
+// trashing data hydrated by other importers (uniform convention with the
+// synthea and lantern packages; see synthea.clearResearchData's source param).
+// Upstream-directory proxy inserts stamp the actual upstream base URL instead.
+const HYDRATION_SOURCE = {
+    lantern: 'urn:honeycomb:hydration:lantern',
+    nppes: 'urn:honeycomb:hydration:nppes',
+    vhdir: 'urn:honeycomb:hydration:vhdir'
+};
+function stampSource(resource, sourceUri){
+    if(sourceUri){
+        set(resource, 'meta.source', sourceUri);
+    }
+    return resource;
+}
+
 const __pdMethods = {
     initUsCore: async function(){
         console.log("Initializing US Core...");
@@ -203,7 +220,7 @@ const __pdMethods = {
                     if(!has(fhirResource, 'id')){
                         fhirResource.id = Random.id();
                       }
-                    await Endpoints.insertAsync(fhirResource)
+                    await Endpoints.insertAsync(stampSource(fhirResource, HYDRATION_SOURCE.lantern))
                 }
             }
         }
@@ -225,13 +242,13 @@ const __pdMethods = {
                 //console.log(get(fhirResource, 'resourceType'));
                 if(get(fhirResource, 'resourceType') === "Organization"){
                     if(!await Organizations.findOneAsync({"name": get(fhirResource, "name")})){
-                        await Organizations.insertAsync(fhirResource)
+                        await Organizations.insertAsync(stampSource(fhirResource, HYDRATION_SOURCE.nppes))
                     }
                 } else if(get(fhirResource, 'resourceType') === "Practitioner"){
                     let name = get(fhirResource, 'name[0].text');
                     //console.log(name);
                     if(!await Practitioners.findOneAsync({"name.0.text": name})){
-                        await Practitioners.insertAsync(fhirResource, {filter: false, validate: false})
+                        await Practitioners.insertAsync(stampSource(fhirResource, HYDRATION_SOURCE.nppes), {filter: false, validate: false})
                     }
 
                 }
@@ -324,7 +341,7 @@ const __pdMethods = {
             for(const codeSystem of codeSystemsArray){
                 if(get(codeSystem, 'resourceType') === "CodeSystem"){
                     if(!await CodeSystems.findOneAsync({id: get(codeSystem, 'id')})){
-                        await CodeSystems.insertAsync(codeSystem)
+                        await CodeSystems.insertAsync(stampSource(codeSystem, HYDRATION_SOURCE.vhdir))
                     }
                 }
             }
@@ -645,7 +662,7 @@ const __pdMethods = {
         for(const searchParameter of searchParametersArray){
             if(get(searchParameter, 'resourceType') === "SearchParameter"){
                 if(!await SearchParameters.findOneAsync({id: get(searchParameter, 'id')})){
-                    await SearchParameters.insertAsync(searchParameter, {filter: false, validate: false})
+                    await SearchParameters.insertAsync(stampSource(searchParameter, HYDRATION_SOURCE.vhdir), {filter: false, validate: false})
                 }
             }
         }
@@ -730,7 +747,7 @@ const __pdMethods = {
         for(const structureDefinition of structureDefinitionsArray){
             if(get(structureDefinition, 'resourceType') === "StructureDefinition"){
                 if(!await StructureDefinitions.findOneAsync({id: get(structureDefinition, 'id')})){
-                    await StructureDefinitions.insertAsync(structureDefinition)
+                    await StructureDefinitions.insertAsync(stampSource(structureDefinition, HYDRATION_SOURCE.vhdir))
                 }
             }
         }
@@ -823,7 +840,7 @@ const __pdMethods = {
         for(const valueSet of valueSetsArray){
             if(get(valueSet, 'resourceType') === "ValueSet"){
                 if(!await ValueSets.findOneAsync({id: get(valueSet, 'id')})){
-                    await ValueSets.insertAsync(valueSet, {filter: false, validate: false})
+                    await ValueSets.insertAsync(stampSource(valueSet, HYDRATION_SOURCE.vhdir), {filter: false, validate: false})
                 }
             }
         }
@@ -911,7 +928,7 @@ const __pdMethods = {
                             
                                                 // lets try to insert the record
                                                 try {
-                                                    response = await Collections[FhirUtilities.pluralizeResourceName(get(proxyInsertEntry, 'resource.resourceType'))].insertAsync(proxyInsertEntry.resource, {validate: false, filter: false});
+                                                    response = await Collections[FhirUtilities.pluralizeResourceName(get(proxyInsertEntry, 'resource.resourceType'))].insertAsync(stampSource(proxyInsertEntry.resource, upstreamDirectory), {validate: false, filter: false});
                                                 } catch(error) {
                                                     log.error('ProxyInsert insert error', { error: error?.message })
                                                 }
@@ -939,7 +956,7 @@ const __pdMethods = {
                         
                                     // lets try to insert the record
                                     try {
-                                        await Collections[FhirUtilities.pluralizeResourceName(get(parsedContent, 'resource.resourceType'))].insertAsync(parsedContent.resource, {validate: false, filter: false});
+                                        await Collections[FhirUtilities.pluralizeResourceName(get(parsedContent, 'resource.resourceType'))].insertAsync(stampSource(parsedContent.resource, upstreamDirectory), {validate: false, filter: false});
                                     } catch(error) {
                                         log.error('ProxyInsert insert error (single resource)', { error: error?.message })
                                     }

--- a/npmPackages/synthea/server/methods/generateTrialsResources.js
+++ b/npmPackages/synthea/server/methods/generateTrialsResources.js
@@ -92,6 +92,11 @@ const STUDY_TEMPLATES = [
 // ResearchSubject records referencing them. Canonical name is already the
 // dotted 'synthea.generateTrialsResources' (no rename → no aliases). Uses the
 // global Meteor.ServerMethods per the npmPackages exemplar.
+// FHIR meta.source lineage stamp: every record this package hydrates carries
+// this uri so scoped cleanup (synthea.clearResearchData { source }) can remove
+// synthea-generated data without touching records from other importers.
+const SYNTHEA_SOURCE_URI = 'urn:honeycomb:hydration:synthea';
+
 Meteor.ServerMethods.define('synthea.generateTrialsResources', {
   description: 'Generate synthetic ResearchStudy records and convert existing patients into ResearchSubjects',
   phi: true
@@ -189,10 +194,11 @@ Meteor.ServerMethods.define('synthea.generateTrialsResources', {
             display: 'Research Medical Center'
           }],
           meta: {
-            lastUpdated: now
+            lastUpdated: now,
+            source: SYNTHEA_SOURCE_URI
           }
         };
-        
+
         await ResearchStudies.insertAsync(researchStudy);
         studyIds.push(studyId);
         createdStudies.push(researchStudy);
@@ -253,10 +259,11 @@ Meteor.ServerMethods.define('synthea.generateTrialsResources', {
             display: 'Research Study Consent'
           },
           meta: {
-            lastUpdated: new Date()
+            lastUpdated: new Date(),
+            source: SYNTHEA_SOURCE_URI
           }
         };
-        
+
         // Add end date for some statuses
         if (['ineligible', 'off-study', 'withdrawn'].includes(randomStatus)) {
           researchSubject.period.end = new Date().toISOString();

--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
     "a11y:ci": "jest --config jest.a11y.config.cjs --ci",
     "test:workflow-parser": "node --test workflows/rspack.workflowParser.test.mjs",
     "audit:collections": "node scripts/audit-global-collections.js",
-    "test:rpc-methods": "node --test tests/rpc/"
+    "test:rpc-methods": "node --test tests/rpc/",
+    "test:oauth-assertion": "node --test tests/unit/server/lib/verifyClientAssertion.test.mjs"
   },
   "dependencies": {
     "@accounts/client": "0.33.1",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,8 @@
     "test:rpc-methods": "node --test tests/rpc/",
     "test:oauth-assertion": "node --test tests/unit/server/lib/verifyClientAssertion.test.mjs",
     "test:patient-compartment": "node --test tests/unit/server/lib/patientCompartment.test.mjs",
-    "test:write-sanitization": "node --test tests/unit/server/lib/writeSanitization.test.mjs"
+    "test:write-sanitization": "node --test tests/unit/server/lib/writeSanitization.test.mjs",
+    "test:secure-config": "node --test tests/unit/server/lib/assertSecureConfig.test.mjs"
   },
   "dependencies": {
     "@accounts/client": "0.33.1",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
     "audit:collections": "node scripts/audit-global-collections.js",
     "test:rpc-methods": "node --test tests/rpc/",
     "test:oauth-assertion": "node --test tests/unit/server/lib/verifyClientAssertion.test.mjs",
-    "test:patient-compartment": "node --test tests/unit/server/lib/patientCompartment.test.mjs"
+    "test:patient-compartment": "node --test tests/unit/server/lib/patientCompartment.test.mjs",
+    "test:write-sanitization": "node --test tests/unit/server/lib/writeSanitization.test.mjs"
   },
   "dependencies": {
     "@accounts/client": "0.33.1",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,8 @@
     "test:oauth-assertion": "node --test tests/unit/server/lib/verifyClientAssertion.test.mjs",
     "test:patient-compartment": "node --test tests/unit/server/lib/patientCompartment.test.mjs",
     "test:write-sanitization": "node --test tests/unit/server/lib/writeSanitization.test.mjs",
-    "test:secure-config": "node --test tests/unit/server/lib/assertSecureConfig.test.mjs"
+    "test:secure-config": "node --test tests/unit/server/lib/assertSecureConfig.test.mjs",
+    "test:outbound-url-guard": "node --test tests/unit/server/lib/outboundUrlGuard.test.mjs"
   },
   "dependencies": {
     "@accounts/client": "0.33.1",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
     "test:workflow-parser": "node --test workflows/rspack.workflowParser.test.mjs",
     "audit:collections": "node scripts/audit-global-collections.js",
     "test:rpc-methods": "node --test tests/rpc/",
-    "test:oauth-assertion": "node --test tests/unit/server/lib/verifyClientAssertion.test.mjs"
+    "test:oauth-assertion": "node --test tests/unit/server/lib/verifyClientAssertion.test.mjs",
+    "test:patient-compartment": "node --test tests/unit/server/lib/patientCompartment.test.mjs"
   },
   "dependencies": {
     "@accounts/client": "0.33.1",

--- a/server/FhirEndpoints.js
+++ b/server/FhirEndpoints.js
@@ -13,6 +13,8 @@ import { SearchParametersEngine } from './SearchParametersEngine.js';
 // matches imports/lib/loggerRedact.js usage).
 import patientCompartmentModule from './lib/patientCompartment.js';
 const { isCompartmentExempt, recordMatchesCompartment, buildPatientCompartmentQuery } = patientCompartmentModule;
+import writeSanitizationModule from './lib/writeSanitization.js';
+const { governSecurityLabels } = writeSanitizationModule;
 
 import { get, has, set, unset, cloneDeep, capitalize, findIndex, countBy } from 'lodash';
 import moment from 'moment';
@@ -1744,7 +1746,19 @@ if(typeof serverRouteManifest === "object"){
               if (get(req, 'body')) {
                 let newRecord = req.body;
                 log.trace('req.body', req.body);
-                
+
+                // CR-4 (security audit 2026-07-01): the client cannot set its own
+                // meta.security access labels on create — labeling a resource
+                // 'unrestricted' would make PHI world-readable (the compartment
+                // filter treats 'unrestricted' as public). Privileged (system /
+                // clinician) writers may label legitimately.
+                {
+                  const writeRole = get(authorizationContext, 'role', 'PAT');
+                  const practitionerFullAccess = get(Meteor, 'settings.private.accessControl.practitionerFullAccess', true);
+                  const callerMaySetSecurity = isCompartmentExempt({ role: writeRole, resourceType: routeResourceType, practitionerFullAccess: practitionerFullAccess });
+                  newRecord = governSecurityLabels(newRecord, { existingRecord: null, callerMaySetSecurity: callerMaySetSecurity });
+                }
+
   
                 let newlyAssignedId = Random.id();
   
@@ -1892,9 +1906,21 @@ if(typeof serverRouteManifest === "object"){
         
               if (req.body) {
                 let newRecord = cloneDeep(req.body);
-        
+
                 log.trace('req.body', req.body);
-        
+
+                // CR-4 (security audit 2026-07-01): govern client-supplied
+                // meta.security on write. On update the existing record's server
+                // labels are preserved; on create any client label is dropped —
+                // unless the caller is a privileged (system / clinician) writer.
+                {
+                  const writeRole = get(authorizationContext, 'role', 'PAT');
+                  const practitionerFullAccess = get(Meteor, 'settings.private.accessControl.practitionerFullAccess', true);
+                  const callerMaySetSecurity = isCompartmentExempt({ role: writeRole, resourceType: routeResourceType, practitionerFullAccess: practitionerFullAccess });
+                  const existingRecord = await Collections[collectionName].findOneAsync({ id: req.params.id });
+                  newRecord = governSecurityLabels(newRecord, { existingRecord: existingRecord, callerMaySetSecurity: callerMaySetSecurity });
+                }
+
                 newRecord.resourceType = routeResourceType;
                 newRecord = RestHelpers.toMongo(newRecord);
         
@@ -2128,23 +2154,43 @@ if(typeof serverRouteManifest === "object"){
                   }
 
                   let newlyAssignedId;
-          
+
+                  // CR-4 (security audit 2026-07-01): a non-privileged writer
+                  // cannot patch server-owned meta.security access labels. Strip
+                  // any meta.security-targeting patch key (and the security
+                  // sub-field of a wholesale meta patch) unless the caller is a
+                  // privileged (system / clinician) writer.
+                  const patchWriteRole = get(authorizationContext, 'role', 'PAT');
+                  const patchPractitionerFullAccess = get(Meteor, 'settings.private.accessControl.practitionerFullAccess', true);
+                  const patchMaySetSecurity = isCompartmentExempt({ role: patchWriteRole, resourceType: routeResourceType, practitionerFullAccess: patchPractitionerFullAccess });
+                  function stripClientSecurityPatchKeys(patchObj){
+                    if (patchMaySetSecurity) { return patchObj; }
+                    Object.keys(patchObj).forEach(function(k){
+                      if (k === 'meta.security' || k.indexOf('meta.security') === 0) {
+                        delete patchObj[k];
+                      } else if (k === 'meta' && patchObj[k] && typeof patchObj[k] === 'object') {
+                        delete patchObj[k].security;
+                      }
+                    });
+                    return patchObj;
+                  }
+
                   if(numRecordsToUpdate > 1){
                     log.debug('Found existing records; this is an update interaction, not a create interaction');
                     log.debug(numRecordsToUpdate + ' records found...');
-  
+
                     if(process.env.DEBUG){
                       log.debug('req.query', req.query);
                       log.debug('req.params', req.params);
-                      log.debug('req.body', req.body);  
+                      log.debug('req.body', req.body);
                     }
-                    
+
                     let setObjectPatch = {};
                     Object.keys(req.query).forEach(function(key){
                       setObjectPatch[key] = get(req.body, key);
                     })
-  
-                    
+                    stripClientSecurityPatchKeys(setObjectPatch);
+
                     log.debug('setObjectPatch', setObjectPatch);
                     let result = await Collections[collectionName].updateAsync({id: req.params.id}, {$set: setObjectPatch}, {multi: true});
   
@@ -2164,9 +2210,10 @@ if(typeof serverRouteManifest === "object"){
                     Object.keys(req.query).forEach(function(key){
                       setObjectPatch[key] = get(req.body, key);
                     })
+                    stripClientSecurityPatchKeys(setObjectPatch);
                     log.debug('setObjectPatch', setObjectPatch);
-  
-                    
+
+
                     await Collections[collectionName].updateAsync({_id: setObjectPatch._id}, {$set: setObjectPatch});
   
                     delete setObjectPatch._document;

--- a/server/FhirEndpoints.js
+++ b/server/FhirEndpoints.js
@@ -1909,16 +1909,30 @@ if(typeof serverRouteManifest === "object"){
 
                 log.trace('req.body', req.body);
 
-                // CR-4 (security audit 2026-07-01): govern client-supplied
-                // meta.security on write. On update the existing record's server
-                // labels are preserved; on create any client label is dropped —
-                // unless the caller is a privileged (system / clinician) writer.
+                // CR-3 follow-up + CR-4 (security audit 2026-07-01): on PUT,
+                // (a) enforce the patient compartment against the EXISTING record
+                // so a patient token cannot overwrite another patient's resource
+                // by id (update-by-id IDOR — the CR-3 class the audit did not name
+                // for PUT), and (b) govern client-supplied meta.security (preserve
+                // the server's existing labels on update, strip on create).
+                // Privileged system/clinician writers bypass both.
                 {
                   const writeRole = get(authorizationContext, 'role', 'PAT');
+                  const acDisabled = get(Meteor, 'settings.private.fhir.disableAccessControl') === true;
                   const practitionerFullAccess = get(Meteor, 'settings.private.accessControl.practitionerFullAccess', true);
-                  const callerMaySetSecurity = isCompartmentExempt({ role: writeRole, resourceType: routeResourceType, practitionerFullAccess: practitionerFullAccess });
+                  const callerExempt = isCompartmentExempt({ role: writeRole, resourceType: routeResourceType, practitionerFullAccess: practitionerFullAccess });
                   const existingRecord = await Collections[collectionName].findOneAsync({ id: req.params.id });
-                  newRecord = governSecurityLabels(newRecord, { existingRecord: existingRecord, callerMaySetSecurity: callerMaySetSecurity });
+
+                  if (existingRecord && !acDisabled && !callerExempt && !recordMatchesCompartment(existingRecord, authorizationContext, routeResourceType)) {
+                    log.phi('Instance put denied - target resource outside patient compartment', null, { action: 'update', resourceType: routeResourceType });
+                    res.status(403).json({
+                      resourceType: "OperationOutcome",
+                      issue: [{ severity: "error", code: "forbidden", diagnostics: `Access to this ${routeResourceType} resource is not authorized` }]
+                    });
+                    return;
+                  }
+
+                  newRecord = governSecurityLabels(newRecord, { existingRecord: existingRecord, callerMaySetSecurity: callerExempt });
                 }
 
                 newRecord.resourceType = routeResourceType;

--- a/server/FhirEndpoints.js
+++ b/server/FhirEndpoints.js
@@ -9,7 +9,10 @@ import querystring from 'querystring';
 
 import RestHelpers from './RestHelpers.js';
 import { SearchParametersEngine } from './SearchParametersEngine.js';
-import { isCompartmentExempt, recordMatchesCompartment, buildPatientCompartmentQuery } from './lib/patientCompartment.js';
+// Default-import + destructure (CJS module.exports, not ESM named exports —
+// matches imports/lib/loggerRedact.js usage).
+import patientCompartmentModule from './lib/patientCompartment.js';
+const { isCompartmentExempt, recordMatchesCompartment, buildPatientCompartmentQuery } = patientCompartmentModule;
 
 import { get, has, set, unset, cloneDeep, capitalize, findIndex, countBy } from 'lodash';
 import moment from 'moment';

--- a/server/FhirEndpoints.js
+++ b/server/FhirEndpoints.js
@@ -9,6 +9,7 @@ import querystring from 'querystring';
 
 import RestHelpers from './RestHelpers.js';
 import { SearchParametersEngine } from './SearchParametersEngine.js';
+import { isCompartmentExempt, recordMatchesCompartment, buildPatientCompartmentQuery } from './lib/patientCompartment.js';
 
 import { get, has, set, unset, cloneDeep, capitalize, findIndex, countBy } from 'lodash';
 import moment from 'moment';
@@ -702,6 +703,32 @@ if(typeof serverRouteManifest === "object"){
 
                 records = await Collections[collectionName].find({id: req.params.id}, defaultOptions).fetch();
 
+                // CR-3 (security audit 2026-07-01): patient-compartment enforcement
+                // on instance read. The record was fetched by id alone; deny (403)
+                // when it belongs to a different patient's compartment. A genuine
+                // miss (records empty) falls through to the 404 path below, so this
+                // does NOT disclose existence of resources outside the compartment.
+                // Mirrors the granular-scope 403 denial a few lines down and the
+                // search handler's authQuery role gate.
+                if (Array.isArray(records) && records.length > 0) {
+                  const acDisabled = get(Meteor, 'settings.private.fhir.disableAccessControl') === true;
+                  const practitionerFullAccess = get(Meteor, 'settings.private.accessControl.practitionerFullAccess', true);
+                  if (!acDisabled && !isCompartmentExempt({ role: userRole, resourceType: routeResourceType, practitionerFullAccess: practitionerFullAccess })) {
+                    if (!recordMatchesCompartment(records[0], authorizationContext, routeResourceType)) {
+                      log.phi('Instance read denied - resource outside patient compartment', null, { action: 'read', resourceType: routeResourceType });
+                      res.status(403).json({
+                        resourceType: "OperationOutcome",
+                        issue: [{
+                          severity: "error",
+                          code: "forbidden",
+                          diagnostics: `Access to this ${routeResourceType} resource is not authorized`
+                        }]
+                      });
+                      return;
+                    }
+                  }
+                }
+
                 // plain ol regular approach
                 log.debug('records', records);
 
@@ -1255,56 +1282,23 @@ if(typeof serverRouteManifest === "object"){
                 }
                 
                 if(hipaaAccess.granted){
-                  // Check if healthcare practitioner/provider with full access
-                  const isPractitioner = (userRole === 'healthcare practitioner' || userRole === 'healthcare provider');
+                  // CR-3 (security audit 2026-07-01): the role gate and the
+                  // patient-compartment query now come from the shared module
+                  // (server/lib/patientCompartment.js) — the SAME definition the
+                  // instance read/delete/patch handlers enforce as a predicate, so
+                  // search and instance access can never diverge. isCompartmentExempt
+                  // folds the former inline practitioner-full-access / reference-
+                  // resource / system / noauth bypasses into one gate.
                   const practitionerFullAccess = get(Meteor, 'settings.private.accessControl.practitionerFullAccess', true);
 
-                  // Reference resources that don't belong to patient compartment per FHIR R4 spec
-                  // These are organizational resources accessible with appropriate scope without patient references
-                  const referenceResources = ['Location', 'Practitioner', 'PractitionerRole',
-                                              'Organization', 'HealthcareService', 'Endpoint'];
-                  const isReferenceResource = referenceResources.includes(routeResourceType);
-
-                  if (isPractitioner && practitionerFullAccess) {
-                    // Healthcare practitioner with full access - use search query as-is
+                  if (isCompartmentExempt({ role: userRole, resourceType: routeResourceType, practitionerFullAccess: practitionerFullAccess })) {
+                    // System / practitioner-full-access / reference resource — no
+                    // patient compartment filter (scope was already verified upstream).
                     mongoQuery = searchQuery;
-                    log.debug('Practitioner full access - no authorization filter applied');
-                  } else if (isReferenceResource) {
-                    // Reference resources bypass patient compartment filtering
-                    // The scope check (isResourceScopeAuthorized) already verified access
-                    mongoQuery = searchQuery;
-                    log.phi('Reference resource - no patient compartment filter applied for:', null, { action: 'search' });
+                    log.debug('Compartment-exempt request - no patient authorization filter applied');
                   } else {
-                    // Apply authorization filters
-                    let authQuery = {$or: [
-                      {'meta.security.display': {$eq: 'unrestricted'}}
-                    ]}
-                    if(routeResourceType === "Patient"){
-                      if(get(authorizationContext, 'patientId')){
-                        authQuery.$or.push({'id': get(authorizationContext, 'patientId')})
-                      }
-                      if(get(authorizationContext, 'practitionerId')){
-                        authQuery.$or.push({'generalPractitioner.reference': {$regex: get(authorizationContext, 'practitionerId')}})
-                      }
-                    } else {
-                      // FHIR resources use different reference paths for patients:
-                      // - Some use 'subject.reference' (Observation, Condition, Procedure, DiagnosticReport, etc.)
-                      // - Some use 'patient.reference' (AllergyIntolerance, CarePlan, CareTeam, Encounter, Immunization, MedicationRequest, etc.)
-                      // - Coverage uses 'beneficiary.reference'
-                      // We check all to properly filter by patient authorization
-                      // References may be stored as: Patient/uuid, urn:uuid:uuid, or just uuid
-                      if(get(authorizationContext, 'patientId')){
-                        let patientId = get(authorizationContext, 'patientId');
-                        let patientRefs = [
-                          patientId,
-                          'Patient/' + patientId,
-                          'urn:uuid:' + patientId
-                        ];
-                        authQuery.$or.push({'subject.reference': { $in: patientRefs }});
-                        authQuery.$or.push({'patient.reference': { $in: patientRefs }});
-                        authQuery.$or.push({'beneficiary.reference': { $in: patientRefs }});
-                      }
-                    }
+                    // Apply the patient-compartment authorization filter.
+                    let authQuery = buildPatientCompartmentQuery(authorizationContext, routeResourceType);
 
                     // Merge authorization query with search query
                     if(get(Meteor, 'settings.private.debug') === true) {
@@ -2107,9 +2101,29 @@ if(typeof serverRouteManifest === "object"){
   
                 if(typeof Collections[collectionName] === "object"){
                   let numRecordsToUpdate = await Collections[collectionName].find({id: req.params.id}).countAsync();
-  
-                  log.debug('Number of records found matching the id: ', numRecordsToUpdate); 
-                  
+
+                  log.debug('Number of records found matching the id: ', numRecordsToUpdate);
+
+                  // CR-3 (security audit 2026-07-01): patient-compartment enforcement
+                  // on instance patch. Deny (403) when the target belongs to another
+                  // patient's compartment, before applying any field mutation.
+                  if (numRecordsToUpdate > 0) {
+                    const patchRole = get(authorizationContext, 'role', 'PAT');
+                    const acDisabled = get(Meteor, 'settings.private.fhir.disableAccessControl') === true;
+                    const practitionerFullAccess = get(Meteor, 'settings.private.accessControl.practitionerFullAccess', true);
+                    if (!acDisabled && !isCompartmentExempt({ role: patchRole, resourceType: routeResourceType, practitionerFullAccess: practitionerFullAccess })) {
+                      const targetRecord = await Collections[collectionName].findOneAsync({id: req.params.id});
+                      if (!recordMatchesCompartment(targetRecord, authorizationContext, routeResourceType)) {
+                        log.phi('Instance patch denied - resource outside patient compartment', null, { action: 'update', resourceType: routeResourceType });
+                        res.status(403).json({
+                          resourceType: "OperationOutcome",
+                          issue: [{ severity: "error", code: "forbidden", diagnostics: `Access to this ${routeResourceType} resource is not authorized` }]
+                        });
+                        return;
+                      }
+                    }
+                  }
+
                   let newlyAssignedId;
           
                   if(numRecordsToUpdate > 1){
@@ -2206,11 +2220,30 @@ if(typeof serverRouteManifest === "object"){
               }
   
               if (await Collections[collectionName].find({id: req.params.id}).countAsync() === 0) {
-  
+
                 // Not Found
                 res.status(404).json();
-  
+
               } else {
+                // CR-3 (security audit 2026-07-01): patient-compartment enforcement
+                // on instance delete. Deny (403) when the target belongs to another
+                // patient's compartment, before removing anything. The record is
+                // known to exist here (count > 0), so 403 (not 404) is correct and
+                // matches the instance-read denial.
+                const deleteRole = get(authorizationContext, 'role', 'PAT');
+                const acDisabled = get(Meteor, 'settings.private.fhir.disableAccessControl') === true;
+                const practitionerFullAccess = get(Meteor, 'settings.private.accessControl.practitionerFullAccess', true);
+                if (!acDisabled && !isCompartmentExempt({ role: deleteRole, resourceType: routeResourceType, practitionerFullAccess: practitionerFullAccess })) {
+                  const targetRecord = await Collections[collectionName].findOneAsync({id: req.params.id});
+                  if (!recordMatchesCompartment(targetRecord, authorizationContext, routeResourceType)) {
+                    log.phi('Instance delete denied - resource outside patient compartment', null, { action: 'delete', resourceType: routeResourceType });
+                    res.status(403).json({
+                      resourceType: "OperationOutcome",
+                      issue: [{ severity: "error", code: "forbidden", diagnostics: `Access to this ${routeResourceType} resource is not authorized` }]
+                    });
+                    return;
+                  }
+                }
                 Collections[collectionName].remove({id: req.params.id}, function(error, result){
                   if (result) {
                     // No Content

--- a/server/OAuthEndpoints.js
+++ b/server/OAuthEndpoints.js
@@ -19,6 +19,7 @@ import fs from 'fs';
 import crypto from 'crypto';
 import jwt from 'jsonwebtoken';
 import forge from 'node-forge';
+import { verifyClientAssertionSignature } from '/server/lib/verifyClientAssertion.js';
 import express from 'express';
 
 import bodyParser from 'body-parser';
@@ -915,13 +916,30 @@ WebApp.handlers.post("/oauth/token", async (req, res) => {
           return;
         }
         
-        // TODO: Verify JWT signature against client's public key
-        // This would involve:
-        // 1. Fetching the client's JWK from their jwks_uri (if external client)
-        // 2. Or using the registered public key from our database
-        // 3. Verifying the JWT signature matches
-        // For now, we'll trust the assertion if the client is registered
-        
+        // CR-1 (security audit 2026-07-01): verify the client_assertion
+        // signature against the registered client's public key BEFORE issuing a
+        // token. Resolves the client's JWKS (inline or via jwks_uri), matches
+        // the key by kid, and rejects alg:none / HS* downgrade attempts. Without
+        // this, any party could forge an assertion for a registered
+        // backend-services client and mint a system/*.* bearer token.
+        // (The SMART-asymmetric block further down does the equivalent inline;
+        // dedup to the shared helper is a follow-up, kept out of this security
+        // commit to avoid touching a passing (g)(10) path.)
+        const assertionCheck = await verifyClientAssertionSignature({
+          client: registeredClient,
+          clientAssertion: client_assertion,
+          fetchImpl: fetch
+        });
+
+        if (!assertionCheck.verified) {
+          log.warn('client_credentials assertion signature rejected', { clientId: clientId, reason: assertionCheck.reason });
+          res.status(401).json({
+            "error": "invalid_client",
+            "error_description": "client_assertion signature verification failed"
+          });
+          return;
+        }
+
         // Generate access token for the client
         let access_token = Random.id();
         let scopes = get(req.body, 'scope', registeredClient.scope || 'system/*.read');
@@ -1371,88 +1389,39 @@ WebApp.handlers.post("/oauth/token", async (req, res) => {
           return;
         }
 
-        // Get JWKS from client record or fetch from jwks_uri
-        let jwks = null;
-        if (asymmetricClient.jwks) {
-          jwks = asymmetricClient.jwks;
-          log.debug('SMART asymmetric - using inline JWKS');
-        } else if (asymmetricClient.jwks_uri) {
-          log.debug('SMART asymmetric - fetching JWKS from', { jwks_uri: asymmetricClient.jwks_uri });
-          try {
-            const jwksResponse = await fetch(asymmetricClient.jwks_uri);
-            if (jwksResponse.ok) {
-              jwks = await jwksResponse.json();
-            } else {
-              log.error('SMART asymmetric - failed to fetch JWKS', { status: jwksResponse.status });
-            }
-          } catch (fetchError) {
-            log.error('SMART asymmetric - error fetching JWKS', { error: fetchError.message });
-          }
-        }
+        // Verify the client_assertion signature against the client's registered
+        // key material. CR-1 (2026-07-24): this SMART-asymmetric path and the
+        // client_credentials path above now share the hardened helper
+        // (server/lib/verifyClientAssertion.js) — one JWKS-resolution path
+        // (inline or jwks_uri), one algorithm whitelist. Previously this block
+        // passed decoded.header.alg straight into jwt.verify (trusting any
+        // claimed alg); the helper pins verification to asymmetric algorithms,
+        // so alg:none / HS* downgrade attempts are rejected on BOTH call sites.
+        const assertionCheck = await verifyClientAssertionSignature({
+          client: asymmetricClient,
+          clientAssertion: client_assertion,
+          fetchImpl: fetch
+        });
 
-        if (!jwks || !jwks.keys) {
-          log.error('SMART asymmetric - no JWKS available for client', { clientId });
+        if (!assertionCheck.verified) {
+          log.error('SMART asymmetric - client assertion rejected', { clientId, reason: assertionCheck.reason });
           if (!res.headersSent) {
             res.setHeader('Content-Type', 'application/json');
             res.status(401).json({
               error: 'invalid_client',
-              error_description: 'Client has no JWKS configured'
+              error_description: 'Client assertion signature verification failed'
             }).end();
           }
           return;
         }
 
-        // Find the key by kid
-        const key = jwks.keys.find(k => k.kid === hasKid);
-        if (!key) {
-          log.error('SMART asymmetric - key not found with kid', { kid: hasKid });
-          if (!res.headersSent) {
-            res.setHeader('Content-Type', 'application/json');
-            res.status(401).json({
-              error: 'invalid_client',
-              error_description: 'Key not found in client JWKS'
-            }).end();
-          }
-          return;
-        }
-
-        // Convert JWK to PEM for verification
-        try {
-          const { createPublicKey } = await import('crypto');
-          const publicKey = createPublicKey({ key: key, format: 'jwk' });
-          const pem = publicKey.export({ type: 'spki', format: 'pem' });
-
-          // Verify the JWT
-          jwt.verify(client_assertion, pem, { algorithms: [decoded.header.alg] }, (error, verifiedJwt) => {
-            if (error) {
-              log.error('SMART asymmetric - JWT verification failed', { error: error.message });
-              if (!res.headersSent) {
-                res.setHeader('Content-Type', 'application/json');
-                res.status(401).json({
-                  error: 'invalid_client',
-                  error_description: 'Client assertion signature verification failed'
-                }).end();
-              }
-            } else {
-              log.debug('SMART asymmetric - JWT verified successfully');
-              // Success - return token response
-              if (!res.headersSent) {
-                res.setHeader('Content-Type', 'application/json');
-                res.setHeader('Cache-Control', 'no-store');
-                res.setHeader('Pragma', 'no-cache');
-                res.status(200).send(Buffer.from(JSON.stringify(returnPayload.data))).end();
-              }
-            }
-          });
-        } catch (cryptoError) {
-          log.error('SMART asymmetric - crypto error', { error: cryptoError.message });
-          if (!res.headersSent) {
-            res.setHeader('Content-Type', 'application/json');
-            res.status(401).json({
-              error: 'invalid_client',
-              error_description: 'Failed to process client key'
-            }).end();
-          }
+        log.debug('SMART asymmetric - JWT verified successfully');
+        // Success - return token response
+        if (!res.headersSent) {
+          res.setHeader('Content-Type', 'application/json');
+          res.setHeader('Cache-Control', 'no-store');
+          res.setHeader('Pragma', 'no-cache');
+          res.status(200).send(Buffer.from(JSON.stringify(returnPayload.data))).end();
         }
         return;
 

--- a/server/OAuthEndpoints.js
+++ b/server/OAuthEndpoints.js
@@ -19,7 +19,10 @@ import fs from 'fs';
 import crypto from 'crypto';
 import jwt from 'jsonwebtoken';
 import forge from 'node-forge';
-import { verifyClientAssertionSignature } from '/server/lib/verifyClientAssertion.js';
+// Default-import + destructure (the CJS module is module.exports, not ESM named
+// exports — matches imports/lib/loggerRedact.js usage).
+import verifyClientAssertionModule from '/server/lib/verifyClientAssertion.js';
+const { verifyClientAssertionSignature } = verifyClientAssertionModule;
 import express from 'express';
 
 import bodyParser from 'body-parser';

--- a/server/OAuthEndpoints.js
+++ b/server/OAuthEndpoints.js
@@ -23,6 +23,8 @@ import forge from 'node-forge';
 // exports — matches imports/lib/loggerRedact.js usage).
 import verifyClientAssertionModule from '/server/lib/verifyClientAssertion.js';
 const { verifyClientAssertionSignature } = verifyClientAssertionModule;
+import outboundUrlGuardModule from '/server/lib/outboundUrlGuard.js';
+const { isSafeOutboundUrl } = outboundUrlGuardModule;
 import express from 'express';
 
 import bodyParser from 'body-parser';
@@ -174,6 +176,17 @@ WebApp.handlers.post("/oauth/registration", async (req, res) => {
 
   async function fetchCertificate(certificateUrl, certificateArray = [], certificateSerialNumbers = []) {
     log.debug('fetchCertificate.certificateUrl', { certificateUrl });
+
+    // CR-10 (security audit 2026-07-01): certificateUrl originates from a
+    // caller-supplied certificate's AIA extension. Block internal / cloud-
+    // metadata / private targets before fetching (SSRF). Guarding at the entry
+    // point covers every call site (top-level + recursive).
+    const urlCheck = isSafeOutboundUrl(certificateUrl, { allowlist: get(Meteor, 'settings.private.fhir.udapFetchAllowlist', []) });
+    if (!urlCheck.safe) {
+      log.warn('fetchCertificate blocked - unsafe URL', { reason: urlCheck.reason });
+      return certificateArray;
+    }
+
     try {
       // Fetch the certificate from the URL using meteor/http
 
@@ -263,7 +276,8 @@ WebApp.handlers.post("/oauth/registration", async (req, res) => {
               const httpIndex = extension.value.toString().indexOf('http');
               const recursiveLookupUrl = extension.value.toString().substring(httpIndex);
 
-              // Recursively fetch additional certificates
+              // Recursively fetch additional certificates. The caller-supplied
+              // URL is SSRF-guarded at the fetchCertificate entry point (CR-10).
               await fetchCertificate(recursiveLookupUrl, certificateArray, certificateSerialNumbers);
               if (Array.isArray(recursiveCerts)) {
                 recursiveCerts.forEach(cert => certificateArray.push(cert));
@@ -278,7 +292,8 @@ WebApp.handlers.post("/oauth/registration", async (req, res) => {
               const httpRevocationIndex = extension.value.toString().indexOf('http');
               const intermediateCertRevokationUrl = extension.value.toString().substring(httpRevocationIndex);
 
-              // Fetch the revocation list
+              // Fetch the revocation list (SSRF-guarded at the
+              // fetchRevokationList entry point, CR-10).
               revokedSerialNumbers = await fetchRevokationList(intermediateCertRevokationUrl);
               checkRevokedSerialNumbersAgainstCerts(revokedSerialNumbers, certificateSerialNumbers, res);
             }
@@ -2286,6 +2301,15 @@ function checkRevokedSerialNumbersAgainstCerts(revokedSerialNumbers, recursiveCe
 // }
 
 export async function fetchRevokationList(revokationUrl) {
+  // CR-10 (security audit 2026-07-01): revokationUrl originates from a
+  // caller-supplied certificate's CRL extension. Block internal / cloud-metadata
+  // / private targets before fetching (SSRF).
+  const urlCheck = isSafeOutboundUrl(revokationUrl, { allowlist: get(Meteor, 'settings.private.fhir.udapFetchAllowlist', []) });
+  if (!urlCheck.safe) {
+    log.warn('fetchRevokationList blocked - unsafe URL', { reason: urlCheck.reason });
+    return [];
+  }
+
   try {
     // Fetch the revocation list from the URL using meteor/http
     // const res = HTTP.call('GET', revokationUrl, { npmRequestOptions: { encoding: null } });

--- a/server/SyntheaMethods.js
+++ b/server/SyntheaMethods.js
@@ -181,24 +181,34 @@ ServerMethods.define('synthea.generateResearchSubjects', {
 });
 
 ServerMethods.define('synthea.clearResearchData', {
-  description: 'Remove all ResearchStudy and ResearchSubject records (settings-gated by enableSyntheaDbUtils)',
+  description: 'Remove ResearchStudy and ResearchSubject records, optionally scoped to one meta.source (settings-gated by enableSyntheaDbUtils)',
   aliases: ['clearResearchData'],
-  // Public by PRE-MIGRATION design: guarded only by the
-  // settings.public.enableSyntheaDbUtils feature gate (checked first below).
+  // Public BY DESIGN (blessed 2026-07-24, ME-2 review): the synthea package is
+  // sandbox/bootstrap hydration tooling expected to be removed from production
+  // builds entirely; the settings.public.enableSyntheaDbUtils gate (checked
+  // first below) is the operative guard, and requireAuth stays false to keep
+  // hydration low-friction in single-user (PHR) and sandbox configurations.
   requireAuth: false,
+  positionalParams: ['source'],
   phi: true   // removes patient-linked ResearchSubject records
 }, async function(params, context) {
-  log.info('Clearing Research Data...');
+  // Optional lineage scope: hydration importers stamp meta.source (e.g.
+  // 'urn:honeycomb:hydration:synthea'), so one importer's records can be
+  // cleared without trashing data hydrated from other sources.
+  const source = get(params, 'source', '');
+  const selector = source ? { 'meta.source': source } : {};
+
+  log.info('Clearing Research Data...', { source: source || 'ALL' });
 
   if (!Meteor.settings.public.enableSyntheaDbUtils) {
     throw new Meteor.Error('not-enabled', 'Synthea DB Utils are not enabled');
   }
 
-  const studiesRemoved = await ResearchStudies.removeAsync({});
-  const subjectsRemoved = await ResearchSubjects.removeAsync({});
+  const studiesRemoved = await ResearchStudies.removeAsync(selector);
+  const subjectsRemoved = await ResearchSubjects.removeAsync(selector);
 
   return {
     success: true,
-    message: `Removed ${studiesRemoved} Research Studies and ${subjectsRemoved} Research Subjects`
+    message: `Removed ${studiesRemoved} Research Studies and ${subjectsRemoved} Research Subjects` + (source ? ` (meta.source: ${source})` : '')
   };
 });

--- a/server/lib/assertSecureConfig.js
+++ b/server/lib/assertSecureConfig.js
@@ -1,0 +1,58 @@
+// server/lib/assertSecureConfig.js
+//
+// CR-2 remediation (security audit 2026-07-01): a PRODUCTION deployment must not
+// run with authentication or access control disabled. disableOauth:true (and
+// disableAccessControl:true) ship in settings files; a production profile that
+// inherits one opens the FHIR API to unauthenticated access. The reads already
+// default secure (absent = enabled), so this module powers a fail-closed startup
+// assertion: production refuses to boot with either flag set, while local dev
+// (which legitimately runs disableOauth:true) is never blocked.
+//
+// CommonJS module (require + module.exports), NOT ESM export — dual-context
+// (Meteor bundle + node --test on CI's node 20). See memory
+// dual-context-lib-must-be-cjs.
+// TODO(node24): revert to ESM export once CI runs Node >=24 (Meteor 3.6+).
+const { get } = require('lodash');
+
+// Evaluate whether the auth/access-control config is safe to boot.
+//   settings            — Meteor.settings (or equivalent)
+//   isProduction        — Meteor.isProduction (NODE_ENV=production)
+//   sandboxAcknowledged — the deployment DECLARES itself an intentional open
+//                         sandbox (unauthenticated FHIR API by design). An open
+//                         sandbox is a supported, first-class mode — not an
+//                         accident — so when declared, production boots normally.
+// Returns { secure, violations: string[], sandboxMode }.
+//   - dev (isProduction false): always secure — the flags are allowed locally.
+//   - production, no disable flags: secure.
+//   - production, disable flags, sandbox DECLARED: secure + sandboxMode:true
+//     (an intended open sandbox; caller logs an informational notice).
+//   - production, disable flags, NOT declared: INSECURE — the accident case;
+//     the caller refuses to boot.
+function checkProductionAuthConfig({ settings, isProduction, sandboxAcknowledged = false } = {}) {
+  const violations = [];
+
+  if (!isProduction) {
+    return { secure: true, violations: violations, sandboxMode: false };
+  }
+
+  if (get(settings, 'private.fhir.disableOauth') === true) {
+    violations.push('settings.private.fhir.disableOauth is true');
+  }
+  if (get(settings, 'private.fhir.disableAccessControl') === true) {
+    violations.push('settings.private.fhir.disableAccessControl is true');
+  }
+
+  if (violations.length === 0) {
+    return { secure: true, violations: violations, sandboxMode: false };
+  }
+  if (sandboxAcknowledged) {
+    // Intentional open sandbox — a supported deployment posture. Boot is
+    // allowed; the caller logs that the API is unauthenticated by design.
+    return { secure: true, violations: violations, sandboxMode: true };
+  }
+  // Auth disabled in production without declaring an open sandbox — treat as an
+  // accidental exposure and refuse to boot.
+  return { secure: false, violations: violations, sandboxMode: false };
+}
+
+module.exports = { checkProductionAuthConfig };

--- a/server/lib/outboundUrlGuard.js
+++ b/server/lib/outboundUrlGuard.js
@@ -1,0 +1,95 @@
+// server/lib/outboundUrlGuard.js
+//
+// CR-10 remediation (security audit 2026-07-01): validate a URL before the
+// server fetches it, so a caller-controlled URL (e.g. a UDAP certificate's
+// authorityInfoAccess / cRLDistributionPoints extension) cannot make the server
+// reach internal targets — cloud metadata (169.254.169.254), loopback, or
+// RFC-1918 private ranges (SSRF).
+//
+// CommonJS module (require + module.exports), NOT ESM export — dual-context
+// (Meteor bundle + node --test on CI's node 20). See memory
+// dual-context-lib-must-be-cjs.
+// TODO(node24): revert to ESM export once CI runs Node >=24 (Meteor 3.6+).
+//
+// NOTE (residual): this validates the URL's literal host. It does NOT resolve
+// DNS, so a public hostname that resolves to an internal IP (DNS rebinding) is
+// not caught here — that needs resolve-then-pin-the-socket, a larger change.
+// This closes the direct-IP / internal-hostname SSRF, which is the sharp
+// exploit; DNS-rebinding hardening is a documented follow-up.
+
+// True for an IPv4/IPv6 literal in a loopback / private / link-local / reserved
+// range that must never be reachable from a server-side fetch.
+function isPrivateOrReservedIp(host) {
+  const v4 = host.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
+  if (v4) {
+    const a = parseInt(v4[1], 10);
+    const b = parseInt(v4[2], 10);
+    if (a === 0) { return true; }                        // 0.0.0.0/8
+    if (a === 127) { return true; }                      // loopback
+    if (a === 10) { return true; }                       // private
+    if (a === 172 && b >= 16 && b <= 31) { return true; }// private
+    if (a === 192 && b === 168) { return true; }         // private
+    if (a === 169 && b === 254) { return true; }         // link-local (IMDS)
+    if (a === 100 && b >= 64 && b <= 127) { return true; }// CGNAT 100.64/10
+    if (a >= 224) { return true; }                       // multicast / reserved
+    return false;
+  }
+  const h = host.toLowerCase().replace(/^\[/, '').replace(/\]$/, '');
+  if (h === '::1' || h === '::') { return true; }        // IPv6 loopback / unspecified
+  if (h.startsWith('fe80:')) { return true; }            // IPv6 link-local
+  if (h.startsWith('fc') || h.startsWith('fd')) { return true; } // IPv6 unique-local
+  return false;
+}
+
+// True for hostnames that conventionally resolve to internal infrastructure.
+function isInternalHostname(host) {
+  const h = host.toLowerCase();
+  if (h === 'localhost') { return true; }
+  if (h === 'metadata.google.internal') { return true; }
+  if (h.endsWith('.local') || h.endsWith('.internal') || h.endsWith('.localdomain')) { return true; }
+  return false;
+}
+
+// Validate a URL for server-side fetching.
+//   rawUrl    — the candidate URL string
+//   allowlist — optional array of hostnames; when non-empty, the host MUST match
+//               one (exact, or as a dot-suffix — 'ca.example.com' allows
+//               'certs.ca.example.com'). Internal/private targets are blocked
+//               regardless of the allowlist.
+// Returns { safe: boolean, reason: string }. Never throws.
+function isSafeOutboundUrl(rawUrl, { allowlist = [] } = {}) {
+  let url;
+  try {
+    url = new URL(rawUrl);
+  } catch (parseError) {
+    return { safe: false, reason: 'unparseable url' };
+  }
+
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    return { safe: false, reason: 'non-http(s) scheme: ' + url.protocol };
+  }
+
+  const host = url.hostname;
+  if (!host) {
+    return { safe: false, reason: 'no host' };
+  }
+  if (isInternalHostname(host)) {
+    return { safe: false, reason: 'internal hostname: ' + host };
+  }
+  if (isPrivateOrReservedIp(host)) {
+    return { safe: false, reason: 'private/reserved address: ' + host };
+  }
+
+  if (Array.isArray(allowlist) && allowlist.length > 0) {
+    const matched = allowlist.some(function(entry) {
+      return host === entry || host.endsWith('.' + entry);
+    });
+    if (!matched) {
+      return { safe: false, reason: 'host not in allowlist: ' + host };
+    }
+  }
+
+  return { safe: true, reason: 'ok' };
+}
+
+module.exports = { isSafeOutboundUrl };

--- a/server/lib/patientCompartment.js
+++ b/server/lib/patientCompartment.js
@@ -1,0 +1,131 @@
+// server/lib/patientCompartment.js
+//
+// CR-3 remediation (security audit 2026-07-01): shared patient-compartment
+// authorization for the FHIR instance handlers — GET/DELETE/PATCH
+// /baseR4/<Resource>/:id in server/FhirEndpoints.js. Those handlers looked
+// records up by `id` alone, applying none of the compartment filtering the
+// SEARCH handler builds inline (FhirEndpoints.js:1259-1339), so a
+// patient-scoped token could read/delete/patch any patient's record by id.
+//
+// Pure and dependency-light (lodash only) so it unit-tests offline — see
+// tests/unit/server/lib/patientCompartment.test.mjs. It mirrors the search
+// handler's role gate + authQuery $or so the two cannot diverge; unifying the
+// search path onto this module is a follow-up (kept out of this security commit
+// to avoid touching the passing (g)(10) search path).
+
+// lodash is CommonJS; default-import + destructure so this resolves under BOTH
+// plain `node --test` (the unit tests) and the Meteor server bundle. A named
+// ESM import (`import { get } from 'lodash'`) works only under Meteor's
+// transpiler and throws in node.
+import lodash from 'lodash';
+const { get } = lodash;
+
+// Resource types OUTSIDE the patient compartment per FHIR R4 — organizational /
+// directory resources reachable by scope alone. Mirrors FhirEndpoints.js:1264.
+const REFERENCE_RESOURCES = ['Location', 'Practitioner', 'PractitionerRole', 'Organization', 'HealthcareService', 'Endpoint'];
+
+// True when the patient-compartment filter should NOT be applied for a request:
+// privileged roles and non-compartment resource types. Fail-closed — only
+// KNOWN-exempt roles bypass; any other role (patient, the 'PAT' default,
+// anything unrecognized) gets filtered. Mirrors the search handler's gate
+// (practitioner-full-access / reference-resource / noauth / SYSTEM).
+export function isCompartmentExempt({ role, resourceType, practitionerFullAccess = true } = {}) {
+  if (role === 'SYSTEM' || role === 'noauth') {
+    return true;
+  }
+  const isPractitioner = (role === 'healthcare practitioner' || role === 'healthcare provider');
+  if (isPractitioner && practitionerFullAccess) {
+    return true;
+  }
+  if (REFERENCE_RESOURCES.includes(resourceType)) {
+    return true;
+  }
+  return false;
+}
+
+// The three reference formats a compartment record may store for a patient
+// (mirrors FhirEndpoints.js:1298-1302).
+function patientRefVariants(patientId) {
+  return [patientId, 'Patient/' + patientId, 'urn:uuid:' + patientId];
+}
+
+// The MongoDB $or query form of the compartment, for the SEARCH handler (which
+// filters at the database, not per-record). This is the SAME membership
+// definition recordMatchesCompartment() applies as a predicate — kept in one
+// place so the search filter and the instance-handler checks can never diverge.
+// Callers gate on isCompartmentExempt() first; this builds the filter for
+// non-exempt requests. Mirrors the (now-removed) inline authQuery.
+export function buildPatientCompartmentQuery(authorizationContext, resourceType) {
+  const orClauses = [{ 'meta.security.display': { $eq: 'unrestricted' } }];
+  const patientId = get(authorizationContext, 'patientId');
+
+  if (resourceType === 'Patient') {
+    if (patientId) {
+      orClauses.push({ 'id': patientId });
+    }
+    const practitionerId = get(authorizationContext, 'practitionerId');
+    if (practitionerId) {
+      orClauses.push({ 'generalPractitioner.reference': { $regex: practitionerId } });
+    }
+  } else if (patientId) {
+    const refs = patientRefVariants(patientId);
+    orClauses.push({ 'subject.reference': { $in: refs } });
+    orClauses.push({ 'patient.reference': { $in: refs } });
+    orClauses.push({ 'beneficiary.reference': { $in: refs } });
+  }
+
+  return { $or: orClauses };
+}
+
+// Post-fetch predicate: does this already-loaded record belong to the
+// requester's patient compartment? Mirrors the search authQuery $or
+// (FhirEndpoints.js:1279-1306):
+//   - any meta.security entry with display 'unrestricted' is public
+//   - Patient: the record IS the token's patient (by id), or names the token's
+//     practitioner as generalPractitioner
+//   - all other resources: subject/patient/beneficiary.reference is the token's
+//     patient (in any of the three ref formats)
+// Callers must first check isCompartmentExempt() (and the disableAccessControl
+// setting); this predicate is the per-record membership test only.
+export function recordMatchesCompartment(record, authorizationContext, resourceType) {
+  if (!record) {
+    return false;
+  }
+
+  // Public 'unrestricted' records are readable regardless of compartment. The
+  // search query matches ANY array element, so check all of them.
+  const securityLabels = get(record, 'meta.security', []);
+  if (Array.isArray(securityLabels) && securityLabels.some(function(label) { return get(label, 'display') === 'unrestricted'; })) {
+    return true;
+  }
+
+  const patientId = get(authorizationContext, 'patientId');
+  if (!patientId) {
+    // No patient context → nothing in a patient compartment matches (fail closed).
+    return false;
+  }
+
+  if (resourceType === 'Patient') {
+    if (get(record, 'id') === patientId) {
+      return true;
+    }
+    const practitionerId = get(authorizationContext, 'practitionerId');
+    const generalPractitioners = get(record, 'generalPractitioner', []);
+    if (practitionerId && Array.isArray(generalPractitioners) && generalPractitioners.some(function(gp) {
+      return (get(gp, 'reference') || '').includes(practitionerId);
+    })) {
+      return true;
+    }
+    return false;
+  }
+
+  const refs = patientRefVariants(patientId);
+  for (const path of ['subject.reference', 'patient.reference', 'beneficiary.reference']) {
+    if (refs.includes(get(record, path))) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export default { isCompartmentExempt, recordMatchesCompartment, buildPatientCompartmentQuery };

--- a/server/lib/patientCompartment.js
+++ b/server/lib/patientCompartment.js
@@ -13,12 +13,11 @@
 // search path onto this module is a follow-up (kept out of this security commit
 // to avoid touching the passing (g)(10) search path).
 
-// lodash is CommonJS; default-import + destructure so this resolves under BOTH
-// plain `node --test` (the unit tests) and the Meteor server bundle. A named
-// ESM import (`import { get } from 'lodash'`) works only under Meteor's
-// transpiler and throws in node.
-import lodash from 'lodash';
-const { get } = lodash;
+// CommonJS module (require + module.exports), NOT ESM export — consumed both by
+// the Meteor server bundle and by `node --test` on CI's node 20, where a .js
+// under a type:commonjs package loads as CommonJS. Genuine CJS + default-import
+// is the repo's proven dual-context pattern (see imports/lib/loggerRedact.js).
+const { get } = require('lodash');
 
 // Resource types OUTSIDE the patient compartment per FHIR R4 — organizational /
 // directory resources reachable by scope alone. Mirrors FhirEndpoints.js:1264.
@@ -29,7 +28,7 @@ const REFERENCE_RESOURCES = ['Location', 'Practitioner', 'PractitionerRole', 'Or
 // KNOWN-exempt roles bypass; any other role (patient, the 'PAT' default,
 // anything unrecognized) gets filtered. Mirrors the search handler's gate
 // (practitioner-full-access / reference-resource / noauth / SYSTEM).
-export function isCompartmentExempt({ role, resourceType, practitionerFullAccess = true } = {}) {
+function isCompartmentExempt({ role, resourceType, practitionerFullAccess = true } = {}) {
   if (role === 'SYSTEM' || role === 'noauth') {
     return true;
   }
@@ -55,7 +54,7 @@ function patientRefVariants(patientId) {
 // place so the search filter and the instance-handler checks can never diverge.
 // Callers gate on isCompartmentExempt() first; this builds the filter for
 // non-exempt requests. Mirrors the (now-removed) inline authQuery.
-export function buildPatientCompartmentQuery(authorizationContext, resourceType) {
+function buildPatientCompartmentQuery(authorizationContext, resourceType) {
   const orClauses = [{ 'meta.security.display': { $eq: 'unrestricted' } }];
   const patientId = get(authorizationContext, 'patientId');
 
@@ -87,7 +86,7 @@ export function buildPatientCompartmentQuery(authorizationContext, resourceType)
 //     patient (in any of the three ref formats)
 // Callers must first check isCompartmentExempt() (and the disableAccessControl
 // setting); this predicate is the per-record membership test only.
-export function recordMatchesCompartment(record, authorizationContext, resourceType) {
+function recordMatchesCompartment(record, authorizationContext, resourceType) {
   if (!record) {
     return false;
   }
@@ -128,4 +127,4 @@ export function recordMatchesCompartment(record, authorizationContext, resourceT
   return false;
 }
 
-export default { isCompartmentExempt, recordMatchesCompartment, buildPatientCompartmentQuery };
+module.exports = { isCompartmentExempt, recordMatchesCompartment, buildPatientCompartmentQuery };

--- a/server/lib/patientCompartment.js
+++ b/server/lib/patientCompartment.js
@@ -17,6 +17,10 @@
 // the Meteor server bundle and by `node --test` on CI's node 20, where a .js
 // under a type:commonjs package loads as CommonJS. Genuine CJS + default-import
 // is the repo's proven dual-context pattern (see imports/lib/loggerRedact.js).
+// TODO(node24): this CJS style is a workaround for CI's Node 20.11 (no ESM
+// syntax detection in a .js). Once CI runs Node >=24 (via a Meteor 3.6+ upgrade),
+// this file MAY revert to clean ESM `export` + named imports. See memory
+// dual-context-lib-must-be-cjs. Confirm the CI node version before reverting.
 const { get } = require('lodash');
 
 // Resource types OUTSIDE the patient compartment per FHIR R4 — organizational /

--- a/server/lib/verifyClientAssertion.js
+++ b/server/lib/verifyClientAssertion.js
@@ -1,0 +1,116 @@
+// server/lib/verifyClientAssertion.js
+//
+// CR-1 remediation (security audit 2026-07-01): verify the signature of a
+// client_assertion JWT against the registered client's public key BEFORE the
+// /oauth/token client_credentials + jwt-bearer flow issues a system token.
+//
+// Pure and dependency-light (jsonwebtoken + node:crypto, injectable fetch) so
+// it unit-tests offline — see verifyClientAssertion.test.mjs. The endpoint
+// (server/OAuthEndpoints.js) is the only production caller.
+//
+// Mirrors the already-correct SMART-asymmetric verification block further down
+// OAuthEndpoints.js (resolve JWKS inline-or-jwks_uri → find key by kid →
+// JWK→PEM → jwt.verify) but hardens the algorithm handling: only asymmetric
+// signing algorithms are permitted, so a forged alg:none or an HS* algorithm-
+// confusion attempt (HMAC-signing with the public key as the secret) can never
+// verify.
+
+import jwt from 'jsonwebtoken';
+import { createPublicKey } from 'crypto';
+
+// Asymmetric signature algorithms only. Deliberately excludes 'none' and the
+// HS* family — a client_assertion is proof-of-possession of a PRIVATE key, so
+// symmetric/none algorithms are never valid here and allowing them opens
+// alg-confusion / downgrade attacks.
+const ALLOWED_ALGS = ['RS256', 'RS384', 'RS512', 'ES256', 'ES384', 'ES512', 'PS256', 'PS384', 'PS512'];
+
+// Resolve a client's JWKS: inline `client.jwks` wins; otherwise fetch
+// `client.jwks_uri`. Returns { keys: [...] } or null. fetchImpl is injectable
+// for tests; production passes meteor/fetch.
+async function resolveJwks(client, fetchImpl) {
+  if (client && client.jwks && Array.isArray(client.jwks.keys)) {
+    return client.jwks;
+  }
+  if (client && client.jwks_uri && typeof fetchImpl === 'function') {
+    try {
+      const response = await fetchImpl(client.jwks_uri);
+      if (response && response.ok) {
+        const body = await response.json();
+        if (body && Array.isArray(body.keys)) {
+          return body;
+        }
+      }
+      return null;
+    } catch (fetchError) {
+      return null;
+    }
+  }
+  return null;
+}
+
+// Verify a client_assertion JWT against the registered client's public key.
+//
+//   client         — the OAuthClients record (carries jwks or jwks_uri)
+//   clientAssertion — the raw JWT string
+//   fetchImpl      — optional fetch for jwks_uri resolution (meteor/fetch in prod)
+//
+// Returns { verified: boolean, reason?: string, payload?: object }. NEVER
+// throws — the caller treats any non-verified result as invalid_client.
+export async function verifyClientAssertionSignature({ client, clientAssertion, fetchImpl } = {}) {
+  if (!clientAssertion) {
+    return { verified: false, reason: 'no client_assertion provided' };
+  }
+
+  let decoded;
+  try {
+    decoded = jwt.decode(clientAssertion, { complete: true });
+  } catch (decodeError) {
+    return { verified: false, reason: 'client_assertion could not be decoded' };
+  }
+  if (!decoded || !decoded.header) {
+    return { verified: false, reason: 'client_assertion could not be decoded' };
+  }
+
+  const alg = decoded.header.alg;
+  if (!alg || !ALLOWED_ALGS.includes(alg)) {
+    // Covers alg:none and the HS* algorithm-confusion class.
+    return { verified: false, reason: `disallowed or missing alg: ${alg || '(none)'}` };
+  }
+
+  const jwks = await resolveJwks(client, fetchImpl);
+  if (!jwks || !Array.isArray(jwks.keys) || jwks.keys.length === 0) {
+    return { verified: false, reason: 'client has no jwks / jwks_uri key material' };
+  }
+
+  // Select the key: by kid when the header names one, else the sole key.
+  const kid = decoded.header.kid;
+  let jwk;
+  if (kid) {
+    jwk = jwks.keys.find(function(k) { return k.kid === kid; });
+    if (!jwk) {
+      return { verified: false, reason: `no key in client JWKS matches kid ${kid}` };
+    }
+  } else if (jwks.keys.length === 1) {
+    jwk = jwks.keys[0];
+  } else {
+    return { verified: false, reason: 'client_assertion header has no kid and client publishes multiple keys' };
+  }
+
+  let pem;
+  try {
+    pem = createPublicKey({ key: jwk, format: 'jwk' }).export({ type: 'spki', format: 'pem' });
+  } catch (keyError) {
+    return { verified: false, reason: 'client public key could not be parsed' };
+  }
+
+  try {
+    // Pin the algorithm to the (already whitelisted) header alg; jwt.verify
+    // enforces exp when present.
+    const payload = jwt.verify(clientAssertion, pem, { algorithms: [alg] });
+    return { verified: true, payload };
+  } catch (verifyError) {
+    return { verified: false, reason: verifyError && verifyError.message ? verifyError.message : 'signature verification failed' };
+  }
+}
+
+export default { verifyClientAssertionSignature };

--- a/server/lib/verifyClientAssertion.js
+++ b/server/lib/verifyClientAssertion.js
@@ -15,8 +15,13 @@
 // confusion attempt (HMAC-signing with the public key as the secret) can never
 // verify.
 
-import jwt from 'jsonwebtoken';
-import { createPublicKey } from 'crypto';
+// CommonJS module (require + module.exports), NOT ESM export. Consumed both by
+// the Meteor server bundle and by `node --test` on CI's node 20, where a .js
+// under a type:commonjs package loads as CommonJS. Genuine CJS + default-import
+// is the repo's proven dual-context pattern (see imports/lib/loggerRedact.js,
+// Logger.js); ESM `export` + named import throws on node 20.
+const jwt = require('jsonwebtoken');
+const { createPublicKey } = require('crypto');
 
 // Asymmetric signature algorithms only. Deliberately excludes 'none' and the
 // HS* family — a client_assertion is proof-of-possession of a PRIVATE key, so
@@ -56,7 +61,7 @@ async function resolveJwks(client, fetchImpl) {
 //
 // Returns { verified: boolean, reason?: string, payload?: object }. NEVER
 // throws — the caller treats any non-verified result as invalid_client.
-export async function verifyClientAssertionSignature({ client, clientAssertion, fetchImpl } = {}) {
+async function verifyClientAssertionSignature({ client, clientAssertion, fetchImpl } = {}) {
   if (!clientAssertion) {
     return { verified: false, reason: 'no client_assertion provided' };
   }
@@ -113,4 +118,4 @@ export async function verifyClientAssertionSignature({ client, clientAssertion, 
   }
 }
 
-export default { verifyClientAssertionSignature };
+module.exports = { verifyClientAssertionSignature };

--- a/server/lib/verifyClientAssertion.js
+++ b/server/lib/verifyClientAssertion.js
@@ -20,6 +20,10 @@
 // under a type:commonjs package loads as CommonJS. Genuine CJS + default-import
 // is the repo's proven dual-context pattern (see imports/lib/loggerRedact.js,
 // Logger.js); ESM `export` + named import throws on node 20.
+// TODO(node24): this CJS style is a workaround for CI's Node 20.11 (no ESM
+// syntax detection in a .js). Once CI runs Node >=24 (via a Meteor 3.6+ upgrade),
+// this file MAY revert to clean ESM `export` + named imports. See memory
+// dual-context-lib-must-be-cjs. Confirm the CI node version before reverting.
 const jwt = require('jsonwebtoken');
 const { createPublicKey } = require('crypto');
 

--- a/server/lib/writeSanitization.js
+++ b/server/lib/writeSanitization.js
@@ -13,6 +13,10 @@
 // under a type:commonjs package loads as CommonJS. Genuine CJS + default-import
 // is the repo's proven dual-context pattern (see imports/lib/loggerRedact.js).
 
+// TODO(node24): this CJS style is a workaround for CI's Node 20.11 (no ESM
+// syntax detection in a .js). Once CI runs Node >=24 (via a Meteor 3.6+ upgrade),
+// this file MAY revert to clean ESM `export` + named imports. See memory
+// dual-context-lib-must-be-cjs. Confirm the CI node version before reverting.
 const { get, set, unset, cloneDeep } = require('lodash');
 
 // Return a copy of incomingRecord with meta.security governed by the server:

--- a/server/lib/writeSanitization.js
+++ b/server/lib/writeSanitization.js
@@ -1,0 +1,41 @@
+// server/lib/writeSanitization.js
+//
+// CR-4 remediation (security audit 2026-07-01): govern server-controlled
+// resource metadata on inbound writes (POST/PUT/PATCH in server/FhirEndpoints.js).
+// Those handlers persisted req.body wholesale, so a non-privileged client could
+// set its own meta.security access labels — e.g. POST a resource with
+// meta.security:[{display:'unrestricted'}] to self-publish PHI as world-readable
+// (the compartment filter treats 'unrestricted' as public), or relabel a
+// record's access class. The server, not the client, owns security labels.
+//
+// CommonJS module (require + module.exports), NOT ESM export — consumed both by
+// the Meteor server bundle and by `node --test` on CI's node 20, where a .js
+// under a type:commonjs package loads as CommonJS. Genuine CJS + default-import
+// is the repo's proven dual-context pattern (see imports/lib/loggerRedact.js).
+
+const { get, set, unset, cloneDeep } = require('lodash');
+
+// Return a copy of incomingRecord with meta.security governed by the server:
+//   - privileged writers (callerMaySetSecurity: system / clinician) keep their
+//     supplied labels — clinical/system labeling is legitimate.
+//   - everyone else: the client cannot set meta.security. On UPDATE the existing
+//     record's labels are preserved; on CREATE any client-supplied labels are
+//     dropped.
+// Pure — does not mutate its inputs.
+function governSecurityLabels(incomingRecord, { existingRecord = null, callerMaySetSecurity = false } = {}) {
+  const result = cloneDeep(incomingRecord);
+  if (callerMaySetSecurity) {
+    return result;
+  }
+  const existingSecurity = existingRecord ? get(existingRecord, 'meta.security') : undefined;
+  if (existingSecurity !== undefined) {
+    // Preserve the server's existing labels; the client cannot change them.
+    set(result, 'meta.security', cloneDeep(existingSecurity));
+  } else if (get(result, 'meta.security') !== undefined) {
+    // No prior label; drop any client-supplied one.
+    unset(result, 'meta.security');
+  }
+  return result;
+}
+
+module.exports = { governSecurityLabels };

--- a/server/main.js
+++ b/server/main.js
@@ -5,6 +5,9 @@ import '/imports/startup/both/loggingSetup.js';
 import LoggerModule from '/imports/lib/Logger.js';
 const log = LoggerModule.Logger.for('main');
 
+import assertSecureConfigModule from './lib/assertSecureConfig.js';
+const { checkProductionAuthConfig } = assertSecureConfigModule;
+
 // Log immediately to see if we're reaching this point
 log.info('==========================================================================================');
 log.info('Starting server initialization...', { TEST_RUN: process.env.TEST_RUN, ENABLE_SYNCED_CRON: process.env.ENABLE_SYNCED_CRON });
@@ -451,6 +454,44 @@ Meteor.startup(function() {
     initializeWorkflowHooks();
   } catch (e) {
     log.error('Failed to initialize workflow hooks', { error: e && e.message, stack: e && e.stack });
+  }
+});
+
+// CR-2 (security audit 2026-07-01): fail-closed config assertion. A PRODUCTION
+// deployment must not ACCIDENTALLY boot with OAuth or access control disabled —
+// that silently opens the FHIR API to unauthenticated access. Local dev
+// (Meteor.isDevelopment) is never blocked; it legitimately runs disableOauth.
+//
+// An INTENTIONAL open sandbox (unauthenticated FHIR API by design — a supported
+// deployment posture) declares itself via settings.private.fhir.openSandbox:true
+// (or OPEN_SANDBOX=true). When declared, production boots normally with an
+// informational notice. When NOT declared, auth-off in production is treated as
+// an accident and the server refuses to boot.
+Meteor.startup(function() {
+  const settingsOpenSandbox =
+    Meteor.settings && Meteor.settings.private && Meteor.settings.private.fhir &&
+    Meteor.settings.private.fhir.openSandbox === true;
+  const sandboxAcknowledged = settingsOpenSandbox || process.env.OPEN_SANDBOX === 'true';
+
+  const configCheck = checkProductionAuthConfig({
+    settings: Meteor.settings,
+    isProduction: Meteor.isProduction,
+    sandboxAcknowledged: sandboxAcknowledged
+  });
+
+  if (!configCheck.secure) {
+    log.error('FATAL: refusing to boot — production deployment has authentication/access control disabled and is not declared an open sandbox', {
+      violations: configCheck.violations,
+      remedy: 'enable OAuth + access control for production, OR declare an intentional open sandbox via settings.private.fhir.openSandbox:true (or OPEN_SANDBOX=true)'
+    });
+    // Fail closed: do not serve requests with an accidentally-insecure config.
+    process.exit(1);
+  }
+
+  if (configCheck.sandboxMode) {
+    log.warn('Open sandbox mode: the FHIR API is UNAUTHENTICATED by configuration (settings.private.fhir.openSandbox)', {
+      unauthenticated: configCheck.violations
+    });
   }
 });
 

--- a/settings/accounts.multiuser.settings.template.json
+++ b/settings/accounts.multiuser.settings.template.json
@@ -69,7 +69,7 @@
     "accounts": {
       "authMode": "traditional",
       "adminUsername": "admin",
-      "adminPassword": "changeme123",
+      "adminPassword": "",
       "emailFrom": "noreply@honeycomb.app",
       "sendWelcomeEmail": false,
       "defaultRole": "user",
@@ -99,11 +99,11 @@
       "oauth": {
         "google": {
           "clientId": "YOUR_GOOGLE_CLIENT_ID",
-          "secret": "YOUR_GOOGLE_SECRET"
+          "secret": ""
         },
         "github": {
-          "clientId": "YOUR_GITHUB_CLIENT_ID", 
-          "secret": "YOUR_GITHUB_SECRET"
+          "clientId": "YOUR_GITHUB_CLIENT_ID",
+          "secret": ""
         }
       },
       "blockedDomains": [],
@@ -115,7 +115,10 @@
     "security": {
       "cors": {
         "enabled": true,
-        "allowedOrigins": ["http://localhost:3000", "http://localhost:3100"]
+        "allowedOrigins": [
+          "http://localhost:3000",
+          "http://localhost:3100"
+        ]
       },
       "ipWhitelist": [],
       "ipBlacklist": [],
@@ -132,7 +135,7 @@
         "port": 587,
         "secure": false,
         "username": "YOUR_SMTP_USERNAME",
-        "password": "YOUR_SMTP_PASSWORD"
+        "password": ""
       }
     },
     "logging": {

--- a/settings/settings.pacio.template.json
+++ b/settings/settings.pacio.template.json
@@ -16,38 +16,33 @@
       "palette": {
         "primaryColor": "#4A90A4",
         "primaryText": "rgba(255, 255, 255, 1) !important",
-        
         "secondaryColor": "#67B3CC",
         "secondaryText": "rgba(255, 255, 255, 1) !important",
-        
         "cardColor": "#ffffff !important",
         "cardTextColor": "rgba(0, 0, 0, 1) !important",
-        
         "errorColor": "rgb(128,20,60) !important",
         "errorText": "#ffffff !important",
-        
         "appBarColor": "#2C3E50 !important",
         "appBarTextColor": "#ffffff !important",
-        
         "paperColor": "#ffffff !important",
         "paperTextColor": "rgba(0, 0, 0, 1) !important",
-        
         "backgroundCanvas": "#f5f7fa",
         "background": "linear-gradient(45deg, #4A90A4 30%, #67B3CC 90%)",
-        
         "nivoTheme": "blue_green"
       }
     },
     "loggingThreshold": "debug",
     "fhirAutoSubscribe": true,
-    "smartOnFhir": [{
-      "vendor": "PACIO Project",
-      "client_id": "pacio-honeycomb-client",
-      "scope": "launch launch/patient patient/read patient/write offline_access fhirUser openid profile patient/Observation.read patient/DocumentReference.read patient/DocumentReference.write patient/Composition.read patient/Composition.write patient/Goal.read patient/Goal.write patient/NutritionOrder.read patient/NutritionOrder.write patient/ServiceRequest.read patient/ServiceRequest.write patient/List.read patient/List.write patient/Binary.read patient/Binary.write",
-      "fhirServiceUrl": "https://api.logicahealth.org/paciotest/data",
-      "redirect_uri": "./patient-quickchart",
-      "iss": ""
-    }],
+    "smartOnFhir": [
+      {
+        "vendor": "PACIO Project",
+        "client_id": "pacio-honeycomb-client",
+        "scope": "launch launch/patient patient/read patient/write offline_access fhirUser openid profile patient/Observation.read patient/DocumentReference.read patient/DocumentReference.write patient/Composition.read patient/Composition.write patient/Goal.read patient/Goal.write patient/NutritionOrder.read patient/NutritionOrder.write patient/ServiceRequest.read patient/ServiceRequest.write patient/List.read patient/List.write patient/Binary.read patient/Binary.write",
+        "fhirServiceUrl": "https://api.logicahealth.org/paciotest/data",
+        "redirect_uri": "./patient-quickchart",
+        "iss": ""
+      }
+    ],
     "capabilityStatement": {
       "resourceTypes": [
         "AllergyIntolerance",
@@ -263,82 +258,171 @@
       "autopublishSubscriptions": true,
       "rest": {
         "Binary": {
-          "interactions": ["read", "create", "update", "delete"],
+          "interactions": [
+            "read",
+            "create",
+            "update",
+            "delete"
+          ],
           "search": false,
           "publication": true
         },
         "CareTeam": {
-          "interactions": ["read", "create", "update", "delete", "search"],
+          "interactions": [
+            "read",
+            "create",
+            "update",
+            "delete",
+            "search"
+          ],
           "search": true,
           "publication": true
         },
         "CarePlan": {
-          "interactions": ["read", "create", "update", "delete", "search"],
+          "interactions": [
+            "read",
+            "create",
+            "update",
+            "delete",
+            "search"
+          ],
           "search": true,
           "publication": true
         },
         "Communication": {
-          "interactions": ["read", "create", "update", "delete", "search"],
+          "interactions": [
+            "read",
+            "create",
+            "update",
+            "delete",
+            "search"
+          ],
           "search": true,
           "publication": true
         },
         "Composition": {
-          "interactions": ["read", "create", "update", "delete", "search"],
+          "interactions": [
+            "read",
+            "create",
+            "update",
+            "delete",
+            "search"
+          ],
           "search": true,
           "publication": true
         },
         "Condition": {
-          "interactions": ["read", "create", "update", "delete", "search"],
+          "interactions": [
+            "read",
+            "create",
+            "update",
+            "delete",
+            "search"
+          ],
           "search": true,
           "publication": true
         },
         "Consent": {
-          "interactions": ["read", "create", "update", "delete", "search"],
+          "interactions": [
+            "read",
+            "create",
+            "update",
+            "delete",
+            "search"
+          ],
           "search": true,
           "publication": true
         },
         "DocumentReference": {
-          "interactions": ["read", "create", "update", "delete", "search"],
+          "interactions": [
+            "read",
+            "create",
+            "update",
+            "delete",
+            "search"
+          ],
           "search": true,
           "publication": true
         },
         "Goal": {
-          "interactions": ["read", "create", "update", "delete", "search"],
+          "interactions": [
+            "read",
+            "create",
+            "update",
+            "delete",
+            "search"
+          ],
           "search": true,
           "publication": true
         },
         "List": {
-          "interactions": ["read", "create", "update", "delete", "search"],
+          "interactions": [
+            "read",
+            "create",
+            "update",
+            "delete",
+            "search"
+          ],
           "search": true,
           "publication": true
         },
         "Location": {
-          "interactions": ["read", "create", "update", "delete", "search"],
+          "interactions": [
+            "read",
+            "create",
+            "update",
+            "delete",
+            "search"
+          ],
           "search": true,
           "publication": true
         },
         "NutritionOrder": {
-          "interactions": ["read", "create", "update", "delete", "search"],
+          "interactions": [
+            "read",
+            "create",
+            "update",
+            "delete",
+            "search"
+          ],
           "search": true,
           "publication": true
         },
         "Observation": {
-          "interactions": ["read", "create", "update", "delete", "search"],
+          "interactions": [
+            "read",
+            "create",
+            "update",
+            "delete",
+            "search"
+          ],
           "search": true,
           "publication": true
         },
         "Patient": {
-          "interactions": ["read", "search"],
+          "interactions": [
+            "read",
+            "search"
+          ],
           "search": true,
           "publication": true
         },
         "Practitioner": {
-          "interactions": ["read", "search"],
+          "interactions": [
+            "read",
+            "search"
+          ],
           "search": true,
           "publication": true
         },
         "ServiceRequest": {
-          "interactions": ["read", "create", "update", "delete", "search"],
+          "interactions": [
+            "read",
+            "create",
+            "update",
+            "delete",
+            "search"
+          ],
           "search": true,
           "publication": true
         }
@@ -360,13 +444,15 @@
       },
       "advanceDirectives": {
         "maxFileSize": 10485760,
-        "allowedFileTypes": ["application/pdf"],
+        "allowedFileTypes": [
+          "application/pdf"
+        ],
         "requireSignature": false
       }
     },
-    "accountServerTokenSecret": "pacio-secret-token-change-in-production",
+    "accountServerTokenSecret": "",
     "google": {
-      "mapsApiKey": "YOUR_GOOGLE_MAPS_API_KEY_HERE"
+      "mapsApiKey": ""
     }
   }
 }

--- a/tests/unit/server/lib/assertSecureConfig.test.mjs
+++ b/tests/unit/server/lib/assertSecureConfig.test.mjs
@@ -1,0 +1,74 @@
+// tests/unit/server/lib/assertSecureConfig.test.mjs
+//
+// CR-2 reproduction + regression test (security audit 2026-07-01).
+//
+// The hole: disableOauth:true (and disableAccessControl:true) ship in settings
+// files. A production profile inheriting one opens the FHIR API to
+// unauthenticated access. The reads already default secure (absent = enabled),
+// so the teeth is a startup assertion that refuses to boot a PRODUCTION
+// deployment with either flag set — while leaving local dev (which legitimately
+// runs disableOauth:true) untouched.
+//
+// Drives server/lib/assertSecureConfig.js — the pure checker the startup
+// assertion calls. Run: node --test tests/unit/server/lib/assertSecureConfig.test.mjs
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import assertSecureConfigModule from '../../../../server/lib/assertSecureConfig.js';
+const { checkProductionAuthConfig } = assertSecureConfigModule;
+
+// --- dev is never blocked (localhost runs disableOauth:true by design) --------
+
+test('development is always secure — the flags are allowed in dev', () => {
+  const settings = { private: { fhir: { disableOauth: true, disableAccessControl: true } } };
+  const r = checkProductionAuthConfig({ settings, isProduction: false });
+  assert.equal(r.secure, true);
+  assert.equal(r.violations.length, 0);
+});
+
+// --- production with the flags off is fine ------------------------------------
+
+test('production with auth enabled (flags absent) is secure', () => {
+  const r = checkProductionAuthConfig({ settings: { private: { fhir: {} } }, isProduction: true });
+  assert.equal(r.secure, true);
+});
+
+// --- the vulnerability: production must refuse the disable flags ---------------
+
+test('production with disableOauth:true is INSECURE (would refuse boot)', () => {
+  const settings = { private: { fhir: { disableOauth: true } } };
+  const r = checkProductionAuthConfig({ settings, isProduction: true });
+  assert.equal(r.secure, false);
+  assert.ok(r.violations.some(v => v.includes('disableOauth')));
+});
+
+test('production with disableAccessControl:true is INSECURE', () => {
+  const settings = { private: { fhir: { disableAccessControl: true } } };
+  const r = checkProductionAuthConfig({ settings, isProduction: true });
+  assert.equal(r.secure, false);
+  assert.ok(r.violations.some(v => v.includes('disableAccessControl')));
+});
+
+test('both flags produce two violations', () => {
+  const settings = { private: { fhir: { disableOauth: true, disableAccessControl: true } } };
+  const r = checkProductionAuthConfig({ settings, isProduction: true });
+  assert.equal(r.secure, false);
+  assert.equal(r.violations.length, 2);
+});
+
+// --- intentional open sandbox is a supported first-class mode -----------------
+
+test('a declared open sandbox lets production boot with auth off (supported mode)', () => {
+  const settings = { private: { fhir: { disableOauth: true } } };
+  const r = checkProductionAuthConfig({ settings, isProduction: true, sandboxAcknowledged: true });
+  assert.equal(r.secure, true, 'a declared open sandbox is allowed to boot');
+  assert.equal(r.sandboxMode, true, 'flagged as sandbox mode for the informational notice');
+  assert.ok(r.violations.length > 0, 'the disabled flags are still reported');
+});
+
+test('the sandbox declaration is a no-op when config is already secure', () => {
+  const r = checkProductionAuthConfig({ settings: { private: { fhir: {} } }, isProduction: true, sandboxAcknowledged: true });
+  assert.equal(r.secure, true);
+  assert.equal(r.sandboxMode, false);
+});

--- a/tests/unit/server/lib/outboundUrlGuard.test.mjs
+++ b/tests/unit/server/lib/outboundUrlGuard.test.mjs
@@ -1,0 +1,74 @@
+// tests/unit/server/lib/outboundUrlGuard.test.mjs
+//
+// CR-10 reproduction + regression test (security audit 2026-07-01).
+//
+// The hole: the UDAP registration flow fetches URLs extracted verbatim from a
+// caller-supplied certificate's authorityInfoAccess / cRLDistributionPoints
+// extensions (OAuthEndpoints.js recursive fetchCertificate / fetchRevokationList),
+// with no host validation. A crafted cert makes the server fetch internal
+// endpoints — cloud metadata (169.254.169.254), loopback, private ranges (SSRF).
+//
+// Drives server/lib/outboundUrlGuard.js — isSafeOutboundUrl(), which the fetch
+// sites now consult before making a request.
+// Run: node --test tests/unit/server/lib/outboundUrlGuard.test.mjs
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import outboundUrlGuardModule from '../../../../server/lib/outboundUrlGuard.js';
+const { isSafeOutboundUrl } = outboundUrlGuardModule;
+
+// --- the vulnerability: internal / metadata / private targets are blocked -----
+
+test('blocks the cloud-metadata IMDS address (the sharpest SSRF)', () => {
+  assert.equal(isSafeOutboundUrl('http://169.254.169.254/latest/meta-data/').safe, false);
+});
+
+test('blocks loopback (v4 + v6) and localhost', () => {
+  assert.equal(isSafeOutboundUrl('http://127.0.0.1/x').safe, false);
+  assert.equal(isSafeOutboundUrl('http://localhost:8080/x').safe, false);
+  assert.equal(isSafeOutboundUrl('http://[::1]/x').safe, false);
+});
+
+test('blocks RFC-1918 private ranges', () => {
+  for (const h of ['http://10.0.0.5/', 'http://172.16.0.1/', 'http://172.31.255.1/', 'http://192.168.1.1/']) {
+    assert.equal(isSafeOutboundUrl(h).safe, false, h);
+  }
+});
+
+test('blocks internal-looking hostnames and metadata alias', () => {
+  assert.equal(isSafeOutboundUrl('http://foo.internal/x').safe, false);
+  assert.equal(isSafeOutboundUrl('http://db.local/x').safe, false);
+  assert.equal(isSafeOutboundUrl('http://metadata.google.internal/x').safe, false);
+});
+
+test('blocks non-http(s) schemes', () => {
+  assert.equal(isSafeOutboundUrl('file:///etc/passwd').safe, false);
+  assert.equal(isSafeOutboundUrl('gopher://x/').safe, false);
+});
+
+test('rejects an unparseable url', () => {
+  assert.equal(isSafeOutboundUrl('not a url').safe, false);
+  assert.equal(isSafeOutboundUrl('').safe, false);
+});
+
+// --- legitimate public CA endpoints are allowed ------------------------------
+
+test('allows a public https CA endpoint', () => {
+  assert.equal(isSafeOutboundUrl('https://certs.ca.example.com/aia/intermediate.crt').safe, true);
+  assert.equal(isSafeOutboundUrl('http://crl.ca.example.com/list.crl').safe, true);
+});
+
+// --- optional allowlist tightens to specific hosts ---------------------------
+
+test('an allowlist, when configured, restricts to matching hosts (suffix match)', () => {
+  const opts = { allowlist: ['ca.example.com'] };
+  assert.equal(isSafeOutboundUrl('https://certs.ca.example.com/x', opts).safe, true, 'subdomain matches');
+  assert.equal(isSafeOutboundUrl('https://ca.example.com/x', opts).safe, true, 'exact matches');
+  assert.equal(isSafeOutboundUrl('https://evil.example.org/x', opts).safe, false, 'non-listed host blocked');
+});
+
+test('an internal target is still blocked even if the allowlist would match', () => {
+  const opts = { allowlist: ['internal'] };
+  assert.equal(isSafeOutboundUrl('http://foo.internal/x', opts).safe, false);
+});

--- a/tests/unit/server/lib/patientCompartment.test.mjs
+++ b/tests/unit/server/lib/patientCompartment.test.mjs
@@ -1,0 +1,155 @@
+// tests/unit/server/lib/patientCompartment.test.mjs
+//
+// CR-3 reproduction + regression test (security audit 2026-07-01).
+//
+// The hole: the FHIR instance handlers — GET/DELETE/PATCH /baseR4/<Resource>/:id
+// — looked resources up by `id` alone, with none of the patient-compartment
+// filtering the SEARCH handler applies. A patient-scoped token could read,
+// delete, or patch ANY patient's resource by guessing/knowing its id (IDOR).
+//
+// These tests drive server/lib/patientCompartment.js — the extracted predicate
+// (recordMatchesCompartment) and role gate (isCompartmentExempt) the instance
+// handlers now consult before touching a record. The logic mirrors the search
+// handler's inline authQuery (FhirEndpoints.js:1259-1339) as the single source
+// of truth.
+//
+// Run: node --test tests/unit/server/lib/patientCompartment.test.mjs
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { isCompartmentExempt, recordMatchesCompartment, buildPatientCompartmentQuery } from '../../../../server/lib/patientCompartment.js';
+
+// --- the vulnerability: a patient must not match another patient's record -----
+
+test('a patient token does NOT match another patient\'s resource (subject.reference)', () => {
+  const record = { resourceType: 'Observation', id: 'obs1', subject: { reference: 'Patient/A' } };
+  const ctxOther = { role: 'patient', patientId: 'B' };
+  assert.equal(recordMatchesCompartment(record, ctxOther, 'Observation'), false);
+});
+
+test('a patient token DOES match its own resource across the three ref formats', () => {
+  const ctx = { role: 'patient', patientId: 'A' };
+  for (const ref of ['A', 'Patient/A', 'urn:uuid:A']) {
+    assert.equal(recordMatchesCompartment({ subject: { reference: ref } }, ctx, 'Observation'), true, ref);
+    assert.equal(recordMatchesCompartment({ patient: { reference: ref } }, ctx, 'AllergyIntolerance'), true, ref);
+    assert.equal(recordMatchesCompartment({ beneficiary: { reference: ref } }, ctx, 'Coverage'), true, ref);
+  }
+});
+
+test('Patient resource: token matches only its own Patient record by id', () => {
+  const ctx = { role: 'patient', patientId: 'A' };
+  assert.equal(recordMatchesCompartment({ resourceType: 'Patient', id: 'A' }, ctx, 'Patient'), true);
+  assert.equal(recordMatchesCompartment({ resourceType: 'Patient', id: 'B' }, ctx, 'Patient'), false);
+});
+
+test('an unrestricted meta.security label is public to any compartment', () => {
+  const record = { subject: { reference: 'Patient/A' }, meta: { security: [{ display: 'unrestricted' }] } };
+  assert.equal(recordMatchesCompartment(record, { role: 'patient', patientId: 'B' }, 'Observation'), true);
+});
+
+test('no patient context in the token matches nothing (fail closed)', () => {
+  const record = { subject: { reference: 'Patient/A' } };
+  assert.equal(recordMatchesCompartment(record, { role: 'patient' }, 'Observation'), false);
+});
+
+test('a record with no matching reference is denied', () => {
+  const record = { resourceType: 'Observation', id: 'x' };
+  assert.equal(recordMatchesCompartment(record, { role: 'patient', patientId: 'A' }, 'Observation'), false);
+});
+
+// --- the role gate: who bypasses the compartment ------------------------------
+
+test('SYSTEM and noauth roles are exempt (no compartment filtering)', () => {
+  assert.equal(isCompartmentExempt({ role: 'SYSTEM', resourceType: 'Observation' }), true);
+  assert.equal(isCompartmentExempt({ role: 'noauth', resourceType: 'Observation' }), true);
+});
+
+test('a practitioner is exempt only when practitionerFullAccess is on', () => {
+  assert.equal(isCompartmentExempt({ role: 'healthcare practitioner', resourceType: 'Observation', practitionerFullAccess: true }), true);
+  assert.equal(isCompartmentExempt({ role: 'healthcare practitioner', resourceType: 'Observation', practitionerFullAccess: false }), false);
+});
+
+test('reference/organizational resource types are exempt', () => {
+  for (const rt of ['Location', 'Practitioner', 'Organization', 'HealthcareService', 'Endpoint', 'PractitionerRole']) {
+    assert.equal(isCompartmentExempt({ role: 'patient', resourceType: rt }), true, rt);
+  }
+});
+
+test('a patient role on a compartment resource is NOT exempt (the case that closes the hole)', () => {
+  assert.equal(isCompartmentExempt({ role: 'patient', resourceType: 'Observation', practitionerFullAccess: true }), false);
+  // unknown/default roles also fall through to filtering (fail closed)
+  assert.equal(isCompartmentExempt({ role: 'PAT', resourceType: 'Observation' }), false);
+});
+
+// --- the search query form (buildPatientCompartmentQuery) ---------------------
+
+test('search query for a compartment resource includes unrestricted + the three ref paths', () => {
+  const q = buildPatientCompartmentQuery({ role: 'patient', patientId: 'A' }, 'Observation');
+  assert.ok(Array.isArray(q.$or));
+  const refs = ['A', 'Patient/A', 'urn:uuid:A'];
+  assert.deepEqual(q.$or[0], { 'meta.security.display': { $eq: 'unrestricted' } });
+  assert.deepEqual(q.$or.find(c => c['subject.reference']), { 'subject.reference': { $in: refs } });
+  assert.deepEqual(q.$or.find(c => c['patient.reference']), { 'patient.reference': { $in: refs } });
+  assert.deepEqual(q.$or.find(c => c['beneficiary.reference']), { 'beneficiary.reference': { $in: refs } });
+});
+
+test('search query for Patient resource keys on id + generalPractitioner', () => {
+  const q = buildPatientCompartmentQuery({ role: 'patient', patientId: 'A', practitionerId: 'P1' }, 'Patient');
+  assert.deepEqual(q.$or.find(c => c.id), { id: 'A' });
+  assert.deepEqual(q.$or.find(c => c['generalPractitioner.reference']), { 'generalPractitioner.reference': { $regex: 'P1' } });
+});
+
+test('search query with no patient context is just the unrestricted clause', () => {
+  const q = buildPatientCompartmentQuery({ role: 'patient' }, 'Observation');
+  assert.deepEqual(q.$or, [{ 'meta.security.display': { $eq: 'unrestricted' } }]);
+});
+
+// The query (search) and the predicate (instance handlers) must agree on the
+// SAME record set — that agreement is the whole point of the shared module.
+// Evaluate the $or against sample records the way MongoDB would, and confirm it
+// matches recordMatchesCompartment for each.
+test('search query and instance predicate agree on the same records (coherence)', () => {
+  const ctx = { role: 'patient', patientId: 'A' };
+  const q = buildPatientCompartmentQuery(ctx, 'Observation');
+
+  // Resolve a dotted path the way MongoDB does — traversing INTO arrays, so
+  // 'meta.security.display' yields every array element's display value.
+  function valuesAtPath(record, path) {
+    return path.split('.').reduce(function(acc, key) {
+      const next = [];
+      for (const node of acc) {
+        if (node == null) { continue; }
+        const v = node[key];
+        if (Array.isArray(v)) { next.push(...v); }
+        else if (v !== undefined) { next.push(v); }
+      }
+      return next;
+    }, [record]);
+  }
+
+  function matchesOr(record) {
+    return q.$or.some(function(clause) {
+      const [path, cond] = Object.entries(clause)[0];
+      const values = valuesAtPath(record, path);
+      return values.some(function(value) {
+        if (cond && cond.$eq !== undefined) { return value === cond.$eq; }
+        if (cond && cond.$in !== undefined) { return cond.$in.includes(value); }
+        return value === cond;
+      });
+    });
+  }
+
+  const records = [
+    { subject: { reference: 'Patient/A' } },                                   // own → match
+    { subject: { reference: 'Patient/B' } },                                   // other → deny
+    { patient: { reference: 'urn:uuid:A' } },                                  // own (alt path) → match
+    { beneficiary: { reference: 'A' } },                                       // own (bare) → match
+    { subject: { reference: 'Patient/B' }, meta: { security: [{ display: 'unrestricted' }] } }, // public → match
+    { id: 'z' }                                                                // nothing → deny
+  ];
+  for (const r of records) {
+    assert.equal(matchesOr(r), recordMatchesCompartment(r, ctx, 'Observation'),
+      'query and predicate disagree on ' + JSON.stringify(r));
+  }
+});

--- a/tests/unit/server/lib/patientCompartment.test.mjs
+++ b/tests/unit/server/lib/patientCompartment.test.mjs
@@ -18,7 +18,10 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 
-import { isCompartmentExempt, recordMatchesCompartment, buildPatientCompartmentQuery } from '../../../../server/lib/patientCompartment.js';
+// Default-import + destructure (see verifyClientAssertion.test.mjs): named ESM
+// imports of a type:commonjs .js throw on CI's node 20; the default export works.
+import patientCompartmentModule from '../../../../server/lib/patientCompartment.js';
+const { isCompartmentExempt, recordMatchesCompartment, buildPatientCompartmentQuery } = patientCompartmentModule;
 
 // --- the vulnerability: a patient must not match another patient's record -----
 

--- a/tests/unit/server/lib/verifyClientAssertion.test.mjs
+++ b/tests/unit/server/lib/verifyClientAssertion.test.mjs
@@ -1,0 +1,134 @@
+// server/lib/verifyClientAssertion.test.mjs
+//
+// CR-1 reproduction + regression test (security audit 2026-07-01).
+//
+// The hole: the /oauth/token client_credentials + jwt-bearer path decoded the
+// client_assertion and issued a system access_token WITHOUT verifying the JWT
+// signature (OAuthEndpoints.js had a literal "TODO: Verify JWT signature"). Any
+// party could forge an assertion for a registered backend-services client and
+// receive a system/*.* bearer token.
+//
+// These tests drive server/lib/verifyClientAssertion.js — the extracted,
+// pure verification helper that BOTH /oauth/token call sites now use before
+// issuing a token: the client_credentials + jwt-bearer path (the original CR-1
+// hole) and the SMART-asymmetric path (unified onto the same helper 2026-07-24,
+// which also gained the alg-whitelist hardening these tests assert).
+// Run: node --test tests/unit/server/lib/verifyClientAssertion.test.mjs
+//
+// Placement: tests/unit/ mirrors the source tree (tests/unit/server/lib/ ↔
+// server/lib/). See .claude/rules/testing/test-organization.md.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { generateKeyPairSync, createPublicKey, randomUUID } from 'node:crypto';
+import jwt from 'jsonwebtoken';
+
+import { verifyClientAssertionSignature } from '../../../../server/lib/verifyClientAssertion.js';
+
+// --- helpers ---------------------------------------------------------------
+
+// Make an RSA keypair and its public JWK (with a kid), as a registered client
+// would publish in its JWKS.
+function makeKeypair(kid) {
+  const { publicKey, privateKey } = generateKeyPairSync('rsa', { modulusLength: 2048 });
+  const jwk = publicKey.export({ format: 'jwk' });
+  jwk.kid = kid;
+  jwk.alg = 'RS256';
+  jwk.use = 'sig';
+  return { privateKey, publicJwk: jwk };
+}
+
+function signAssertion(privateKey, kid, claims = {}) {
+  const iss = claims.iss || 'backend-client-123';
+  return jwt.sign(
+    { iss, sub: iss, aud: 'https://example.org/oauth/token', jti: randomUUID(), ...claims },
+    privateKey,
+    { algorithm: 'RS256', keyid: kid, expiresIn: '5m' }
+  );
+}
+
+// --- the vulnerability: wrong-key signatures must be rejected ---------------
+
+test('rejects an assertion signed by a key that is NOT the client\'s registered key', async () => {
+  const attacker = makeKeypair('kid-attacker');
+  const registered = makeKeypair('kid-registered');
+
+  // Attacker forges an assertion for a client whose JWKS holds a DIFFERENT key.
+  const forged = signAssertion(attacker.privateKey, 'kid-attacker');
+  const client = { _id: 'backend-client-123', jwks: { keys: [registered.publicJwk] } };
+
+  const result = await verifyClientAssertionSignature({ client, clientAssertion: forged });
+  assert.equal(result.verified, false, 'forged assertion must NOT verify');
+});
+
+test('rejects when the kid in the assertion is not present in the client JWKS', async () => {
+  const registered = makeKeypair('kid-registered');
+  const other = makeKeypair('kid-missing');
+  const assertion = signAssertion(other.privateKey, 'kid-missing');
+  const client = { _id: 'c1', jwks: { keys: [registered.publicJwk] } };
+
+  const result = await verifyClientAssertionSignature({ client, clientAssertion: assertion });
+  assert.equal(result.verified, false);
+});
+
+test('rejects a client that has no key material (no jwks, no jwks_uri)', async () => {
+  const kp = makeKeypair('kid-1');
+  const assertion = signAssertion(kp.privateKey, 'kid-1');
+  const client = { _id: 'c1' };
+
+  const result = await verifyClientAssertionSignature({ client, clientAssertion: assertion });
+  assert.equal(result.verified, false);
+  assert.match(result.reason, /no.*key|jwks/i);
+});
+
+test('rejects the alg=none downgrade even for a registered client', async () => {
+  const registered = makeKeypair('kid-registered');
+  // Unsigned token with alg:none.
+  const noneToken = jwt.sign({ iss: 'c1', sub: 'c1' }, '', { algorithm: 'none' });
+  const client = { _id: 'c1', jwks: { keys: [registered.publicJwk] } };
+
+  const result = await verifyClientAssertionSignature({ client, clientAssertion: noneToken });
+  assert.equal(result.verified, false, 'alg=none must never verify');
+});
+
+// --- the legitimate path still works ---------------------------------------
+
+test('accepts an assertion correctly signed by the client\'s registered inline JWKS key', async () => {
+  const kp = makeKeypair('kid-good');
+  const assertion = signAssertion(kp.privateKey, 'kid-good');
+  const client = { _id: 'backend-client-123', jwks: { keys: [kp.publicJwk] } };
+
+  const result = await verifyClientAssertionSignature({ client, clientAssertion: assertion });
+  assert.equal(result.verified, true, result.reason);
+  assert.equal(result.payload.iss, 'backend-client-123');
+});
+
+test('resolves JWKS from jwks_uri via the injected fetch and verifies', async () => {
+  const kp = makeKeypair('kid-remote');
+  const assertion = signAssertion(kp.privateKey, 'kid-remote');
+  const client = { _id: 'c1', jwks_uri: 'https://client.example/jwks.json' };
+
+  // Injected fetch stub — keeps the unit test offline.
+  const fetchImpl = async function(url) {
+    assert.equal(url, 'https://client.example/jwks.json');
+    return { ok: true, json: async () => ({ keys: [kp.publicJwk] }) };
+  };
+
+  const result = await verifyClientAssertionSignature({ client, clientAssertion: assertion, fetchImpl });
+  assert.equal(result.verified, true, result.reason);
+});
+
+test('rejects an expired assertion even with a valid signature', async () => {
+  const kp = makeKeypair('kid-exp');
+  // Signed correctly but already expired.
+  const expired = jwt.sign(
+    { iss: 'c1', sub: 'c1', exp: Math.floor(Date.now() / 1000) - 60 },
+    kp.privateKey,
+    { algorithm: 'RS256', keyid: 'kid-exp' }
+  );
+  const client = { _id: 'c1', jwks: { keys: [kp.publicJwk] } };
+
+  const result = await verifyClientAssertionSignature({ client, clientAssertion: expired });
+  assert.equal(result.verified, false);
+  assert.match(result.reason, /expired|exp/i);
+});

--- a/tests/unit/server/lib/verifyClientAssertion.test.mjs
+++ b/tests/unit/server/lib/verifyClientAssertion.test.mjs
@@ -23,7 +23,11 @@ import assert from 'node:assert/strict';
 import { generateKeyPairSync, createPublicKey, randomUUID } from 'node:crypto';
 import jwt from 'jsonwebtoken';
 
-import { verifyClientAssertionSignature } from '../../../../server/lib/verifyClientAssertion.js';
+// Default-import + destructure (not named import): the helper is a .js under a
+// type:commonjs package, so node loads it as CommonJS on CI (node 20). A named
+// ESM import throws there; the default export object works on every node.
+import verifyClientAssertionModule from '../../../../server/lib/verifyClientAssertion.js';
+const { verifyClientAssertionSignature } = verifyClientAssertionModule;
 
 // --- helpers ---------------------------------------------------------------
 

--- a/tests/unit/server/lib/writeSanitization.test.mjs
+++ b/tests/unit/server/lib/writeSanitization.test.mjs
@@ -1,0 +1,67 @@
+// tests/unit/server/lib/writeSanitization.test.mjs
+//
+// CR-4 reproduction + regression test (security audit 2026-07-01).
+//
+// The hole: POST/PUT/PATCH persisted req.body wholesale, so a client could set
+// its own meta.security access labels — e.g. POST a resource with
+// meta.security:[{display:'unrestricted'}] to self-publish PHI as world-readable
+// (the compartment filter treats 'unrestricted' as public), or relabel a
+// record's access class. The server, not the client, must own security labels.
+//
+// These tests drive server/lib/writeSanitization.js — governSecurityLabels(),
+// which the write handlers now apply to inbound resources.
+//
+// Run: node --test tests/unit/server/lib/writeSanitization.test.mjs
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+// Default-import + destructure (see verifyClientAssertion.test.mjs): named ESM
+// imports of a type:commonjs .js throw on CI's node 20; the default export works.
+import writeSanitizationModule from '../../../../server/lib/writeSanitization.js';
+const { governSecurityLabels } = writeSanitizationModule;
+
+// --- the vulnerability: a non-privileged client cannot set security labels ----
+
+test('CREATE: a client-supplied unrestricted label is stripped for a non-privileged writer', () => {
+  const incoming = { resourceType: 'Observation', subject: { reference: 'Patient/A' }, meta: { security: [{ display: 'unrestricted' }] } };
+  const out = governSecurityLabels(incoming, { existingRecord: null, callerMaySetSecurity: false });
+  assert.equal(out.meta.security, undefined, 'client security label must not survive create');
+});
+
+test('UPDATE: the existing server label is preserved, not the client-supplied one', () => {
+  const existing = { meta: { security: [{ display: 'restricted' }] } };
+  const incoming = { resourceType: 'Observation', meta: { security: [{ display: 'unrestricted' }] } };
+  const out = governSecurityLabels(incoming, { existingRecord: existing, callerMaySetSecurity: false });
+  assert.deepEqual(out.meta.security, [{ display: 'restricted' }], 'server label must win over client label on update');
+});
+
+test('UPDATE with no prior label: a client-supplied label is dropped', () => {
+  const existing = { resourceType: 'Observation' }; // no meta.security
+  const incoming = { meta: { security: [{ display: 'unrestricted' }] } };
+  const out = governSecurityLabels(incoming, { existingRecord: existing, callerMaySetSecurity: false });
+  assert.equal(out.meta.security, undefined);
+});
+
+// --- privileged writers (system / clinician) may label legitimately -----------
+
+test('a privileged writer keeps its supplied security label', () => {
+  const incoming = { meta: { security: [{ display: 'restricted' }] } };
+  const out = governSecurityLabels(incoming, { existingRecord: null, callerMaySetSecurity: true });
+  assert.deepEqual(out.meta.security, [{ display: 'restricted' }]);
+});
+
+// --- benign passthrough + purity ---------------------------------------------
+
+test('a resource with no security label is unchanged for a non-privileged writer', () => {
+  const incoming = { resourceType: 'Observation', subject: { reference: 'Patient/A' } };
+  const out = governSecurityLabels(incoming, { existingRecord: null, callerMaySetSecurity: false });
+  assert.equal(out.meta && out.meta.security, undefined);
+  assert.equal(out.subject.reference, 'Patient/A', 'non-security fields pass through untouched');
+});
+
+test('does not mutate the input record', () => {
+  const incoming = { meta: { security: [{ display: 'unrestricted' }] } };
+  governSecurityLabels(incoming, { existingRecord: null, callerMaySetSecurity: false });
+  assert.deepEqual(incoming.meta.security, [{ display: 'unrestricted' }], 'input must be left intact (pure)');
+});


### PR DESCRIPTION
## Security remediation campaign — pre-certification audit

Remediation of the CRITICAL findings from the 2026-07-01 security audit
(`docs/security/2026-07-01-honeycomb-security-audit.md`), re-verified against
main on 2026-07-24. **Every Critical in the core repo is now fixed.**

Still a review branch (draft) — not for merge until the weekend Inferno (g)(10)
re-run validates the auth-surface changes and the OpenID work lands. Companion
docs: `docs/security/2026-07-24-audit-status-diff.md` (finding-by-finding status
with commit refs) and `docs/security/remediation-actions.md` (human-only secret
rotation).

### Criticals fixed

| Finding | Exploit closed | How |
|---|---|---|
| **CR-1** | Forge a `client_credentials` assertion for a registered backend client → mint a `system/*` token | Verify the JWT signature before issuing (`server/lib/verifyClientAssertion.js`); both `/oauth/token` JWT paths unified onto it with an asymmetric-alg whitelist (blocks `alg:none` / HS* confusion) |
| **CR-2** | Production silently boots with auth off (`disableOauth` shipped in 12 settings files) | Fail-closed `Meteor.startup` assertion (`server/lib/assertSecureConfig.js`) — production refuses to boot with auth disabled **unless** declared an open sandbox (`settings.private.fhir.openSandbox`); dev never blocked |
| **CR-3** | A patient token reads/deletes/patches/**overwrites** any patient's resource by id (IDOR) | Patient-compartment enforcement on instance read/DELETE/PATCH **and PUT** (`server/lib/patientCompartment.js`); the search handler now consumes the same module, so query and instance checks can't diverge |
| **CR-4** | A client self-labels a resource `meta.security: unrestricted` to publish PHI world-readable | Server governs `meta.security` on POST/PUT/PATCH (`server/lib/writeSanitization.js`) — strip on create, preserve server labels on update; privileged writers may label |
| **CR-5 / CR-6** | Committed secrets (pacio token, admin password) + force-tracked secret settings | Untracked (`git rm --cached`) + scrubbed `*.template.json`; custom gitleaks rules fail CI on reintroduction. **Rotation is human-only** (see `remediation-actions.md`) |
| **CR-10** | A crafted UDAP cert's AIA/CRL URL makes the server fetch cloud metadata / internal hosts (SSRF) | Outbound-URL guard (`server/lib/outboundUrlGuard.js`) at the fetch entry points — blocks IMDS/loopback/private/internal; optional `settings.private.fhir.udapFetchAllowlist` |

CR-9 was resolved pre-campaign; CR-7/CR-8 method-auth holes were already closed via `requireAuth`.

### How each fix is structured

One disciplined shape per finding: a **pure, unit-tested `server/lib/*.js` helper** wired into the endpoint, **reproduce-before-fix** (a failing test proving the hole, plus a bypass-stub check proving the test catches regressions), **one finding per commit**, and **CI-gated** in the `rpc-method-tests` job. CR-1/CR-3/CR-4 are confirmed green on node-20 CI; CR-2/CR-10 in flight.

Note the `fix(ci)` commit: the helpers were initially written with ESM `export` in `.js` files, which passed on local Node 25 but broke CI's Node 20 (loads them as CommonJS). Converted to genuine CommonJS + default-import (the repo's proven dual-context pattern); flagged with a `TODO(node24)` to revert once CI runs Node ≥24.

### Also included

- **`feat(hydration)`** — `meta.source` lineage stamps on synthea/provider-directory/lantern imports + source-scoped `synthea.clearResearchData` (data-lineage groundwork; ME-2 `requireAuth:false` blessed as sandbox tooling).
- Risk calibration: the only deployment is the care-commons **sandbox** (no production PHI), so committed-secret findings are hygiene backlog — but a hard gate before any first real production deploy.

### Not in this branch

- **CR-7/CR-8 residuals** (merkalis relay allowlist, ipfs-swarm multiaddr SSRF) — live in the `extensions/*` **nested repos**; commit there, reusing the `outboundUrlGuard` pattern.
- **High/Medium tier** — expired-resume-token on FHIR REST (HI-1 follow-up), regex escaping (HI-7), TLS-verify (HI-8), BulkData CORS (HI-12), cookie flags (HI-13), egress/bulk-store (HI-14/15).
- **Follow-ups surfaced this session** — PUT ownership-ref (subject.reference) spoofing on create; DNS-rebinding hardening for the SSRF guard; unifying the two remaining inline compartment blocks; the deferred live two-patient token-scoped integration tests (post-OpenID).

### Verification

Each Critical: unit suite green, app boots with `settings.honeycomb.localhost.json`, 11/11 endpoint smoke. Full record in `docs/security/2026-07-24-audit-status-diff.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
