### PR TITLE
Production hardening: analytics PHI scrub + self-distribution update check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -648,6 +648,21 @@ jobs:
       - run:
           name: global.Collections contract audit
           command: npm run audit:collections
+      # ESM-subject unit tests (imports/lib, zero imports — bare-checkout
+      # safe). Subjects use `export` in .js, so the scripts carry
+      # --experimental-detect-module for this job's node 20 (default-on ≥22).
+      - run:
+          name: SMART launch builders (PKCE)
+          command: npm run test:smart-launch
+      - run:
+          name: Endpoint conformance probe
+          command: npm run test:conformance-probe
+      - run:
+          name: Analytics path scrubbing (PHI)
+          command: npm run test:analytics-scrub
+      - run:
+          name: Release-feed update check
+          command: npm run test:update-check
 
   # Dedicated RPC method-test job (Stage 1, docs/RPC-TESTING.md): boots the
   # app against its OWN ephemeral Mongo sidecar, then runs the JSON-RPC test

--- a/imports/lib/SessionKeys.js
+++ b/imports/lib/SessionKeys.js
@@ -60,6 +60,7 @@ export const APP_WIDTH        = 'appWidth';
 export const VIEWPORT         = 'viewport';
 export const SESSION_INSPECTOR_OPEN = 'sessionInspectorOpen'; // Cmd/Ctrl+Shift+D debug dashboard
 export const THEME_DIALOG_OPEN      = 'themeDialogOpen';      // Cmd/Ctrl+Shift+T theme palette dialog
+export const ABOUT_DIALOG_OPEN      = 'aboutDialogOpen';      // Cmd/Ctrl+Shift+A about + update status
 
 // ── FHIR id / display toggles ────────────────────────────────────────────────
 export const SHOW_SYSTEM_IDS    = 'showSystemIds';
@@ -129,6 +130,7 @@ export default {
   CURRENT_USER, SESSION_ID, ACCOUNTS_ACCESS_TOKEN, ACCOUNTS_REFRESH_TOKEN,
   SELECTED_ENDPOINT, SELECTED_ENDPOINT_ID, SPIDER_SCANNING,
   THEME, DISPLAY_NAVBARS, APP_HEIGHT, APP_WIDTH, VIEWPORT, SESSION_INSPECTOR_OPEN, THEME_DIALOG_OPEN,
+  ABOUT_DIALOG_OPEN,
   SHOW_SYSTEM_IDS, SHOW_FHIR_IDS, SHOW_EXPERIMENTAL,
   SIMULATOR_MISSION_ID, SIMULATOR_LAUNCH_DATE, SIMULATOR_VEHICLE,
   SIMULATOR_MISSION_MODE, SELECTED_CREWED_VEHICLE,

--- a/imports/lib/scrubAnalyticsPath.js
+++ b/imports/lib/scrubAnalyticsPath.js
@@ -1,0 +1,63 @@
+// imports/lib/scrubAnalyticsPath.js
+//
+// Privacy scrubber for analytics pageview paths. Honeycomb routes carry
+// FHIR resource ids, Mongo _ids, UUIDs, and one-time tokens in the URL
+// (/patients/:id, /vital-signs/:patientId/:observationId,
+// /email-list/unsubscribe/:token, ?connect-code=... on the OAuth callback).
+// None of that may reach Google Analytics — ids assigned to a patient are
+// identifiers even when they look like random strings, and the FTC Health
+// Breach Notification Rule reaches PHR-vendor telemetry that HIPAA doesn't.
+//
+// Strategy: report the route *shape*, not the URL. Query string and fragment
+// are dropped unconditionally; any id-shaped path segment becomes ":id".
+// Deliberately over-scrubs on ambiguity — a mangled pageview bucket is
+// cheap, a leaked identifier is not.
+//
+// Pure and dependency-free: node --test via
+// tests/unit/imports/lib/scrubAnalyticsPath.test.mjs (npm run test:analytics-scrub).
+
+const UUID_SEGMENT = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const HEX_SEGMENT = /^[0-9a-f]{16,}$/i;
+const PURE_DIGITS = /^[0-9]+$/;
+const HAS_DIGIT = /[0-9]/;
+const HAS_UPPERCASE = /[A-Z]/;
+
+function isIdShaped(segment) {
+  if (PURE_DIGITS.test(segment)) {
+    return true;
+  }
+  if (UUID_SEGMENT.test(segment) || HEX_SEGMENT.test(segment)) {
+    return true;
+  }
+  // Anything digit-bearing of meaningful length: FHIR ids, Random.id,
+  // LOINC-in-path, seed ids. Route words are lowercase kebab and the rare
+  // digit-bearing ones ("r4") stay short.
+  if (HAS_DIGIT.test(segment) && segment.length >= 6) {
+    return true;
+  }
+  // Long mixed-case blobs without digits: base64ish tokens, the all-letter
+  // tail of the Random.id distribution. Route words are lowercase kebab.
+  if (HAS_UPPERCASE.test(segment) && segment.length >= 15) {
+    return true;
+  }
+  return false;
+}
+
+export function scrubAnalyticsPath(pathname) {
+  const raw = String(pathname || '');
+  // Query string and fragment never ship — they carry OAuth codes and
+  // search terms.
+  const pathOnly = raw.split(/[?#]/)[0];
+  if (!pathOnly || pathOnly === '/') {
+    return '/';
+  }
+  const scrubbed = pathOnly.split('/').map(function(segment) {
+    if (!segment) {
+      return segment;   // preserve leading/duplicate slashes as-is
+    }
+    return isIdShaped(segment) ? ':id' : segment;
+  }).join('/');
+  return scrubbed || '/';
+}
+
+export default scrubAnalyticsPath;

--- a/imports/lib/updateCheck.js
+++ b/imports/lib/updateCheck.js
@@ -1,0 +1,60 @@
+// imports/lib/updateCheck.js
+//
+// Pure release-feed evaluation for the self-distribution updater. The
+// homepage serves /releases.json (extensions/orbital-homepage/server/http.js);
+// server/UpdateChecker.js fetches it once at startup and runs the payload
+// through evaluateReleaseFeed(). Dependency-free so it stays node --test-able
+// (npm run test:update-check).
+
+// Semver-ish compare: returns 1 / 0 / -1. Tolerates a leading "v" and
+// missing segments ("1.2" == "1.2.0"). Unparseable input sorts lowest so a
+// mangled feed can never claim to be newer than a real version.
+export function compareVersions(a, b) {
+  function parse(value) {
+    const cleaned = String(value || '').trim().replace(/^v/i, '');
+    if (!/^\d+(\.\d+)*($|[-+])/.test(cleaned)) {
+      return null;
+    }
+    return cleaned.split(/[-+]/)[0].split('.').map(function(n) { return parseInt(n, 10) || 0; });
+  }
+  const pa = parse(a);
+  const pb = parse(b);
+  if (!pa && !pb) { return 0; }
+  if (!pa) { return -1; }
+  if (!pb) { return 1; }
+  const length = Math.max(pa.length, pb.length);
+  for (let i = 0; i < length; i++) {
+    const na = pa[i] || 0;
+    const nb = pb[i] || 0;
+    if (na > nb) { return 1; }
+    if (na < nb) { return -1; }
+  }
+  return 0;
+}
+
+// feed × product × currentVersion → status object for the UI. Never throws;
+// every failure mode is "no update" (an updater must never break the app it
+// is trying to update).
+export function evaluateReleaseFeed(feed, productKey, currentVersion) {
+  const product = (feed && feed.products && feed.products[productKey]) || null;
+  const latest = (product && product.latest) || '';
+  const current = String(currentVersion || '');
+
+  const status = {
+    updateAvailable: false,
+    current: current,
+    latest: latest,
+    released: (product && product.released) || '',
+    notes: (product && product.notes) || '',
+    downloadUrl: (product && product.downloadUrl) || '',
+    downloads: (product && product.downloads) || {}
+  };
+
+  // Unknown current version → never nag (misconfigured deployment should
+  // not spam users with a false update flag).
+  if (!product || !latest || !current) {
+    return status;
+  }
+  status.updateAvailable = compareVersions(latest, current) === 1;
+  return status;
+}

--- a/imports/startup/client/hotkeys.js
+++ b/imports/startup/client/hotkeys.js
@@ -1,7 +1,7 @@
 // imports/startup/client/hotkeys.js
 
 import { Session } from 'meteor/session';
-import { SESSION_INSPECTOR_OPEN, THEME_DIALOG_OPEN } from '/imports/lib/SessionKeys.js';
+import { SESSION_INSPECTOR_OPEN, THEME_DIALOG_OPEN, ABOUT_DIALOG_OPEN } from '/imports/lib/SessionKeys.js';
 
 export function initializeKeyboardShortcuts() {
   document.addEventListener('keydown', (event) => {
@@ -55,8 +55,15 @@ export function initializeKeyboardShortcuts() {
       window.dispatchEvent(new CustomEvent('toggleServerConfiguration'));
     }
 
-    // Cmd/Ctrl + Shift + A — Toggle Admin Links sidebar section
+    // Cmd/Ctrl + Shift + A — Toggle About dialog (version + update status)
     if ((event.metaKey || event.ctrlKey) && event.shiftKey && (event.key === 'A' || event.key === 'a')) {
+      event.preventDefault();
+      Session.set(ABOUT_DIALOG_OPEN, !Session.get(ABOUT_DIALOG_OPEN));
+    }
+
+    // Cmd/Ctrl + Shift + U — Toggle Admin Links sidebar section
+    // (was Shift+A; moved 2026-07-31 when the About dialog claimed that combo)
+    if ((event.metaKey || event.ctrlKey) && event.shiftKey && (event.key === 'U' || event.key === 'u')) {
       event.preventDefault();
       window.dispatchEvent(new CustomEvent('toggleAdminLinks'));
     }

--- a/imports/startup/client/index.js
+++ b/imports/startup/client/index.js
@@ -55,14 +55,10 @@ Meteor.startup(() => {
   // Load additional modules based on configuration
   const modules = get(Meteor, 'settings.public.modules', {});
 
-  // Analytics module
-  if (modules.analytics?.enabled) {
-    import(/* webpackIgnore: true */ './analytics-startup').catch(error => {
-      log.warn('Analytics startup module not found', { error: error.message });
-    });
-  } else {
-    log.info('Analytics module disabled in settings');
-  }
+  // Analytics: no startup module — GA4 initializes in imports/ui/App.jsx,
+  // gated on settings.public.google.analytics.measurementId, with pageview
+  // scrubbing (imports/lib/scrubAnalyticsPath.js). A ./analytics-startup
+  // dynamic import used to sit here but the module never existed.
 
   // Chat module
   if (modules.chat?.enabled) {

--- a/imports/ui/AboutDialog.jsx
+++ b/imports/ui/AboutDialog.jsx
@@ -1,0 +1,185 @@
+// imports/ui/AboutDialog.jsx
+//
+// About + update-status dialog. Opened from the Header info icon or
+// Cmd/Ctrl+Shift+A (Session key ABOUT_DIALOG_OPEN). Shows the app version,
+// host runtime info (OS, node, electron), and the cached result of the
+// startup /releases.json check (server/UpdateChecker.js), with a manual
+// re-check button. Settings-gated: when settings.public.updates is absent
+// the update section explains itself instead of erroring.
+
+import React, { useState, useEffect } from 'react';
+import {
+  Dialog, DialogTitle, DialogContent, DialogActions, Button, Typography,
+  Alert, AlertTitle, Box, Table, TableBody, TableRow, TableCell,
+  CircularProgress, Divider
+} from '@mui/material';
+import DownloadIcon from '@mui/icons-material/Download';
+import RefreshIcon from '@mui/icons-material/Refresh';
+import { Meteor } from 'meteor/meteor';
+import { Session } from 'meteor/session';
+import { useTracker } from 'meteor/react-meteor-data';
+import { get } from 'lodash';
+import { ABOUT_DIALOG_OPEN } from '/imports/lib/SessionKeys.js';
+
+// Electron exposes itself in the renderer userAgent: "... Electron/31.2.0 ..."
+function electronVersionFromUserAgent() {
+  const match = (navigator.userAgent || '').match(/Electron\/([\d.]+)/);
+  return match ? match[1] : '';
+}
+
+function AboutDialog() {
+  const open = useTracker(function() {
+    return !!Session.get(ABOUT_DIALOG_OPEN);
+  }, []);
+
+  const [info, setInfo] = useState(null);      // null = loading
+  const [checking, setChecking] = useState(false);
+  const [loadError, setLoadError] = useState(null);
+
+  async function loadStatus() {
+    try {
+      const result = await Meteor.rpc('updates.getStatus', {});
+      setInfo(result || {});
+      setLoadError(null);
+    } catch (err) {
+      setLoadError(get(err, 'reason', err.message));
+      setInfo({});
+    }
+  }
+
+  useEffect(function() {
+    if (open) {
+      loadStatus();
+    }
+  }, [open]);
+
+  function handleClose() {
+    Session.set(ABOUT_DIALOG_OPEN, false);
+  }
+
+  async function handleCheckNow() {
+    setChecking(true);
+    try {
+      await Meteor.rpc('updates.checkNow', {});
+      await loadStatus();
+    } catch (err) {
+      setLoadError(get(err, 'reason', err.message));
+    } finally {
+      setChecking(false);
+    }
+  }
+
+  const appTitle = get(Meteor, 'settings.public.title', 'Node on FHIR');
+  const status = get(info, 'status', null);
+  const updateAvailable = !!get(status, 'updateAvailable', false);
+  const currentVersion = get(info, 'currentVersion', '') || get(status, 'current', '');
+  const electronVersion = get(info, 'system.electronVersion', '') || electronVersionFromUserAgent();
+
+  return (
+    <Dialog id="aboutDialog" open={open} onClose={handleClose} maxWidth="sm" fullWidth>
+      <DialogTitle>
+        About {appTitle}
+        {currentVersion ? (
+          <Typography variant="body2" color="text.secondary">
+            Version {currentVersion}
+          </Typography>
+        ) : null}
+      </DialogTitle>
+      <DialogContent>
+        {info === null ? (
+          <Box sx={{ display: 'flex', justifyContent: 'center', p: 3 }}>
+            <CircularProgress />
+          </Box>
+        ) : (
+          <Box>
+            {loadError ? (
+              <Alert severity="warning" sx={{ mb: 2 }}>{loadError}</Alert>
+            ) : null}
+
+            {/* Update status */}
+            {!get(info, 'configured', false) ? (
+              <Alert severity="info" sx={{ mb: 2 }}>
+                Update checking is not configured on this deployment
+                (Meteor.settings.public.updates.releasesUrl).
+              </Alert>
+            ) : updateAvailable ? (
+              <Alert
+                severity="info"
+                sx={{ mb: 2 }}
+                action={get(status, 'downloadUrl', '') ? (
+                  <Button
+                    id="aboutDialogDownloadButton"
+                    color="inherit"
+                    size="small"
+                    startIcon={<DownloadIcon />}
+                    onClick={function() { window.open(get(status, 'downloadUrl'), '_blank', 'noopener'); }}
+                  >
+                    Download
+                  </Button>
+                ) : null}
+              >
+                <AlertTitle>Update available — version {get(status, 'latest', '')}</AlertTitle>
+                {get(status, 'notes', '')}
+              </Alert>
+            ) : get(info, 'error', null) ? (
+              <Alert severity="warning" sx={{ mb: 2 }}>
+                Last update check failed: {get(info, 'error')}
+              </Alert>
+            ) : status ? (
+              <Alert severity="success" sx={{ mb: 2 }}>
+                You are on the latest published version.
+              </Alert>
+            ) : (
+              <Alert severity="info" sx={{ mb: 2 }}>
+                No update check has run yet this session.
+              </Alert>
+            )}
+
+            <Divider sx={{ my: 2 }} />
+
+            {/* Runtime info */}
+            <Table size="small" id="aboutDialogSystemTable">
+              <TableBody>
+                <TableRow>
+                  <TableCell sx={{ color: 'text.secondary' }}>Operating system</TableCell>
+                  <TableCell>{get(info, 'system.platform', 'unknown')} ({get(info, 'system.arch', '')})</TableCell>
+                </TableRow>
+                <TableRow>
+                  <TableCell sx={{ color: 'text.secondary' }}>Node</TableCell>
+                  <TableCell>{get(info, 'system.nodeVersion', 'unknown')}</TableCell>
+                </TableRow>
+                <TableRow>
+                  <TableCell sx={{ color: 'text.secondary' }}>Electron</TableCell>
+                  <TableCell>{electronVersion || 'not running in Electron'}</TableCell>
+                </TableRow>
+                <TableRow>
+                  <TableCell sx={{ color: 'text.secondary' }}>Meteor</TableCell>
+                  <TableCell>{get(info, 'system.meteorRelease', 'unknown')}</TableCell>
+                </TableRow>
+                {get(info, 'checkedAt', null) ? (
+                  <TableRow>
+                    <TableCell sx={{ color: 'text.secondary' }}>Last update check</TableCell>
+                    <TableCell>{new Date(get(info, 'checkedAt')).toLocaleString()}</TableCell>
+                  </TableRow>
+                ) : null}
+              </TableBody>
+            </Table>
+          </Box>
+        )}
+      </DialogContent>
+      <DialogActions>
+        <Button
+          id="aboutDialogCheckButton"
+          startIcon={checking ? <CircularProgress size={16} color="inherit" /> : <RefreshIcon />}
+          onClick={handleCheckNow}
+          disabled={checking || !get(info, 'configured', false)}
+        >
+          {checking ? 'Checking…' : 'Check for updates'}
+        </Button>
+        <Button id="aboutDialogCloseButton" onClick={handleClose}>Close</Button>
+      </DialogActions>
+    </Dialog>
+  );
+}
+
+export default AboutDialog;

--- a/imports/ui/App.jsx
+++ b/imports/ui/App.jsx
@@ -48,6 +48,7 @@ import DataGuard from './guards/DataGuard.jsx';
 import ErrorBoundary from './ErrorBoundary.jsx';
 import WelcomeDialog from './components/WelcomeDialog.jsx';
 import SessionInspectorDialog from './SessionInspectorDialog.jsx';
+import AboutDialog from './AboutDialog.jsx';
 import ThemeDialog from './ThemeDialog.jsx';
 import AppSnackbar from './AppSnackbar.jsx';
 import ExtensiblePage from './extensible/ExtensiblePage.jsx';
@@ -1798,6 +1799,7 @@ export function App(props){
             <WelcomeDialog />
             <SessionInspectorDialog />
             <ThemeDialog />
+            <AboutDialog />
             <AppSnackbar />
             <Box sx={{ display: 'flex', flex: 1, overflow: 'hidden' }}>
               <StyledMainRouter style={{flex: 1}} />

--- a/imports/ui/App.jsx
+++ b/imports/ui/App.jsx
@@ -1397,31 +1397,42 @@ const requreSysadmin = (nextState, replace) => {
 
 //===============================================================================================================
 // Analytics
+//
+// PHI discipline: pageviews report the route SHAPE only. Raw URLs carry
+// FHIR/Mongo ids and OAuth codes (/patients/:id, ?connect-code=...), so
+// GA4's automatic page_view is disabled (it sends the full page_location
+// including the query string) and every hit overrides page_location/page_path
+// with the scrubbed path. See imports/lib/scrubAnalyticsPath.js.
+
+import { scrubAnalyticsPath } from '/imports/lib/scrubAnalyticsPath.js';
 
 let analyticsMeasurementId = get(Meteor, 'settings.public.google.analytics.measurementId')
 
 import ReactGA from "react-ga4";
 if(analyticsMeasurementId){
-  ReactGA.initialize(analyticsMeasurementId, {debug: get(Meteor, 'settings.public.google.analytics.debug', false)});
+  ReactGA.initialize(analyticsMeasurementId, {
+    debug: get(Meteor, 'settings.public.google.analytics.debug', false),
+    gtagOptions: {
+      send_page_view: false,
+      anonymize_ip: true
+    }
+  });
 }
 
 function logPageView() {
   if(analyticsMeasurementId){
-    // ReactGA.pageview(window.location.pathname + window.location.search);
-    ReactGA.send({ hitType: "pageview", page: window.location.pathname });
+    const scrubbedPath = scrubAnalyticsPath(window.location.pathname);
+    // Override the auto-collected document location on every subsequent
+    // hit — otherwise gtag attaches the raw URL as page_location itself.
+    ReactGA.set({
+      page_location: window.location.origin + scrubbedPath,
+      page_path: scrubbedPath
+    });
+    ReactGA.send({ hitType: "pageview", page: scrubbedPath });
+  } else {
+    // analytics disabled (no measurementId) — nothing to send
   }
 };
-
-function usePageViews() {
-  // let location = useLocation();
-  React.useEffect(() => {
-    if(analyticsMeasurementId){
-      ReactGA.pageview(window.location.pathname + window.location.search);
-      // ReactGA.set({ page: window.location.pathname });  
-      ReactGA.send({ hitType: "pageview", page: window.location.pathname });
-    }
-  }, [window.location]);
-}
 
 
 
@@ -1572,10 +1583,6 @@ export function App(props){
       }        
     }  
   }
-
-  // forgot why we have this.  I think this is Google Analytics related?
-  // usePageViews();
-
 
   // ------------------------------------------------------------------
   // App UI State

--- a/imports/ui/Header.jsx
+++ b/imports/ui/Header.jsx
@@ -16,7 +16,8 @@ import LightMode from '@mui/icons-material/LightMode';
 import DarkMode from '@mui/icons-material/DarkMode';
 import CastIcon from '@mui/icons-material/Cast';
 import PaletteIcon from '@mui/icons-material/Palette';
-import { THEME_DIALOG_OPEN } from '/imports/lib/SessionKeys.js';
+import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
+import { THEME_DIALOG_OPEN, ABOUT_DIALOG_OPEN } from '/imports/lib/SessionKeys.js';
 
 
 import { Meteor } from 'meteor/meteor';
@@ -88,6 +89,32 @@ function Header({ drawerIsOpen, handleDrawerOpen, lastUpdated }) {
   let [currentUser, setCurrentUser] = useState({
     givenName: 'Anonymous'
   });
+
+  // Self-distribution update tell: ask the server for its cached
+  // /releases.json check (server/UpdateChecker.js pings once at startup,
+  // ~15s after boot, so retry once after that window). Icon renders only
+  // when a newer build is published; failures stay silent.
+  const [updateAvailable, setUpdateAvailable] = useState(false);
+  const headerUserId = useTracker(function() { return Meteor.userId(); }, []);
+  React.useEffect(function() {
+    let cancelled = false;
+    async function checkUpdateStatus() {
+      try {
+        const result = await Meteor.rpc('updates.getStatus', {});
+        if (!cancelled) {
+          setUpdateAvailable(!!get(result, 'status.updateAvailable', false));
+        }
+      } catch (err) {
+        // not signed in yet / check disabled — no update tell
+      }
+    }
+    if (headerUserId) {
+      checkUpdateStatus();
+      const retryTimer = setTimeout(checkUpdateStatus, 30 * 1000);
+      return function() { cancelled = true; clearTimeout(retryTimer); };
+    }
+    return function() { cancelled = true; };
+  }, [headerUserId]);
 
   
 
@@ -365,6 +392,16 @@ function Header({ drawerIsOpen, handleDrawerOpen, lastUpdated }) {
           >
             <PaletteIcon sx={{ color: muiTheme.palette.appbar?.contrastText || muiTheme.palette.primary.contrastText }} />
           </IconButton>
+          {updateAvailable && (
+            <IconButton
+              id="headerUpdateAvailableButton"
+              onClick={function() { Session.set(ABOUT_DIALOG_OPEN, true); }}
+              aria-label="Update Available"
+              title="Update Available"
+            >
+              <InfoOutlinedIcon sx={{ color: muiTheme.palette.warning?.main || muiTheme.palette.appbar?.contrastText }} />
+            </IconButton>
+          )}
           <IconButton
             onClick={function() { navigate('/fhircast-publish'); }}
             aria-label="FHIRcast"

--- a/package.json
+++ b/package.json
@@ -61,7 +61,8 @@
     "test:secure-config": "node --test tests/unit/server/lib/assertSecureConfig.test.mjs",
     "test:outbound-url-guard": "node --test tests/unit/server/lib/outboundUrlGuard.test.mjs",
     "test:conformance-probe": "node --test tests/unit/imports/lib/EndpointConformanceProbe.test.mjs",
-    "test:smart-launch": "node --test tests/unit/imports/lib/SmartLaunch.test.mjs"
+    "test:smart-launch": "node --test tests/unit/imports/lib/SmartLaunch.test.mjs",
+    "test:analytics-scrub": "node --test tests/unit/imports/lib/scrubAnalyticsPath.test.mjs"
   },
   "dependencies": {
     "@accounts/client": "0.33.1",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,8 @@
     "test:outbound-url-guard": "node --test tests/unit/server/lib/outboundUrlGuard.test.mjs",
     "test:conformance-probe": "node --test tests/unit/imports/lib/EndpointConformanceProbe.test.mjs",
     "test:smart-launch": "node --test tests/unit/imports/lib/SmartLaunch.test.mjs",
-    "test:analytics-scrub": "node --test tests/unit/imports/lib/scrubAnalyticsPath.test.mjs"
+    "test:analytics-scrub": "node --test tests/unit/imports/lib/scrubAnalyticsPath.test.mjs",
+    "test:update-check": "node --test tests/unit/imports/lib/updateCheck.test.mjs"
   },
   "dependencies": {
     "@accounts/client": "0.33.1",

--- a/package.json
+++ b/package.json
@@ -60,10 +60,10 @@
     "test:write-sanitization": "node --test tests/unit/server/lib/writeSanitization.test.mjs",
     "test:secure-config": "node --test tests/unit/server/lib/assertSecureConfig.test.mjs",
     "test:outbound-url-guard": "node --test tests/unit/server/lib/outboundUrlGuard.test.mjs",
-    "test:conformance-probe": "node --test tests/unit/imports/lib/EndpointConformanceProbe.test.mjs",
-    "test:smart-launch": "node --test tests/unit/imports/lib/SmartLaunch.test.mjs",
-    "test:analytics-scrub": "node --test tests/unit/imports/lib/scrubAnalyticsPath.test.mjs",
-    "test:update-check": "node --test tests/unit/imports/lib/updateCheck.test.mjs"
+    "test:conformance-probe": "node --experimental-detect-module --test tests/unit/imports/lib/EndpointConformanceProbe.test.mjs",
+    "test:smart-launch": "node --experimental-detect-module --test tests/unit/imports/lib/SmartLaunch.test.mjs",
+    "test:analytics-scrub": "node --experimental-detect-module --test tests/unit/imports/lib/scrubAnalyticsPath.test.mjs",
+    "test:update-check": "node --experimental-detect-module --test tests/unit/imports/lib/updateCheck.test.mjs"
   },
   "dependencies": {
     "@accounts/client": "0.33.1",

--- a/server/UpdateChecker.js
+++ b/server/UpdateChecker.js
@@ -1,0 +1,131 @@
+// server/UpdateChecker.js
+//
+// Self-distribution update check: ping the homepage's /releases.json ONCE
+// at startup (plus on explicit request from the About dialog) and cache the
+// result for the client. This is deliberately not an auto-updater — it only
+// surfaces "a newer build exists" so the Header can show the Update
+// Available affordance.
+//
+// Privacy posture: a bare GET with no query params, no machine ids, no
+// version beacon — the feed operator learns nothing but a hit in the
+// access log. Settings-gated; absent config disables the check entirely.
+//
+//   Meteor.settings.public.updates = {
+//     "releasesUrl": "https://orbital.healthcare/releases.json",
+//     "product": "chronicle-desktop",
+//     "currentVersion": "0.9.0"        // stamped by the desktop build
+//   }
+
+import { Meteor } from 'meteor/meteor';
+import { fetch } from 'meteor/fetch';
+import { get } from 'lodash';
+import { evaluateReleaseFeed } from '/imports/lib/updateCheck.js';
+
+const log = (Meteor.Logger ? Meteor.Logger.for('UpdateChecker') : console);
+
+const STARTUP_DELAY_MS = 15 * 1000;   // stay out of the boot path
+const FETCH_TIMEOUT_MS = 10 * 1000;
+
+// Cached result of the most recent check (null until the first one runs).
+let lastStatus = null;
+let lastCheckedAt = null;
+let lastError = null;
+
+function updateSettings() {
+  return get(Meteor, 'settings.public.updates', null);
+}
+
+export async function runUpdateCheck(reason) {
+  const settings = updateSettings();
+  const releasesUrl = get(settings, 'releasesUrl', '');
+  if (!releasesUrl) {
+    log.info('update check skipped — no settings.public.updates.releasesUrl configured');
+    return null;
+  }
+
+  const controller = new AbortController();
+  const timeout = setTimeout(function() { controller.abort(); }, FETCH_TIMEOUT_MS);
+  try {
+    const response = await fetch(releasesUrl, {
+      method: 'GET',
+      headers: { 'Accept': 'application/json' },
+      signal: controller.signal
+    });
+    const text = await response.text();
+    if (!response.ok) {
+      throw new Error('release feed returned HTTP ' + response.status);
+    }
+    const feed = JSON.parse(text);
+    lastStatus = evaluateReleaseFeed(
+      feed,
+      get(settings, 'product', ''),
+      get(settings, 'currentVersion', '')
+    );
+    lastCheckedAt = new Date();
+    lastError = null;
+    log.info('update check complete', {
+      reason: reason,
+      updateAvailable: lastStatus.updateAvailable,
+      current: lastStatus.current,
+      latest: lastStatus.latest
+    });
+  } catch (error) {
+    // An updater must never break the app it updates — record and move on.
+    lastError = error.message;
+    lastCheckedAt = new Date();
+    log.warn('update check failed', { reason: reason, error: error.message });
+  } finally {
+    clearTimeout(timeout);
+  }
+  return lastStatus;
+}
+
+Meteor.startup(function() {
+  if (!get(updateSettings(), 'releasesUrl', '')) {
+    log.info('update check disabled (no releasesUrl)');
+    return;
+  }
+  // Once per process start, off the boot path.
+  Meteor.setTimeout(function() {
+    runUpdateCheck('startup').catch(function(error) {
+      log.warn('startup update check crashed', { error: error.message });
+    });
+  }, STARTUP_DELAY_MS);
+});
+
+Meteor.ServerMethods.define('updates.getStatus', {
+  description: 'Cached update-check result + host runtime info for the About dialog.',
+  requireAuth: true,
+  positionalParams: [],
+  schemaObject: { type: 'object', properties: {} }
+}, async function(params, context){
+  const settings = updateSettings();
+  return {
+    configured: !!get(settings, 'releasesUrl', ''),
+    releasesUrl: get(settings, 'releasesUrl', ''),
+    product: get(settings, 'product', ''),
+    currentVersion: get(settings, 'currentVersion', ''),
+    status: lastStatus,
+    checkedAt: lastCheckedAt,
+    error: lastError,
+    system: {
+      platform: process.platform,
+      arch: process.arch,
+      nodeVersion: process.version,
+      meteorRelease: Meteor.release,
+      // Present only when the server runs inside an Electron bundle; the
+      // renderer-side Electron version is parsed from the userAgent instead.
+      electronVersion: get(process, 'versions.electron', '')
+    }
+  };
+});
+
+Meteor.ServerMethods.define('updates.checkNow', {
+  description: 'Re-fetch the release feed on demand (About dialog button).',
+  requireAuth: true,
+  positionalParams: [],
+  schemaObject: { type: 'object', properties: {} }
+}, async function(params, context){
+  await runUpdateCheck('manual');
+  return { status: lastStatus, checkedAt: lastCheckedAt, error: lastError };
+});

--- a/server/main.js
+++ b/server/main.js
@@ -181,6 +181,10 @@ import { ConnectedSources } from '/imports/collections/ConnectedSources';
 import './connect/methods.js';
 import './connect/launchHandlers.js';
 
+// Self-distribution update check — one startup ping of the homepage's
+// /releases.json. Settings-gated via settings.public.updates.
+import './UpdateChecker.js';
+
 
 //===============================================================================================================
 // Data Cursors

--- a/settings/settings.honeycomb.localhost.json
+++ b/settings/settings.honeycomb.localhost.json
@@ -276,6 +276,11 @@
         "warning": 5,
         "caution": 10
       }
+    },
+    "updates": {
+      "releasesUrl": "",
+      "product": "chronicle-desktop",
+      "currentVersion": ""
     }
   },
   "private": {

--- a/tests/unit/imports/lib/scrubAnalyticsPath.test.mjs
+++ b/tests/unit/imports/lib/scrubAnalyticsPath.test.mjs
@@ -1,0 +1,63 @@
+// tests/unit/imports/lib/scrubAnalyticsPath.test.mjs
+//
+// node --test tests/unit/imports/lib/scrubAnalyticsPath.test.mjs
+//
+// Analytics pageview paths must never carry identifiers: patient/resource
+// FHIR ids, Mongo _ids, UUIDs, OAuth codes, unsubscribe tokens. The scrubber
+// replaces id-shaped path segments with :id and drops query/hash entirely.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { scrubAnalyticsPath } from '../../../../imports/lib/scrubAnalyticsPath.js';
+
+test('static routes pass through unchanged', () => {
+  assert.equal(scrubAnalyticsPath('/'), '/');
+  assert.equal(scrubAnalyticsPath('/patients'), '/patients');
+  assert.equal(scrubAnalyticsPath('/patient-chart'), '/patient-chart');
+  assert.equal(scrubAnalyticsPath('/server-configuration'), '/server-configuration');
+  assert.equal(scrubAnalyticsPath('/import-data'), '/import-data');
+  assert.equal(scrubAnalyticsPath('/provider-directory'), '/provider-directory');
+});
+
+test('FHIR and Mongo id segments are replaced with :id', () => {
+  // Epic-style FHIR id
+  assert.equal(scrubAnalyticsPath('/patients/erXuFYUfucBZaryVksYEcMg3'), '/patients/:id');
+  // Mongo ObjectId-shaped hex
+  assert.equal(scrubAnalyticsPath('/conditions/5832e8a0ea861706b1857c49'), '/conditions/:id');
+  // Meteor Random.id (17 alnum, mixed case)
+  assert.equal(scrubAnalyticsPath('/observations/Yqvuwage7hLh82gEb'), '/observations/:id');
+  // Synthea/FHIR UUID
+  assert.equal(scrubAnalyticsPath('/patients/91f9ab65-1933-2a48-94b1-b6fef00f7335'), '/patients/:id');
+  // seed-style ids with digits
+  assert.equal(scrubAnalyticsPath('/patients/patient-john-doe-01'), '/patients/:id');
+  assert.equal(scrubAnalyticsPath('/encounters/baseehr-a1-1783128628501'), '/encounters/:id');
+});
+
+test('multi-id routes scrub every id segment', () => {
+  assert.equal(
+    scrubAnalyticsPath('/vital-signs/91f9ab65-1933-2a48-94b1-b6fef00f7335/8867-4'),
+    '/vital-signs/:id/:id'
+  );
+  assert.equal(scrubAnalyticsPath('/hipaa/policies/123'), '/hipaa/policies/:id');
+});
+
+test('query strings and fragments are dropped entirely (OAuth codes, search terms)', () => {
+  assert.equal(
+    scrubAnalyticsPath('/patient-fetch?connect-code=abc123secret&connect-state=xyz'),
+    '/patient-fetch'
+  );
+  assert.equal(scrubAnalyticsPath('/patients#section-2'), '/patients');
+});
+
+test('token-bearing routes are scrubbed', () => {
+  assert.equal(
+    scrubAnalyticsPath('/email-list/unsubscribe/eyJhbGciOiJIUzI1NiIsInR5cCI6'),
+    '/email-list/unsubscribe/:id'
+  );
+});
+
+test('handles junk input without throwing', () => {
+  assert.equal(scrubAnalyticsPath(''), '/');
+  assert.equal(scrubAnalyticsPath(null), '/');
+  assert.equal(scrubAnalyticsPath(undefined), '/');
+});

--- a/tests/unit/imports/lib/updateCheck.test.mjs
+++ b/tests/unit/imports/lib/updateCheck.test.mjs
@@ -1,0 +1,56 @@
+// tests/unit/imports/lib/updateCheck.test.mjs
+//
+// node --test tests/unit/imports/lib/updateCheck.test.mjs
+//
+// Pure release-feed evaluation for the self-distribution updater: semver-ish
+// comparison + feed → status derivation. The network/startup side lives in
+// server/UpdateChecker.js; this layer must stay dependency-free.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { compareVersions, evaluateReleaseFeed } from '../../../../imports/lib/updateCheck.js';
+
+test('compareVersions orders semver-ish strings', () => {
+  assert.equal(compareVersions('1.0.0', '0.9.9'), 1);
+  assert.equal(compareVersions('0.9.0', '0.10.0'), -1);
+  assert.equal(compareVersions('1.2.3', '1.2.3'), 0);
+  assert.equal(compareVersions('1.2', '1.2.0'), 0);
+  assert.equal(compareVersions('v1.3.0', '1.2.9'), 1);   // tolerant of v-prefix
+  assert.equal(compareVersions('garbage', '1.0.0'), -1); // unparseable sorts lowest
+});
+
+test('evaluateReleaseFeed reports an available update', () => {
+  const feed = {
+    updatedAt: '2026-07-31',
+    products: {
+      'chronicle-desktop': {
+        latest: '0.9.1',
+        released: '2026-07-31',
+        notes: 'SMART connect to Epic.',
+        downloadUrl: 'https://orbital.healthcare/downloads/chronicle-0.9.1.dmg'
+      }
+    }
+  };
+  const status = evaluateReleaseFeed(feed, 'chronicle-desktop', '0.9.0');
+  assert.equal(status.updateAvailable, true);
+  assert.equal(status.latest, '0.9.1');
+  assert.equal(status.current, '0.9.0');
+  assert.equal(status.notes, 'SMART connect to Epic.');
+  assert.equal(status.downloadUrl, 'https://orbital.healthcare/downloads/chronicle-0.9.1.dmg');
+});
+
+test('evaluateReleaseFeed reports up-to-date when current >= latest', () => {
+  const feed = { products: { app: { latest: '1.0.0' } } };
+  assert.equal(evaluateReleaseFeed(feed, 'app', '1.0.0').updateAvailable, false);
+  assert.equal(evaluateReleaseFeed(feed, 'app', '1.1.0').updateAvailable, false);
+});
+
+test('evaluateReleaseFeed degrades gracefully on bad input', () => {
+  assert.equal(evaluateReleaseFeed(null, 'app', '1.0.0').updateAvailable, false);
+  assert.equal(evaluateReleaseFeed({}, 'app', '1.0.0').updateAvailable, false);
+  assert.equal(evaluateReleaseFeed({ products: {} }, 'app', '1.0.0').updateAvailable, false);
+  // unknown current version → never nag
+  const feed = { products: { app: { latest: '2.0.0' } } };
+  assert.equal(evaluateReleaseFeed(feed, 'app', '').updateAvailable, false);
+  assert.equal(evaluateReleaseFeed(feed, 'app', null).updateAvailable, false);
+});


### PR DESCRIPTION
## Summary

Production-hardening pass ahead of the first self-distributed desktop release: closes the two launch-blocking gaps identified in the go-to-production sanity check — **analytics PHI leakage** and the **stranded-v1 updater trap** — plus the CI/build plumbing they surfaced.

### 1. Analytics: scrub identifiers from GA pageviews (`c430bde1`)

Audit found GA live (`G-M2LSLWRK2K` in care-commons sandbox + chronicle desktop settings) with two leak paths:

- `logPageView()` sent raw pathnames — ~40 parameterized routes carry FHIR resource ids, Mongo `_id`s, and patient ids (`/patients/:id`, `/vital-signs/:patientId/:observationId`, …)
- GA4's **automatic page_view** was left enabled, which reports the full `page_location` **including query strings** — e.g. `?connect-code=<OAuth authorization code>` on the SMART callback landing

Fix: pageviews now report the route **shape** only. New pure `imports/lib/scrubAnalyticsPath.js` (`:id` for UUID / hex≥16 / pure-digit / digit-bearing≥6 / mixed-case≥15 segments; query+fragment dropped unconditionally), `send_page_view: false` + `anonymize_ip: true`, `page_location`/`page_path` overridden on every hit, dead `usePageViews()` removed. Not HIPAA-covered as a consumer PHR, but the FTC Health Breach Notification Rule reaches PHR-vendor telemetry — pageview identifiers are exactly the GoodRx/BetterHelp fact pattern.

### 2. Self-distribution updater, notify-only rung (`ef437c77`)

"Ping the home server once on startup" — never ship a v1 with no channel to announce v2:

- `server/UpdateChecker.js` — one fetch of the homepage-served `/releases.json` 15s after boot (bare GET: no query params, no machine ids), cached; `updates.getStatus` / `updates.checkNow`. Settings-gated via `settings.public.updates` (`releasesUrl` / `product` / `currentVersion`); every failure mode degrades to "no update"
- Header: amber Info icon, tooltip **Update Available**, rendered only when a newer version is published
- `imports/ui/AboutDialog.jsx` — icon click or **Cmd/Ctrl+Shift+A**: app version, update alert with release notes + Download, OS/Node/Electron/Meteor table, manual re-check. (Admin Links hotkey moved A→U)
- Pure feed evaluation in `imports/lib/updateCheck.js`

Companion commits in sibling repos (already pushed): `orbital-homepage@5144c31` serves `/releases.json` from `settings.private.homepage.releases` (schema is a superset of what electron-updater's generic provider needs, so the future true-auto-update rung won't change clients); `desktop-lattice@18220f4` + `desktop-chronicle@9cf6390` stamp `public.updates.currentVersion` from the desktop package version at build time.

### 3. CI: the four ESM unit suites actually run now (`2e9c398e`)

`test:smart-launch` and `test:conformance-probe` were never CI-wired — and couldn't have passed: their subjects use ESM `export` in `.js`, which CI's node 20 can't load (passes local node 25 only — the CR-1/CR-3 trap again). All four ESM-subject scripts now carry `--experimental-detect-module` and run in the bare-checkout `lib-unit-tests` job (all subjects are zero-import).

### 4. Dead wiring (`c948238c`)

Removed the phantom `./analytics-startup` dynamic import (module never existed).

## Test plan

- [x] `npm run test:analytics-scrub` — 6/6
- [x] `npm run test:update-check` — 4/4
- [x] All four ESM suites verified against a **real node v20.11.0 binary** (CI's exact version): bare = SyntaxError, with flag = 21/21; and node 25 = 21/21
- [x] Live E2E: app self-served a feed (published 0.9.1 vs current 0.9.0) → startup check logged `updateAvailable: true` → header icon appeared post-login → dialog rendered update alert + runtime table → hotkey toggles → manual re-check OK (screenshot in session notes)
- [ ] CI green on this PR (first run of the four newly wired suites)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
