### PR TITLE
Provider directory: indexed search, conformance sweep, org→endpoint linkage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -666,6 +666,9 @@ jobs:
       - run:
           name: Directory search shadow (nameLower)
           command: npm run test:search-shadow
+      - run:
+          name: Org→Endpoint linkage matcher
+          command: npm run test:org-linkage
 
   # Dedicated RPC method-test job (Stage 1, docs/RPC-TESTING.md): boots the
   # app against its OWN ephemeral Mongo sidecar, then runs the JSON-RPC test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -663,6 +663,9 @@ jobs:
       - run:
           name: Release-feed update check
           command: npm run test:update-check
+      - run:
+          name: Directory search shadow (nameLower)
+          command: npm run test:search-shadow
 
   # Dedicated RPC method-test job (Stage 1, docs/RPC-TESTING.md): boots the
   # app against its OWN ephemeral Mongo sidecar, then runs the JSON-RPC test

--- a/npmPackages/provider-directory/client/DirectoryConsole.jsx
+++ b/npmPackages/provider-directory/client/DirectoryConsole.jsx
@@ -539,13 +539,16 @@ function StatusChip({ status }) {
   );
 }
 
-function ResultBand({ band, config, revealIndex }) {
+function ResultBand({ band, config, revealIndex, onLoadMore, loadingMore }) {
   const [expandedId, setExpandedId] = useState(null);
   const hitsById = {};
   (band.hits || []).forEach(function(hit) { hitsById[get(hit, '_id')] = hit; });
   const rows = (band.hits || []).map(function(hit) { return flattenHit(band.resourceName, hit); });
   const countLabel = band.matchCount >= 1000
     ? '1,000+' : band.matchCount.toLocaleString();
+  // Bands fetch 200 by default; the tail beyond the fetched page is reachable
+  // via LOAD MORE (single-band skip pages, deduped on append).
+  const hasMore = band.matchCount > rows.length;
 
   return (
     <Box className="gc-boot" sx={{ animationDelay: (revealIndex * 120) + 'ms', mb: 4 }}>
@@ -639,6 +642,25 @@ function ResultBand({ band, config, revealIndex }) {
           </Box>
         );
       })}
+
+      {hasMore && onLoadMore ? (
+        <button
+          type="button"
+          onClick={function() { onLoadMore(band.resourceName); }}
+          disabled={!!loadingMore}
+          style={{
+            display: 'block', width: '100%', background: 'transparent',
+            border: '1px dashed var(--hairline)', cursor: loadingMore ? 'wait' : 'pointer',
+            padding: '10px 0', marginTop: '6px',
+            fontFamily: 'var(--mono)', fontSize: '10px', letterSpacing: '0.24em',
+            color: config.accent, opacity: loadingMore ? 0.5 : 0.9
+          }}
+        >
+          {loadingMore
+            ? 'ACQUIRING…'
+            : 'LOAD MORE ▸ SHOWING ' + rows.length.toLocaleString() + ' OF ' + countLabel + ' ' + config.unit}
+        </button>
+      ) : null}
     </Box>
   );
 }
@@ -687,6 +709,36 @@ export function DirectoryConsole() {
       if (seq === scanSeq.current) { setScanning(false); }
     }
   }, []);
+
+  // LOAD MORE: fetch the next single-band page (skip = rows already shown)
+  // and append, deduped by _id (page 0 may have carried wide-band extras).
+  const [loadingMoreBand, setLoadingMoreBand] = useState(null);
+  const loadMore = useCallback(async function(resourceName) {
+    const band = (bands || []).find(function(b) { return b.resourceName === resourceName; });
+    if (!band) { return; }
+    setLoadingMoreBand(resourceName);
+    try {
+      const result = await Meteor.rpc('providerDirectory.omniSearch', Object.assign(
+        { q: query, resourceName: resourceName, skip: band.hits.length },
+        facets
+      ));
+      const page = get(result, 'results.0', null);
+      if (page) {
+        setBands(function(current) {
+          return (current || []).map(function(b) {
+            if (b.resourceName !== resourceName) { return b; }
+            const seen = new Set(b.hits.map(function(h) { return String(h._id); }));
+            const appended = b.hits.concat(page.hits.filter(function(h) { return !seen.has(String(h._id)); }));
+            return Object.assign({}, b, { hits: appended });
+          });
+        });
+      }
+    } catch (error) {
+      log.error('loadMore failed', { resourceName: resourceName, error: get(error, 'reason', error.message) });
+    } finally {
+      setLoadingMoreBand(null);
+    }
+  }, [bands, query, facets]);
 
   // Census on boot.
   useEffect(function() {
@@ -957,6 +1009,8 @@ export function DirectoryConsole() {
                     band={band}
                     config={config}
                     revealIndex={index}
+                    onLoadMore={loadMore}
+                    loadingMore={loadingMoreBand === band.resourceName}
                   />
                 );
               })

--- a/npmPackages/provider-directory/client/DirectoryConsole.jsx
+++ b/npmPackages/provider-directory/client/DirectoryConsole.jsx
@@ -340,6 +340,26 @@ function RecordDetail({ resourceName, hit, accent }) {
       {resourceName === 'Endpoint' && get(hit, '_connectable') ? (
         <EndpointFetchPanel endpointId={get(hit, '_id')} accent={accent} />
       ) : null}
+
+      {/* Linked organization → the same bridge via its tier-1-linked endpoint
+          (methods.linkage.js). Gated on patientLaunchable (user decision:
+          every CONNECT VIA chip must be a working connect). Tooltip carries
+          the linkage provenance so operators can see why the link exists. */}
+      {resourceName === 'Organization' && get(hit, '_linkage.patientLaunchable') ? (
+        <Box sx={{ mt: 2, pt: 1.5, borderTop: '1px dashed var(--hairline)' }}>
+          <Box sx={{
+            fontFamily: 'var(--mono)', fontSize: '9px', letterSpacing: '0.24em',
+            color: 'var(--ink-dim)', mb: 1
+          }}
+            title={'linked by ' + get(hit, '_linkage.method', '') +
+              ' (' + get(hit, '_linkage.evidence', '') +
+              ', confidence ' + get(hit, '_linkage.confidence', '') + ')'}
+          >
+            CONNECT VIA {String(get(hit, 'endpoint.0.display', get(hit, '_linkage.matchedName', ''))).toUpperCase()}
+          </Box>
+          <EndpointFetchPanel endpointId={get(hit, '_linkage.endpointId')} accent={accent} />
+        </Box>
+      ) : null}
     </Box>
   );
 }

--- a/npmPackages/provider-directory/client/components/ServerConfiguration.jsx
+++ b/npmPackages/provider-directory/client/components/ServerConfiguration.jsx
@@ -543,16 +543,140 @@ function SearchIndexCard() {
   );
 }
 
+// ---------------------------------------------------------------------------
+// Org ↔ Endpoint Linkage card — tier-1 exact-name linkage of NPPES orgs to
+// connectable endpoints (server/methods.linkage.js). Dry run first, always.
+
+function LinkageCard() {
+  const [stats, setStats] = useState(null);
+  const [starting, setStarting] = useState('');
+  const [error, setError] = useState(null);
+
+  const loadStats = useCallback(async function () {
+    try {
+      const result = await Meteor.rpc('providerDirectory.linkageStats', {});
+      setStats(result || {});
+      setError(null);
+    } catch (err) {
+      setError(get(err, 'reason', err.message));
+      setStats({});
+    }
+  }, []);
+
+  useEffect(function () { loadStats(); }, [loadStats]);
+
+  const running = !!get(stats, 'running', false) || !!get(stats, 'progress.running', false);
+  useEffect(function () {
+    if (!running) { return undefined; }
+    const timer = setInterval(loadStats, 2500);
+    return function () { clearInterval(timer); };
+  }, [running, loadStats]);
+
+  async function run(kind) {
+    setStarting(kind);
+    setError(null);
+    try {
+      if (kind === 'clear') {
+        await Meteor.rpc('providerDirectory.clearLinkage', {});
+      } else {
+        await Meteor.rpc('providerDirectory.linkEndpoints', { dryRun: kind === 'dry', prune: kind === 'link' });
+      }
+      await loadStats();
+    } catch (err) {
+      setError(get(err, 'reason', err.message));
+    } finally {
+      setStarting('');
+    }
+  }
+
+  const progress = get(stats, 'progress', null);
+  const samples = get(stats, 'samples', []);
+
+  return (
+    <Card sx={{ mt: 2 }}>
+      <CardHeader
+        avatar={<BusinessIcon />}
+        title="Org ↔ Endpoint Linkage"
+        subheader="Tier-1 exact-name links: NPPES organizations → connectable endpoints"
+      />
+      <CardContent>
+        {error ? <Alert severity="error" sx={{ mb: 2 }} onClose={function () { setError(null); }}>{error}</Alert> : null}
+        {running ? (
+          <Alert severity="info" sx={{ mb: 2 }}>
+            Linkage running — {get(progress, 'phase', 'scan')} · {Number(get(progress, 'orgsScanned', 0)).toLocaleString()} orgs scanned
+            <LinearProgress sx={{ mt: 1 }} />
+          </Alert>
+        ) : null}
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+          Linked organizations: <strong>{get(stats, 'linked', 0) < 0 ? '—' : Number(get(stats, 'linked', 0)).toLocaleString()}</strong>
+          {' · '}connectable (patient-launchable): <strong>{get(stats, 'launchableLinked', 0) < 0 ? '—' : Number(get(stats, 'launchableLinked', 0)).toLocaleString()}</strong>
+          {get(stats, 'lastRunAt', null) ? ' · last run ' + new Date(get(stats, 'lastRunAt')).toLocaleString() : ''}
+        </Typography>
+        {progress && !running ? (
+          <Typography variant="caption" color="text.secondary" component="div" sx={{ mb: 1 }}>
+            Last run: {Number(get(progress, 'orgsScanned', 0)).toLocaleString()} scanned ·{' '}
+            {Number(get(progress, 'linked', 0)).toLocaleString()} linked ({Number(get(progress, 'vendorLinked', 0)).toLocaleString()} vendor-name, {Number(get(progress, 'lanternLinked', 0)).toLocaleString()} lantern-list) ·{' '}
+            {Number(get(progress, 'refusedLocality', 0)).toLocaleString()} refused by locality guard
+            {get(progress, 'dryRun') ? ' · DRY RUN (nothing written)' : ''}
+          </Typography>
+        ) : null}
+        {samples.length ? (
+          <Box sx={{ maxHeight: 200, overflow: 'auto', mb: 1, p: 1, bgcolor: 'action.hover', borderRadius: 1 }}>
+            {samples.map(function (sample, index) {
+              return (
+                <Typography key={index} variant="caption" component="div" sx={{ fontFamily: 'monospace' }}>
+                  {sample.refused
+                    ? '✗ ' + sample.org + ' — refused: ' + sample.refused
+                    : '✓ ' + sample.org + ' → ' + sample.endpoint + ' [' + (sample.tag || sample.evidence) + ']'}
+                </Typography>
+              );
+            })}
+          </Box>
+        ) : null}
+      </CardContent>
+      <CardActions sx={{ px: 2, pb: 2 }}>
+        <Button
+          id="linkageDryRunButton"
+          variant="outlined"
+          onClick={function () { run('dry'); }}
+          disabled={!!starting || running}
+        >
+          Dry run
+        </Button>
+        <Button
+          id="linkageRunButton"
+          variant="contained"
+          startIcon={starting === 'link' || running ? <CircularProgress size={18} color="inherit" /> : <BusinessIcon />}
+          onClick={function () { run('link'); }}
+          disabled={!!starting || running}
+        >
+          Link endpoints
+        </Button>
+        <Button
+          id="linkageClearButton"
+          color="error"
+          onClick={function () { run('clear'); }}
+          disabled={!!starting || running}
+        >
+          Clear links
+        </Button>
+        <Button startIcon={<RefreshIcon />} onClick={loadStats}>Refresh</Button>
+      </CardActions>
+    </Card>
+  );
+}
+
 // The panel tab renders the National Directory import card plus the search
-// index card (and, when linkage ships, its card) as one column.
+// index and linkage cards as one column.
 function ProviderDirectoryPanel() {
   return (
     <Box>
       <ServerConfiguration />
       <SearchIndexCard />
+      <LinkageCard />
     </Box>
   );
 }
 
-export { SearchIndexCard };
+export { SearchIndexCard, LinkageCard };
 export default ProviderDirectoryPanel;

--- a/npmPackages/provider-directory/client/components/ServerConfiguration.jsx
+++ b/npmPackages/provider-directory/client/components/ServerConfiguration.jsx
@@ -421,4 +421,138 @@ export function ServerConfiguration() {
   );
 }
 
-export default ServerConfiguration;
+// ---------------------------------------------------------------------------
+// Search Index card — nameLower shadow-field backfill for the directory
+// search (server/methods.searchIndex.js). The omniSearch console silently
+// falls back to unindexed scans until every collection reads ready.
+
+function SearchIndexCard() {
+  const [status, setStatus] = useState(null);    // null = loading
+  const [starting, setStarting] = useState(false);
+  const [error, setError] = useState(null);
+
+  const loadStatus = useCallback(async function () {
+    try {
+      const result = await Meteor.rpc('providerDirectory.searchIndexStatus', {});
+      setStatus(result || {});
+      setError(null);
+    } catch (err) {
+      setError(get(err, 'reason', err.message));
+      setStatus({});
+    }
+  }, []);
+
+  useEffect(function () {
+    loadStatus();
+  }, [loadStatus]);
+
+  // Poll while the backfill runs.
+  const running = !!get(status, 'running', false) || !!get(status, 'progress.running', false);
+  useEffect(function () {
+    if (!running) { return undefined; }
+    const timer = setInterval(loadStatus, 2500);
+    return function () { clearInterval(timer); };
+  }, [running, loadStatus]);
+
+  async function startBackfill() {
+    setStarting(true);
+    setError(null);
+    try {
+      await Meteor.rpc('providerDirectory.backfillSearchIndex', {});
+      await loadStatus();
+    } catch (err) {
+      setError(get(err, 'reason', err.message));
+    } finally {
+      setStarting(false);
+    }
+  }
+
+  const collections = get(status, 'collections', []);
+  const allReady = collections.length > 0 && collections.every(function (c) { return c.ready; });
+
+  return (
+    <Card sx={{ mt: 2 }}>
+      <CardHeader
+        avatar={<StorageIcon />}
+        title="Search Index"
+        subheader="nameLower shadow field — indexed prefix search for the directory console"
+      />
+      <CardContent>
+        {error ? <Alert severity="error" sx={{ mb: 2 }} onClose={function () { setError(null); }}>{error}</Alert> : null}
+        {status === null ? (
+          <Box sx={{ display: 'flex', justifyContent: 'center', p: 2 }}><CircularProgress size={24} /></Box>
+        ) : (
+          <Box>
+            {running ? (
+              <Alert severity="info" sx={{ mb: 2 }}>
+                Backfill running — {get(status, 'progress.phase', '…')}
+                <LinearProgress sx={{ mt: 1 }} />
+              </Alert>
+            ) : allReady ? (
+              <Alert severity="success" sx={{ mb: 2 }}>
+                Search index ready — omniSearch is using indexed prefix queries.
+              </Alert>
+            ) : (
+              <Alert severity="warning" sx={{ mb: 2 }}>
+                Some collections are missing the search shadow — directory search
+                falls back to slow unindexed scans until the backfill runs.
+              </Alert>
+            )}
+            <Table size="small" id="searchIndexStatusTable">
+              <TableHead>
+                <TableRow>
+                  <TableCell>Collection</TableCell>
+                  <TableCell align="right">Documents</TableCell>
+                  <TableCell align="right">Missing shadow</TableCell>
+                  <TableCell align="right">Status</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {collections.map(function (row) {
+                  return (
+                    <TableRow key={row.collection}>
+                      <TableCell>{row.collection}</TableCell>
+                      <TableCell align="right">{Number(row.total || 0).toLocaleString()}</TableCell>
+                      <TableCell align="right">
+                        {row.missing < 0 ? '—' : (row.missingCapped ? '1,000+' : Number(row.missing).toLocaleString())}
+                      </TableCell>
+                      <TableCell align="right">
+                        <Chip size="small" label={row.ready ? 'ready' : 'pending'} color={row.ready ? 'success' : 'default'} />
+                      </TableCell>
+                    </TableRow>
+                  );
+                })}
+              </TableBody>
+            </Table>
+          </Box>
+        )}
+      </CardContent>
+      <CardActions sx={{ px: 2, pb: 2 }}>
+        <Button
+          id="buildSearchIndexButton"
+          variant="contained"
+          startIcon={(starting || running) ? <CircularProgress size={18} color="inherit" /> : <StorageIcon />}
+          onClick={startBackfill}
+          disabled={starting || running || allReady}
+        >
+          {running ? 'Building…' : 'Build search index'}
+        </Button>
+        <Button startIcon={<RefreshIcon />} onClick={loadStatus}>Refresh</Button>
+      </CardActions>
+    </Card>
+  );
+}
+
+// The panel tab renders the National Directory import card plus the search
+// index card (and, when linkage ships, its card) as one column.
+function ProviderDirectoryPanel() {
+  return (
+    <Box>
+      <ServerConfiguration />
+      <SearchIndexCard />
+    </Box>
+  );
+}
+
+export { SearchIndexCard };
+export default ProviderDirectoryPanel;

--- a/npmPackages/provider-directory/lib/OrgEndpointLinkage.js
+++ b/npmPackages/provider-directory/lib/OrgEndpointLinkage.js
@@ -1,0 +1,212 @@
+// npmPackages/provider-directory/lib/OrgEndpointLinkage.js
+//
+// Tier-1 org→endpoint linkage: connect NPPES Directory.Organizations rows to
+// connectable core Endpoints so the console can offer "Connect via <endpoint>"
+// on org rows. PRECISION OVER RECALL — a wrong link sends a patient to the
+// wrong health system's login. Tier-1 is EXACT normalized-name membership:
+//
+//   - lantern endpoints: `name` is a semicolon-joined list of the org names
+//     the endpoint serves (Lantern's api_information_source_name) — exact
+//     membership is the strongest evidence available ('lantern-list')
+//   - epic-open / cerner-ignite: the health-system display name (+ cerner
+//     alias / managingOrganization.display) — national brand names
+//     ('vendor-name')
+//
+// Named traps this design handles:
+//   - Beth Israel Deaconess never links via a Deaconess-Evansville name:
+//     exact equality after normalization, no token matching.
+//   - Homonym orgs (Spokane's "Deaconess Hospital" in an athena list vs
+//     Evansville's NPPES org of the same name): 'lantern-list' evidence is
+//     flagged requiresLocalityGuard — the worker refuses the link when NPPES
+//     orgs sharing that name span multiple states. 'vendor-name' evidence
+//     skips the guard (health systems are multi-state by nature).
+//   - Generic names ("clinic", "family medicine") and short names never link.
+//   - A name appearing in MULTIPLE lantern endpoints' lists is ambiguous
+//     (genuinely different practices share names nationally) — refused.
+//
+// Pure and dependency-free: node --test via
+// tests/unit/npmPackages/provider-directory/OrgEndpointLinkage.test.mjs
+// (npm run test:org-linkage). The worker (server/methods.linkage.js) streams
+// orgs through matchOrgTier1 and applies the locality guard.
+
+export const LEGAL_SUFFIXES = new Set([
+  'inc', 'incorporated', 'llc', 'llp', 'lp', 'ltd', 'limited',
+  'pc', 'pa', 'pllc', 'psc', 'sc', 'co', 'corp', 'corporation'
+]);
+
+export const GENERIC_NAMES = new Set([
+  'clinic', 'hospital', 'medical center', 'the medical center', 'medical group',
+  'family medicine', 'family practice', 'family medicine associates',
+  'pharmacy', 'urgent care', 'health center', 'community health center',
+  'medical associates', 'health system', 'primary care', 'internal medicine',
+  'pediatrics', 'womens health', 'behavioral health', 'wellness center'
+]);
+
+const MIN_NAME_LENGTH = 5;
+
+// Tag rank for same-name preference (lower = better).
+const TAG_RANK = { 'epic-open': 0, 'cerner-ignite': 1, 'epic-sandbox': 2, 'lantern': 3 };
+const VENDOR_TAGS = new Set(['epic-open', 'cerner-ignite']);
+
+// casefold → '&'→' and ' → punctuation→spaces → collapse → strip trailing
+// legal-suffix tokens (repeatedly: "x inc llc" → "x", but never empty a name).
+export function normalizeOrgName(raw) {
+  if (typeof raw !== 'string') {
+    return '';
+  }
+  let normalized = raw.toLowerCase()
+    .replace(/&/g, ' and ')
+    .replace(/\./g, '')            // "P.C." → "pc" before punctuation splits it into "p c"
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim()
+    .replace(/\s+/g, ' ');
+  for (;;) {
+    const tokens = normalized.split(' ');
+    if (tokens.length < 2) {
+      break;
+    }
+    const last = tokens[tokens.length - 1];
+    if (!LEGAL_SUFFIXES.has(last)) {
+      break;
+    }
+    tokens.pop();
+    normalized = tokens.join(' ');
+  }
+  return normalized;
+}
+
+function endpointTag(endpointDoc) {
+  const tags = (endpointDoc && endpointDoc.meta && endpointDoc.meta.tag) || [];
+  return (Array.isArray(tags) && tags.length && tags[0].code) || 'unknown';
+}
+
+// The display names an endpoint serves, per lineage shape. Deduped by
+// normalized form; empty normals dropped.
+export function splitEndpointDisplayNames(endpointDoc) {
+  const tag = endpointTag(endpointDoc);
+  const rawNames = [];
+  const name = endpointDoc && endpointDoc.name;
+  if (tag === 'lantern') {
+    if (typeof name === 'string') {
+      name.split(';').forEach(function (part) { rawNames.push(part.trim()); });
+    }
+  } else {
+    if (typeof name === 'string') {
+      rawNames.push(name.trim());
+    }
+    if (Array.isArray(endpointDoc && endpointDoc.alias)) {
+      endpointDoc.alias.forEach(function (alias) {
+        if (typeof alias === 'string') { rawNames.push(alias.trim()); }
+      });
+    }
+    const managing = endpointDoc && endpointDoc.managingOrganization && endpointDoc.managingOrganization.display;
+    if (typeof managing === 'string') {
+      rawNames.push(managing.trim());
+    }
+  }
+  const seen = new Set();
+  const names = [];
+  for (const raw of rawNames) {
+    const normalized = normalizeOrgName(raw);
+    if (!normalized || seen.has(normalized)) {
+      continue;
+    }
+    seen.add(normalized);
+    names.push({ raw: raw, normalized: normalized });
+  }
+  return names;
+}
+
+// normalizedName -> [{ endpointId, tagCode, rawName, patientLaunchable }]
+export function buildEndpointNameIndex(endpointDocs) {
+  const exact = new Map();
+  for (const doc of endpointDocs || []) {
+    const tag = endpointTag(doc);
+    const launchable = !!(doc && doc.conformance && doc.conformance.patientLaunchable);
+    for (const name of splitEndpointDisplayNames(doc)) {
+      if (!exact.has(name.normalized)) {
+        exact.set(name.normalized, []);
+      }
+      exact.get(name.normalized).push({
+        endpointId: doc._id,
+        tagCode: tag,
+        rawName: name.raw,
+        patientLaunchable: launchable
+      });
+    }
+  }
+  return { exact: exact };
+}
+
+function pickPreferred(entries) {
+  const sorted = entries.slice().sort(function (a, b) {
+    if (a.patientLaunchable !== b.patientLaunchable) {
+      return a.patientLaunchable ? -1 : 1;
+    }
+    const rankA = TAG_RANK[a.tagCode] !== undefined ? TAG_RANK[a.tagCode] : 9;
+    const rankB = TAG_RANK[b.tagCode] !== undefined ? TAG_RANK[b.tagCode] : 9;
+    return rankA - rankB;
+  });
+  return sorted[0];
+}
+
+// Exact-membership match with the tier-1 guards. Returns null (no link) or:
+//   { endpointId, endpointTag, rawName, evidence, confidence,
+//     requiresLocalityGuard }
+export function matchOrgTier1(normalizedOrgName, index) {
+  if (!normalizedOrgName || normalizedOrgName.length < MIN_NAME_LENGTH) {
+    return null;
+  }
+  if (GENERIC_NAMES.has(normalizedOrgName)) {
+    return null;
+  }
+  const entries = index.exact.get(normalizedOrgName);
+  if (!entries || !entries.length) {
+    return null;
+  }
+
+  const vendorEntries = entries.filter(function (e) { return VENDOR_TAGS.has(e.tagCode); });
+  if (vendorEntries.length) {
+    // A national system name. Multi-endpoint same-name is fine within the
+    // vendor lists (prefer launchable, then tag rank).
+    const preferred = pickPreferred(vendorEntries);
+    return {
+      endpointId: preferred.endpointId,
+      endpointTag: preferred.tagCode,
+      rawName: preferred.rawName,
+      evidence: 'vendor-name',
+      confidence: 0.95,
+      requiresLocalityGuard: false
+    };
+  }
+
+  // Lantern-list-only evidence: refuse when the same name appears in the
+  // lists of DIFFERENT endpoints — genuinely distinct practices share names
+  // nationally, and we cannot tell which one the org is.
+  const distinctEndpoints = new Set(entries.map(function (e) { return String(e.endpointId); }));
+  if (distinctEndpoints.size > 1) {
+    return null;
+  }
+  const preferred = pickPreferred(entries);
+  return {
+    endpointId: preferred.endpointId,
+    endpointTag: preferred.tagCode,
+    rawName: preferred.rawName,
+    evidence: 'lantern-list',
+    confidence: 0.85,
+    requiresLocalityGuard: true
+  };
+}
+
+// Homonym tell for lantern-list evidence: the NPPES orgs sharing a matched
+// name must sit in (at most) one state. Missing/empty states are ignored;
+// a group with no state data at all has nothing contradicting locality.
+export function passesLocalityGuard(states) {
+  const distinct = new Set();
+  for (const state of states || []) {
+    if (typeof state === 'string' && state.trim()) {
+      distinct.add(state.trim().toUpperCase());
+    }
+  }
+  return distinct.size <= 1;
+}

--- a/npmPackages/provider-directory/lib/searchShadow.js
+++ b/npmPackages/provider-directory/lib/searchShadow.js
@@ -1,0 +1,153 @@
+// npmPackages/provider-directory/lib/searchShadow.js
+//
+// nameLower shadow field for index-bounded directory search.
+//
+// Why: omniSearch needs case-insensitive prefix matching over millions of
+// rows, but `$regex ^X i` cannot use a B-tree index and Mongo collation does
+// not apply to $regex at all. So we maintain a lowercased shadow of the name
+// field (`nameLower` — scalar everywhere, multikey ARRAY on Practitioner),
+// index it, and query it with a CASE-SENSITIVE ^prefix regex, which is
+// index-bounded.
+//
+// ⚠ Every writer that replaces whole Directory/Endpoint documents MUST stamp
+// the shadow (stampNameShadow) or the index goes stale for those rows:
+//   - npmPackages/provider-directory/server/methods.directory.js
+//     installResource() — the NPPES national install uses replaceOne
+//   - extensions/lantern/server/methods.js bulkUpsertEndpoints() +
+//     lantern.seedSandboxEndpoint (inline one-liner; lantern has no import
+//     path into this package)
+// Backfill for existing rows: providerDirectory.backfillSearchIndex
+// (server/methods.searchIndex.js) runs nameLowerPipeline() via updateMany.
+//
+// Pure and dependency-free: node --test via
+// tests/unit/npmPackages/provider-directory/searchShadow.test.mjs
+// (npm run test:search-shadow).
+
+export function toNameLower(value) {
+  if (typeof value !== 'string' || value.length === 0) {
+    return undefined;
+  }
+  return value.toLowerCase();
+}
+
+// Per-document stamping for writers (mutates doc). Practitioner gets the
+// multikey array of every name[].text and name[].family; everything else is
+// a scalar of doc.name. Nameless docs get NO field (absent, never null), so
+// backfillFilter and the readiness check stay consistent.
+export function stampNameShadow(resourceName, doc) {
+  if (!doc || typeof doc !== 'object') {
+    return doc;
+  }
+  if (resourceName === 'Practitioner') {
+    const names = Array.isArray(doc.name) ? doc.name : [];
+    const values = [];
+    for (const humanName of names) {
+      if (!humanName || typeof humanName !== 'object') {
+        continue;
+      }
+      const text = toNameLower(humanName.text);
+      if (text !== undefined) {
+        values.push(text);
+      }
+      const family = toNameLower(humanName.family);
+      if (family !== undefined && family !== text) {
+        values.push(family);
+      }
+    }
+    if (values.length) {
+      doc.nameLower = values;
+    }
+    return doc;
+  }
+  const lowered = toNameLower(doc.name);
+  if (lowered !== undefined) {
+    doc.nameLower = lowered;
+  }
+  return doc;
+}
+
+// updateMany aggregation pipeline for the backfill — server-side, one pass
+// per collection, no document round-trips. $type guard + $$REMOVE keeps
+// nameless/junk docs field-free instead of null.
+export function nameLowerPipeline(resourceName) {
+  if (resourceName === 'Practitioner') {
+    return [{
+      $set: {
+        nameLower: {
+          $let: {
+            vars: { arr: { $cond: [{ $isArray: '$name' }, '$name', []] } },
+            in: {
+              $let: {
+                vars: {
+                  collected: {
+                    $filter: {
+                      input: {
+                        $concatArrays: [
+                          {
+                            $map: {
+                              input: '$$arr',
+                              as: 'n',
+                              in: {
+                                $cond: [
+                                  { $eq: [{ $type: '$$n.text' }, 'string'] },
+                                  { $toLower: '$$n.text' },
+                                  ''
+                                ]
+                              }
+                            }
+                          },
+                          {
+                            $map: {
+                              input: '$$arr',
+                              as: 'n',
+                              in: {
+                                $cond: [
+                                  { $eq: [{ $type: '$$n.family' }, 'string'] },
+                                  { $toLower: '$$n.family' },
+                                  ''
+                                ]
+                              }
+                            }
+                          }
+                        ]
+                      },
+                      as: 'v',
+                      cond: { $ne: ['$$v', ''] }
+                    }
+                  }
+                },
+                in: {
+                  $cond: [
+                    { $gt: [{ $size: '$$collected' }, 0] },
+                    '$$collected',
+                    '$$REMOVE'
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    }];
+  }
+  return [{
+    $set: {
+      nameLower: {
+        $cond: [
+          { $eq: [{ $type: '$name' }, 'string'] },
+          { $toLower: '$name' },
+          '$$REMOVE'
+        ]
+      }
+    }
+  }];
+}
+
+// Which docs still need the shadow — drives both the backfill updateMany and
+// the omniSearch readiness probe (ready when this matches zero docs).
+export function backfillFilter(resourceName) {
+  if (resourceName === 'Practitioner') {
+    return { name: { $type: 'array', $ne: [] }, nameLower: { $exists: false } };
+  }
+  return { name: { $type: 'string' }, nameLower: { $exists: false } };
+}

--- a/npmPackages/provider-directory/server/index.js
+++ b/npmPackages/provider-directory/server/index.js
@@ -10,6 +10,8 @@ import { registerDirectoryCollections } from '../lib/DirectoryCollections.js';
 import './methods.js';
 import './methods.directory.js';
 import './methods.omniSearch.js';
+import './methods.searchIndex.js';
+import './startup.indexes.js';
 import './https.js';
 import './hooks.js';
 

--- a/npmPackages/provider-directory/server/index.js
+++ b/npmPackages/provider-directory/server/index.js
@@ -11,6 +11,7 @@ import './methods.js';
 import './methods.directory.js';
 import './methods.omniSearch.js';
 import './methods.searchIndex.js';
+import './methods.linkage.js';
 import './startup.indexes.js';
 import './https.js';
 import './hooks.js';

--- a/npmPackages/provider-directory/server/methods.directory.js
+++ b/npmPackages/provider-directory/server/methods.directory.js
@@ -40,6 +40,7 @@ import zlib from 'zlib';
 import readline from 'readline';
 
 import { DIRECTORY_RESOURCES, getDirectoryCollection } from '../lib/DirectoryCollections.js';
+import { stampNameShadow } from '../lib/searchShadow.js';
 
 const DEFAULT_BASE_URL = 'https://directory.cms.gov';
 const BATCH_SIZE = 2000;
@@ -323,6 +324,9 @@ async function installResource(resourceName, dir, prog) {
     const id = get(resource, 'id');
     if (!id) { errors++; continue; }
     resource._id = id;
+    // replaceOne wipes any prior shadow field — stamp nameLower here or the
+    // search index goes stale on every NPPES re-install (lib/searchShadow.js).
+    stampNameShadow(resourceName, resource);
     ops.push({ replaceOne: { filter: { _id: id }, replacement: resource, upsert: true } });
     if (ops.length >= BATCH_SIZE) { await flush(); }
   }

--- a/npmPackages/provider-directory/server/methods.linkage.js
+++ b/npmPackages/provider-directory/server/methods.linkage.js
@@ -1,0 +1,278 @@
+// npmPackages/provider-directory/server/methods.linkage.js
+//
+// Org→Endpoint tier-1 linkage worker + methods (lib/OrgEndpointLinkage.js is
+// the pure matcher). Streams the 2.69M NPPES Directory.Organizations rows
+// through an in-memory endpoint-name hash join and writes FHIR-native links:
+//
+//   Organization.endpoint = [{ reference: 'Endpoint/<id>', display }]
+//   Organization._linkage = { method, evidence, confidence, endpointId,
+//                             endpointTag, matchedName, patientLaunchable,
+//                             linkedAt, runId }
+//
+// Every link is auditable (_linkage provenance), reversible (clearLinkage),
+// and idempotent (re-runs converge; prune drops links not re-confirmed by
+// the current run). Lantern-list evidence passes the locality guard first:
+// candidate orgs sharing the matched name must sit in a single state, or the
+// whole name group is refused (the Spokane-vs-Evansville homonym trap).
+//
+//   providerDirectory.linkEndpoints  — background job {dryRun, prune}
+//   providerDirectory.linkageStats   — progress + link counts
+//   providerDirectory.clearLinkage   — $unset all links
+//
+// NOTE: the NPPES national install (methods.directory.js) uses replaceOne —
+// a re-install wipes endpoint/_linkage (and nameLower); re-run linkage after
+// re-installs. Run AFTER a conformance sweep so patientLaunchable preference
+// and the console's chip gating have data.
+
+import { Meteor } from 'meteor/meteor';
+import { Random } from 'meteor/random';
+import { get } from 'lodash';
+import { getDirectoryCollection } from '../lib/DirectoryCollections.js';
+import { Endpoints as CoreEndpoints } from '/imports/lib/schemas/SimpleSchemas/Endpoints.js';
+import {
+  normalizeOrgName,
+  buildEndpointNameIndex,
+  matchOrgTier1,
+  passesLocalityGuard
+} from '../lib/OrgEndpointLinkage.js';
+
+const log = (Meteor.Logger ? Meteor.Logger.for('provider-directory') : console);
+
+const CONFIG_TYPE = 'directoryLinkage';
+const WRITE_BATCH = 1000;
+const PROGRESS_EVERY = 100000;
+const SAMPLE_LIMIT = 50;
+
+let linking = false;
+
+async function stampProgress(patch) {
+  const ServerConfiguration = get(global, 'Collections.ServerConfiguration');
+  if (!ServerConfiguration) {
+    return;
+  }
+  const existing = await ServerConfiguration.findOneAsync({ configType: CONFIG_TYPE });
+  const nextData = Object.assign({}, get(existing, 'data', {}), patch);
+  if (existing) {
+    await ServerConfiguration.updateAsync({ _id: existing._id }, { $set: { data: nextData, updatedAt: new Date() } });
+  } else {
+    await ServerConfiguration.insertAsync({ configType: CONFIG_TYPE, data: nextData, updatedAt: new Date() });
+  }
+}
+
+function linkWrite(orgId, hit, runId, now) {
+  return {
+    updateOne: {
+      filter: { _id: orgId },
+      update: {
+        $set: {
+          endpoint: [{ reference: 'Endpoint/' + hit.endpointId, display: hit.rawName }],
+          _linkage: {
+            method: 'tier1-exact-name',
+            evidence: hit.evidence,
+            confidence: hit.confidence,
+            endpointId: hit.endpointId,
+            endpointTag: hit.endpointTag,
+            matchedName: hit.rawName,
+            patientLaunchable: !!hit.patientLaunchable,
+            linkedAt: now,
+            runId: runId
+          }
+        }
+      }
+    }
+  };
+}
+
+export async function runLinkEndpoints({ dryRun = false, prune = false } = {}) {
+  const runId = Random.id();
+  const now = new Date();
+  const Organizations = getDirectoryCollection('Organization');
+  const orgsRaw = Organizations.rawCollection();
+
+  // Phase 1: endpoint-name index (91K endpoints; a few hundred K names).
+  const endpointDocs = await CoreEndpoints.rawCollection()
+    .find(
+      { name: { $type: 'string', $ne: '' } },
+      { projection: { name: 1, alias: 1, managingOrganization: 1, 'meta.tag': 1, 'conformance.patientLaunchable': 1 } }
+    )
+    .toArray();
+  const launchableById = new Map(endpointDocs.map(function (d) {
+    return [String(d._id), !!get(d, 'conformance.patientLaunchable', false)];
+  }));
+  const index = buildEndpointNameIndex(endpointDocs);
+  log.info('linkage endpoint index built', { endpoints: endpointDocs.length, names: index.exact.size });
+
+  // Phase 2: stream orgs, collect matches. Vendor-evidence hits are final;
+  // lantern-list hits group by matched name for the locality guard.
+  const counters = { orgsScanned: 0, vendorLinked: 0, lanternCandidates: 0, lanternLinked: 0, refusedLocality: 0 };
+  const vendorWrites = [];
+  const lanternGroups = new Map();   // normalizedName -> { hit, orgs: [{orgId, state}] }
+  const samples = [];
+  let flushed = 0;
+
+  async function flushVendor(force) {
+    if (dryRun) {
+      vendorWrites.length = 0;
+      return;
+    }
+    if (vendorWrites.length >= WRITE_BATCH || (force && vendorWrites.length)) {
+      const batch = vendorWrites.splice(0, vendorWrites.length);
+      await orgsRaw.bulkWrite(batch, { ordered: false });
+      flushed += batch.length;
+    }
+  }
+
+  const cursor = orgsRaw.find(
+    { name: { $type: 'string' } },
+    { projection: { name: 1, 'address.state': 1 } }
+  );
+  for await (const org of cursor) {
+    counters.orgsScanned++;
+    const normalized = normalizeOrgName(org.name);
+    const hit = matchOrgTier1(normalized, index);
+    if (hit) {
+      hit.patientLaunchable = launchableById.get(String(hit.endpointId)) || false;
+      if (hit.requiresLocalityGuard) {
+        counters.lanternCandidates++;
+        if (!lanternGroups.has(normalized)) {
+          lanternGroups.set(normalized, { hit: hit, orgs: [] });
+        }
+        lanternGroups.get(normalized).orgs.push({ orgId: org._id, state: get(org, 'address.0.state') });
+      } else {
+        counters.vendorLinked++;
+        if (samples.length < SAMPLE_LIMIT) {
+          samples.push({ org: org.name, endpoint: hit.rawName, evidence: hit.evidence, tag: hit.endpointTag });
+        }
+        vendorWrites.push(linkWrite(org._id, hit, runId, now));
+        await flushVendor(false);
+      }
+    }
+    if (counters.orgsScanned % PROGRESS_EVERY === 0) {
+      await stampProgress({ progress: Object.assign({ running: true, phase: 'scan', runId: runId }, counters) });
+      log.info('linkage scan progress', counters);
+    }
+  }
+  await flushVendor(true);
+
+  // Phase 3: locality guard over lantern-evidence name groups.
+  let lanternWrites = [];
+  for (const [name, group] of lanternGroups) {
+    const states = group.orgs.map(function (o) { return o.state; });
+    if (!passesLocalityGuard(states)) {
+      counters.refusedLocality += group.orgs.length;
+      if (samples.length < SAMPLE_LIMIT) {
+        samples.push({ org: name, refused: 'locality (' + Array.from(new Set(states.filter(Boolean))).join(',') + ')' });
+      }
+      continue;
+    }
+    for (const orgRef of group.orgs) {
+      counters.lanternLinked++;
+      if (samples.length < SAMPLE_LIMIT) {
+        samples.push({ org: name, endpoint: group.hit.rawName, evidence: 'lantern-list', state: orgRef.state });
+      }
+      if (!dryRun) {
+        lanternWrites.push(linkWrite(orgRef.orgId, group.hit, runId, now));
+        if (lanternWrites.length >= WRITE_BATCH) {
+          await orgsRaw.bulkWrite(lanternWrites, { ordered: false });
+          flushed += lanternWrites.length;
+          lanternWrites = [];
+        }
+      }
+    }
+  }
+  if (!dryRun && lanternWrites.length) {
+    await orgsRaw.bulkWrite(lanternWrites, { ordered: false });
+    flushed += lanternWrites.length;
+  }
+
+  // Phase 4: prune links not re-confirmed by this run.
+  let pruned = 0;
+  if (prune && !dryRun) {
+    const result = await orgsRaw.updateMany(
+      { '_linkage.runId': { $exists: true, $ne: runId } },
+      { $unset: { endpoint: 1, _linkage: 1 } }
+    );
+    pruned = result.modifiedCount;
+  }
+
+  const summary = Object.assign({}, counters, {
+    linked: counters.vendorLinked + counters.lanternLinked,
+    written: flushed,
+    pruned: pruned,
+    dryRun: dryRun,
+    runId: runId,
+    finishedAt: new Date()
+  });
+  await stampProgress({ progress: Object.assign({ running: false, phase: 'done' }, summary), lastRunAt: now, samples: samples });
+  log.info('linkage run complete', summary);
+  return Object.assign({ samples: samples }, summary);
+}
+
+Meteor.ServerMethods.define('providerDirectory.linkEndpoints', {
+  description: 'Link NPPES organizations to connectable endpoints (tier-1 exact-name). Background job — poll providerDirectory.linkageStats. dryRun reports without writing; prune drops links not re-confirmed.',
+  requireAuth: true,
+  positionalParams: [],
+  schemaObject: {
+    type: 'object',
+    properties: {
+      dryRun: { type: 'boolean' },
+      prune: { type: 'boolean' }
+    }
+  }
+}, async function (params, context) {
+  if (linking) {
+    throw new Meteor.Error('busy', 'A linkage run is already in progress.');
+  }
+  linking = true;
+  const options = { dryRun: !!get(params, 'dryRun', false), prune: !!get(params, 'prune', false) };
+  runLinkEndpoints(options)
+    .catch(function (error) {
+      log.error('linkage run failed', { error: error.message });
+      return stampProgress({ progress: { running: false, phase: 'failed', error: error.message } });
+    })
+    .finally(function () { linking = false; });
+  return { started: true, dryRun: options.dryRun };
+});
+
+Meteor.ServerMethods.define('providerDirectory.linkageStats', {
+  description: 'Linkage progress, last-run summary + samples, and current link counts.',
+  requireAuth: false,
+  positionalParams: [],
+  schemaObject: { type: 'object', properties: {} }
+}, async function (params, context) {
+  const Organizations = getDirectoryCollection('Organization');
+  const raw = Organizations.rawCollection();
+  const [linked, launchableLinked] = await Promise.all([
+    raw.countDocuments({ _linkage: { $exists: true } }, { maxTimeMS: 5000 }).catch(function () { return -1; }),
+    raw.countDocuments({ '_linkage.patientLaunchable': true }, { maxTimeMS: 5000 }).catch(function () { return -1; })
+  ]);
+  let data = null;
+  const ServerConfiguration = get(global, 'Collections.ServerConfiguration');
+  if (ServerConfiguration) {
+    const doc = await ServerConfiguration.findOneAsync({ configType: CONFIG_TYPE });
+    data = get(doc, 'data', null);
+  }
+  return {
+    running: linking,
+    linked: linked,
+    launchableLinked: launchableLinked,
+    progress: get(data, 'progress', null),
+    samples: get(data, 'samples', []),
+    lastRunAt: get(data, 'lastRunAt', null)
+  };
+});
+
+Meteor.ServerMethods.define('providerDirectory.clearLinkage', {
+  description: 'Remove all org→endpoint links (full reversibility).',
+  requireAuth: true,
+  positionalParams: [],
+  schemaObject: { type: 'object', properties: {} }
+}, async function (params, context) {
+  const Organizations = getDirectoryCollection('Organization');
+  const result = await Organizations.rawCollection().updateMany(
+    { _linkage: { $exists: true } },
+    { $unset: { endpoint: 1, _linkage: 1 } }
+  );
+  log.info('linkage cleared', { modified: result.modifiedCount });
+  return { cleared: result.modifiedCount };
+});

--- a/npmPackages/provider-directory/server/methods.omniSearch.js
+++ b/npmPackages/provider-directory/server/methods.omniSearch.js
@@ -49,7 +49,8 @@ const SEARCH_TARGETS = [
   {
     resourceName: 'Organization',
     nameFields: ['name'],
-    projection: { name: 1, alias: 1, address: 1, telecom: 1, active: 1, id: 1 }
+    // endpoint + _linkage feed the console's "CONNECT VIA" chip (methods.linkage.js)
+    projection: { name: 1, alias: 1, address: 1, telecom: 1, active: 1, id: 1, endpoint: 1, _linkage: 1 }
   },
   {
     resourceName: 'Practitioner',

--- a/npmPackages/provider-directory/server/methods.omniSearch.js
+++ b/npmPackages/provider-directory/server/methods.omniSearch.js
@@ -262,9 +262,13 @@ Meteor.ServerMethods.define('providerDirectory.omniSearch', {
     return { q: q, totals: totals, lastUpdated: lastUpdated, results: [], searchMs: Date.now() - startedAt };
   }
 
+  // Postal facets (city/state/postalCode) never apply to the Endpoint band:
+  // FHIR Endpoint.address is a URL, not an Address, so any geographic facet
+  // would silence the band entirely (address.city can never match). Narrow
+  // the org/practitioner/location bands and let endpoints ride the free text.
   const results = await Promise.all(
     SEARCH_TARGETS.map(function(target) { return searchOneType(target, q, facets, limit); })
-      .concat([searchEndpointsUnified(q, facets, limit)])
+      .concat([searchEndpointsUnified(q, {}, limit)])
   );
 
   const searchMs = Date.now() - startedAt;

--- a/npmPackages/provider-directory/server/methods.omniSearch.js
+++ b/npmPackages/provider-directory/server/methods.omniSearch.js
@@ -32,8 +32,12 @@ import { backfillFilter } from '../lib/searchShadow.js';
 // against). We unify them at the READ layer here, tagging each hit with its
 // meta.source lineage so the console shows one logical directory.
 
-const RESULT_LIMIT_DEFAULT = 8;
-const RESULT_LIMIT_MAX = 25;
+// 200 per band by default (operator decision 2026-08-01): with the nameLower
+// indexes the query cost is trivial, and the console renders whole cohorts
+// (e.g. all 167 Deaconess-Evansville orgs) instead of an unreachable tail.
+// LOAD MORE pages the rest via {resourceName, skip}.
+const RESULT_LIMIT_DEFAULT = 200;
+const RESULT_LIMIT_MAX = 500;
 const COUNT_CAP = 1000;
 const PRIMARY_TIMEOUT_MS = 5000;
 const WIDEBAND_TIMEOUT_MS = 3000;
@@ -122,6 +126,14 @@ const shadowReadiness = new Map();   // cacheKey -> { ready, checkedAt }
 
 async function isShadowReady(rawCollection, resourceName, cacheKey) {
   const cached = shadowReadiness.get(cacheKey);
+  // STICKY once ready: proving "zero missing" is a full-collection scan
+  // (there is no index on field absence), so a ready verdict holds for the
+  // process lifetime. Safe because every writer stamps nameLower at write
+  // time — this probe only bridges the pre-backfill window. Not-ready
+  // verdicts recheck on the TTL so a finished backfill is picked up.
+  if (cached && cached.ready) {
+    return true;
+  }
   if (cached && (Date.now() - cached.checkedAt) < SHADOW_TTL_MS) {
     return cached.ready;
   }
@@ -138,6 +150,25 @@ async function isShadowReady(rawCollection, resourceName, cacheKey) {
   shadowReadiness.set(cacheKey, { ready: ready, checkedAt: Date.now() });
   return ready;
 }
+
+// Warm the readiness cache off the boot path so no user's first search pays
+// the proof-of-zero-missing collection scans (one-time per process).
+Meteor.startup(function() {
+  Meteor.setTimeout(async function() {
+    const warmTargets = [
+      { resourceName: 'Organization', cacheKey: 'Organization' },
+      { resourceName: 'Practitioner', cacheKey: 'Practitioner' },
+      { resourceName: 'Location', cacheKey: 'Location' },
+      { resourceName: 'Endpoint', cacheKey: 'Endpoint.core', raw: function() { return CoreEndpoints.rawCollection(); } },
+      { resourceName: 'Endpoint', cacheKey: 'Endpoint.directory', raw: function() { return getDirectoryCollection('Endpoint').rawCollection(); } }
+    ];
+    for (const target of warmTargets) {
+      const raw = target.raw ? target.raw() : getDirectoryCollection(target.resourceName).rawCollection();
+      await isShadowReady(raw, target.resourceName, target.cacheKey).catch(function() {});
+    }
+    console.log('[provider-directory] search shadow readiness warmed');
+  }, 20 * 1000);
+});
 
 // Selector builder that understands both modes. Endpoint keeps its address
 // branch (URLs are effectively lowercase already; queried as typed, anchored
@@ -178,12 +209,14 @@ function buildFacetSelector(params) {
   return extra;
 }
 
-async function searchOneType(target, q, facets, limit, rawOverride, cacheKey) {
+async function searchOneType(target, q, facets, limit, rawOverride, cacheKey, skip) {
   const raw = rawOverride || getDirectoryCollection(target.resourceName).rawCollection();
   const useShadow = await isShadowReady(raw, target.resourceName, cacheKey || target.resourceName);
   const prefixSelector = buildModeSelector(target, q, facets, { useShadow: useShadow, anchored: true });
+  const offset = skip > 0 ? skip : 0;
 
   let hits = await raw.find(prefixSelector, { projection: target.projection })
+    .skip(offset)
     .limit(limit)
     .maxTimeMS(PRIMARY_TIMEOUT_MS)
     .toArray()
@@ -196,8 +229,10 @@ async function searchOneType(target, q, facets, limit, rawOverride, cacheKey) {
 
   // Wide-band pass — mid-string matches when the prefix pass ran thin.
   // (Still a scan either way, but case-sensitive on nameLower is several
-  // times cheaper than $options:'i' over the raw name fields.)
-  if (hits.length < 3 && q.length >= WIDEBAND_MIN_QUERY) {
+  // times cheaper than $options:'i' over the raw name fields.) First page
+  // only — LOAD MORE pages walk the stable prefix selector, and the client
+  // dedupes by _id anyway.
+  if (offset === 0 && hits.length < 3 && q.length >= WIDEBAND_MIN_QUERY) {
     const wideSelector = buildModeSelector(target, q, facets, { useShadow: useShadow, anchored: false });
     const wideHits = await raw.find(wideSelector, { projection: target.projection })
       .limit(limit)
@@ -227,13 +262,16 @@ async function searchOneType(target, q, facets, limit, rawOverride, cacheKey) {
 // and the NPPES Directory.Endpoints mirror, tag each hit with its source +
 // connectability, and interleave with connectable (FHIR REST) results first so
 // the actionable endpoints surface at the top.
-async function searchEndpointsUnified(q, facets, limit) {
+async function searchEndpointsUnified(q, facets, limit, skip) {
   const coreRaw = CoreEndpoints.rawCollection();
   const directoryRaw = getDirectoryCollection('Endpoint').rawCollection();
 
+  // Pagination note: skip applies to BOTH collections, so a page can carry up
+  // to 2×limit candidates before the merge trims to limit — approximate but
+  // stable for console browsing, and the client dedupes appended pages by _id.
   const [core, directory] = await Promise.all([
-    searchOneType(ENDPOINT_TARGET, q, facets, limit, coreRaw, 'Endpoint.core'),
-    searchOneType(ENDPOINT_TARGET, q, facets, limit, directoryRaw, 'Endpoint.directory')
+    searchOneType(ENDPOINT_TARGET, q, facets, limit, coreRaw, 'Endpoint.core', skip),
+    searchOneType(ENDPOINT_TARGET, q, facets, limit, directoryRaw, 'Endpoint.directory', skip)
   ]);
 
   const coreHits = core.hits.map(function(hit) {
@@ -262,7 +300,7 @@ async function searchEndpointsUnified(q, facets, limit) {
 }
 
 Meteor.ServerMethods.define('providerDirectory.omniSearch', {
-  description: 'Free-text search across the National Directory (organizations, practitioners, locations, endpoints) with bounded counts and estimated totals.',
+  description: 'Free-text search across the National Directory (organizations, practitioners, locations, endpoints) with bounded counts and estimated totals. Pass resourceName + skip to page a single band (LOAD MORE).',
   requireAuth: false,
   positionalParams: ['q'],
   schemaObject: {
@@ -272,15 +310,34 @@ Meteor.ServerMethods.define('providerDirectory.omniSearch', {
       city: { type: 'string' },
       state: { type: 'string' },
       postalCode: { type: 'string' },
-      limit: { type: 'number' }
+      limit: { type: 'number' },
+      resourceName: { type: 'string', enum: ['Organization', 'Practitioner', 'Location', 'Endpoint'] },
+      skip: { type: 'number' }
     },
     required: ['q']
   }
 }, async function(params, context) {
   const q = (get(params, 'q', '') || '').trim();
   const limit = Math.min(Math.max(get(params, 'limit', RESULT_LIMIT_DEFAULT), 1), RESULT_LIMIT_MAX);
+  const skip = Math.max(get(params, 'skip', 0), 0);
+  const onlyResource = get(params, 'resourceName', null);
   const facets = buildFacetSelector(params);
   const startedAt = Date.now();
+
+  // Single-band page (LOAD MORE): skip the totals/lastUpdated ceremony and
+  // return just the requested band.
+  if (onlyResource && q.length >= 2) {
+    const band = onlyResource === 'Endpoint'
+      ? await searchEndpointsUnified(q, {}, limit, skip)
+      : await searchOneType(
+          SEARCH_TARGETS.find(function(t) { return t.resourceName === onlyResource; }),
+          q, facets, limit, null, onlyResource, skip
+        );
+    const pageMs = Date.now() - startedAt;
+    console.log('[provider-directory] omniSearch page "' + q + '" ' + onlyResource +
+      ' skip=' + skip + ' → ' + band.hits.length + ' in ' + pageMs + 'ms');
+    return { q: q, results: [band], searchMs: pageMs };
+  }
 
   // Last-updated signal for the masthead: the most recent endpoint-directory
   // sync (lantern/epic/cerner all stamp ServerConfiguration.lanternSync.lastSyncAt).

--- a/npmPackages/provider-directory/server/methods.omniSearch.js
+++ b/npmPackages/provider-directory/server/methods.omniSearch.js
@@ -22,6 +22,7 @@ import { Meteor } from 'meteor/meteor';
 import { get } from 'lodash';
 import { getDirectoryCollection } from '../lib/DirectoryCollections.js';
 import { Endpoints as CoreEndpoints } from '/imports/lib/schemas/SimpleSchemas/Endpoints.js';
+import { backfillFilter } from '../lib/searchShadow.js';
 
 // Endpoints live in TWO physical collections (a deliberate scale split — see
 // lib/DirectoryCollections.js): the CMS National Directory mirror
@@ -105,6 +106,59 @@ function buildNameSelector(nameFields, regex, extra) {
   return Object.assign({}, selector, extra);
 }
 
+// ---------------------------------------------------------------------------
+// nameLower shadow readiness (lib/searchShadow.js)
+//
+// When a collection's shadow backfill is complete, the primary pass switches
+// from `$regex ^q i` on the name fields (unindexable) to a CASE-SENSITIVE
+// `^q.toLowerCase()` regex on the indexed nameLower field. Until then, the
+// legacy selector runs unchanged. Readiness is a capped count (limit 1) with
+// a 60s TTL cache — cheap, and self-heals after an NPPES re-install wipes
+// shadows (replaceOne) or a backfill completes.
+
+const SHADOW_TTL_MS = 60 * 1000;
+const shadowReadiness = new Map();   // cacheKey -> { ready, checkedAt }
+
+async function isShadowReady(rawCollection, resourceName, cacheKey) {
+  const cached = shadowReadiness.get(cacheKey);
+  if (cached && (Date.now() - cached.checkedAt) < SHADOW_TTL_MS) {
+    return cached.ready;
+  }
+  let ready = false;
+  try {
+    const missing = await rawCollection.countDocuments(backfillFilter(resourceName), {
+      limit: 1,
+      maxTimeMS: 2000
+    });
+    ready = missing === 0;
+  } catch (error) {
+    ready = false;
+  }
+  shadowReadiness.set(cacheKey, { ready: ready, checkedAt: Date.now() });
+  return ready;
+}
+
+// Selector builder that understands both modes. Endpoint keeps its address
+// branch (URLs are effectively lowercase already; queried as typed, anchored
+// or not, so the $or stays fully indexed alongside {address:1}).
+function buildModeSelector(target, q, facets, { useShadow, anchored }) {
+  const escaped = escapeRegex(q);
+  if (!useShadow) {
+    const regex = anchored
+      ? { $regex: '^' + escaped, $options: 'i' }
+      : { $regex: escaped, $options: 'i' };
+    return buildNameSelector(target.nameFields, regex, facets);
+  }
+  const lowered = escapeRegex(q.toLowerCase());
+  const shadowRegex = anchored ? { $regex: '^' + lowered } : { $regex: lowered };
+  const clauses = [{ nameLower: shadowRegex }];
+  if (target.nameFields.indexOf('address') >= 0) {
+    clauses.push({ address: anchored ? { $regex: '^' + escaped } : { $regex: escaped } });
+  }
+  const selector = clauses.length === 1 ? clauses[0] : { $or: clauses };
+  return Object.assign({}, selector, facets);
+}
+
 // Optional facet narrowing (the "precision scan" drawer).
 function buildFacetSelector(params) {
   const extra = {};
@@ -123,11 +177,10 @@ function buildFacetSelector(params) {
   return extra;
 }
 
-async function searchOneType(target, q, facets, limit, rawOverride) {
+async function searchOneType(target, q, facets, limit, rawOverride, cacheKey) {
   const raw = rawOverride || getDirectoryCollection(target.resourceName).rawCollection();
-  const escaped = escapeRegex(q);
-  const prefixRegex = { $regex: '^' + escaped, $options: 'i' };
-  const prefixSelector = buildNameSelector(target.nameFields, prefixRegex, facets);
+  const useShadow = await isShadowReady(raw, target.resourceName, cacheKey || target.resourceName);
+  const prefixSelector = buildModeSelector(target, q, facets, { useShadow: useShadow, anchored: true });
 
   let hits = await raw.find(prefixSelector, { projection: target.projection })
     .limit(limit)
@@ -141,9 +194,10 @@ async function searchOneType(target, q, facets, limit, rawOverride) {
   }).catch(function() { return hits.length; });
 
   // Wide-band pass — mid-string matches when the prefix pass ran thin.
+  // (Still a scan either way, but case-sensitive on nameLower is several
+  // times cheaper than $options:'i' over the raw name fields.)
   if (hits.length < 3 && q.length >= WIDEBAND_MIN_QUERY) {
-    const wideRegex = { $regex: escaped, $options: 'i' };
-    const wideSelector = buildNameSelector(target.nameFields, wideRegex, facets);
+    const wideSelector = buildModeSelector(target, q, facets, { useShadow: useShadow, anchored: false });
     const wideHits = await raw.find(wideSelector, { projection: target.projection })
       .limit(limit)
       .maxTimeMS(WIDEBAND_TIMEOUT_MS)
@@ -177,8 +231,8 @@ async function searchEndpointsUnified(q, facets, limit) {
   const directoryRaw = getDirectoryCollection('Endpoint').rawCollection();
 
   const [core, directory] = await Promise.all([
-    searchOneType(ENDPOINT_TARGET, q, facets, limit, coreRaw),
-    searchOneType(ENDPOINT_TARGET, q, facets, limit, directoryRaw)
+    searchOneType(ENDPOINT_TARGET, q, facets, limit, coreRaw, 'Endpoint.core'),
+    searchOneType(ENDPOINT_TARGET, q, facets, limit, directoryRaw, 'Endpoint.directory')
   ]);
 
   const coreHits = core.hits.map(function(hit) {

--- a/npmPackages/provider-directory/server/methods.searchIndex.js
+++ b/npmPackages/provider-directory/server/methods.searchIndex.js
@@ -1,0 +1,137 @@
+// npmPackages/provider-directory/server/methods.searchIndex.js
+//
+// nameLower shadow-field backfill for the directory search indexes.
+//
+//   providerDirectory.searchIndexStatus   — per-collection {total, missing, ready}
+//   providerDirectory.backfillSearchIndex — background job: one server-side
+//     updateMany (aggregation pipeline, lib/searchShadow.js) per collection.
+//
+// The backfill is BUTTON-triggered, never automatic — an unsolicited write
+// over 4.7M documents on boot of a desktop app is hostile. It is idempotent
+// by construction: the filter only matches docs missing the shadow, and the
+// hydration writers (installResource, lantern bulkUpsertEndpoints) stamp new
+// rows going forward, so re-runs converge to zero work.
+
+import { Meteor } from 'meteor/meteor';
+import { get } from 'lodash';
+import { getDirectoryCollection } from '../lib/DirectoryCollections.js';
+import { Endpoints as CoreEndpoints } from '/imports/lib/schemas/SimpleSchemas/Endpoints.js';
+import { nameLowerPipeline, backfillFilter } from '../lib/searchShadow.js';
+
+const log = (Meteor.Logger ? Meteor.Logger.for('provider-directory') : console);
+
+const CONFIG_TYPE = 'directorySearchIndex';
+const MISSING_COUNT_CAP = 1001;   // "1000+" is enough signal for the UI
+const COUNT_TIMEOUT_MS = 5000;
+
+// One backfill at a time (module-level; mirrors methods.directory.js activeJob).
+let backfillRunning = false;
+
+// The five searchable surfaces. resourceName drives the pipeline/filter
+// shape (Practitioner is the multikey special case); core Endpoints reuses
+// the Endpoint scalar shape.
+function backfillTargets() {
+  return [
+    { label: 'Directory.Organizations', resourceName: 'Organization', collection: getDirectoryCollection('Organization') },
+    { label: 'Directory.Locations', resourceName: 'Location', collection: getDirectoryCollection('Location') },
+    { label: 'Directory.Practitioners', resourceName: 'Practitioner', collection: getDirectoryCollection('Practitioner') },
+    { label: 'Directory.Endpoints', resourceName: 'Endpoint', collection: getDirectoryCollection('Endpoint') },
+    { label: 'Endpoints', resourceName: 'Endpoint', collection: CoreEndpoints }
+  ];
+}
+
+async function stampProgress(patch) {
+  const ServerConfiguration = get(global, 'Collections.ServerConfiguration');
+  if (!ServerConfiguration) {
+    return;
+  }
+  const existing = await ServerConfiguration.findOneAsync({ configType: CONFIG_TYPE });
+  const nextData = Object.assign({}, get(existing, 'data', {}), patch);
+  if (existing) {
+    await ServerConfiguration.updateAsync({ _id: existing._id }, { $set: { data: nextData, updatedAt: new Date() } });
+  } else {
+    await ServerConfiguration.insertAsync({ configType: CONFIG_TYPE, data: nextData, updatedAt: new Date() });
+  }
+}
+
+async function runBackfill() {
+  const startedAt = new Date();
+  const summary = [];
+  try {
+    for (const target of backfillTargets()) {
+      if (!target.collection) {
+        continue;
+      }
+      await stampProgress({ running: true, phase: target.label, startedAt: startedAt });
+      const t0 = Date.now();
+      const result = await target.collection.rawCollection().updateMany(
+        backfillFilter(target.resourceName),
+        nameLowerPipeline(target.resourceName)
+      );
+      const entry = { collection: target.label, modified: result.modifiedCount, ms: Date.now() - t0 };
+      summary.push(entry);
+      log.info('search-index backfill pass complete', entry);
+    }
+  } catch (error) {
+    log.error('search-index backfill failed', { error: error.message });
+    await stampProgress({ running: false, error: error.message, finishedAt: new Date() });
+    return;
+  } finally {
+    backfillRunning = false;
+  }
+  await stampProgress({ running: false, phase: 'done', summary: summary, error: null, finishedAt: new Date() });
+  log.info('search-index backfill complete', { collections: summary.length });
+}
+
+Meteor.ServerMethods.define('providerDirectory.searchIndexStatus', {
+  description: 'Per-collection readiness of the nameLower search shadow (total, missing, ready).',
+  requireAuth: false,
+  positionalParams: [],
+  schemaObject: { type: 'object', properties: {} }
+}, async function (params, context) {
+  const collections = [];
+  for (const target of backfillTargets()) {
+    if (!target.collection) {
+      continue;
+    }
+    const raw = target.collection.rawCollection();
+    const total = await raw.estimatedDocumentCount().catch(function () { return 0; });
+    const missing = await raw.countDocuments(backfillFilter(target.resourceName), {
+      limit: MISSING_COUNT_CAP,
+      maxTimeMS: COUNT_TIMEOUT_MS
+    }).catch(function () { return -1; });
+    collections.push({
+      collection: target.label,
+      total: total,
+      missing: missing,
+      missingCapped: missing >= MISSING_COUNT_CAP,
+      ready: missing === 0
+    });
+  }
+
+  let progress = null;
+  const ServerConfiguration = get(global, 'Collections.ServerConfiguration');
+  if (ServerConfiguration) {
+    const doc = await ServerConfiguration.findOneAsync({ configType: CONFIG_TYPE });
+    progress = get(doc, 'data', null);
+  }
+  return { collections: collections, running: backfillRunning, progress: progress };
+});
+
+Meteor.ServerMethods.define('providerDirectory.backfillSearchIndex', {
+  description: 'Backfill the nameLower search shadow across the directory collections (background job; poll searchIndexStatus).',
+  requireAuth: true,
+  positionalParams: [],
+  schemaObject: { type: 'object', properties: {} }
+}, async function (params, context) {
+  if (backfillRunning) {
+    throw new Meteor.Error('busy', 'A search-index backfill is already running.');
+  }
+  backfillRunning = true;
+  // Fire and return — the panel polls providerDirectory.searchIndexStatus.
+  runBackfill().catch(function (error) {
+    backfillRunning = false;
+    log.error('search-index backfill crashed', { error: error.message });
+  });
+  return { started: true };
+});

--- a/npmPackages/provider-directory/server/startup.indexes.js
+++ b/npmPackages/provider-directory/server/startup.indexes.js
@@ -1,0 +1,45 @@
+// npmPackages/provider-directory/server/startup.indexes.js
+//
+// Directory search indexes. omniSearch queries the nameLower shadow field
+// (lib/searchShadow.js) with case-sensitive ^prefix regexes, which are
+// index-bounded — these indexes are what turn the 5s directory search into
+// a sub-second one. {address:1} on the two Endpoint collections keeps the
+// unified endpoint band's $or fully indexed (one unindexable branch would
+// degrade the whole $or to a scan).
+//
+// createIndexAsync is idempotent (no-op when the index already exists).
+// Index creation is safe BEFORE the backfill runs — docs without the field
+// simply index as null and never match a ^prefix regex.
+
+import { Meteor } from 'meteor/meteor';
+import { getDirectoryCollection } from '../lib/DirectoryCollections.js';
+import { Endpoints as CoreEndpoints } from '/imports/lib/schemas/SimpleSchemas/Endpoints.js';
+
+const log = (Meteor.Logger ? Meteor.Logger.for('provider-directory') : console);
+
+Meteor.startup(async function () {
+  const specs = [
+    { label: 'Directory.Organizations', collection: getDirectoryCollection('Organization'), keys: [{ nameLower: 1 }, { '_linkage.runId': 1 }] },
+    { label: 'Directory.Locations', collection: getDirectoryCollection('Location'), keys: [{ nameLower: 1 }] },
+    { label: 'Directory.Practitioners', collection: getDirectoryCollection('Practitioner'), keys: [{ nameLower: 1 }] },
+    { label: 'Directory.Endpoints', collection: getDirectoryCollection('Endpoint'), keys: [{ nameLower: 1 }, { address: 1 }] },
+    { label: 'Endpoints (core)', collection: CoreEndpoints, keys: [{ nameLower: 1 }, { address: 1 }] }
+  ];
+
+  for (const spec of specs) {
+    if (!spec.collection) {
+      log.warn('search index skipped — collection missing', { label: spec.label });
+      continue;
+    }
+    for (const keys of spec.keys) {
+      try {
+        // _linkage.runId is sparse — only linked orgs carry it (WS3 prune/stats).
+        const options = keys['_linkage.runId'] ? { sparse: true } : {};
+        await spec.collection.createIndexAsync(keys, options);
+      } catch (error) {
+        log.warn('search index create failed', { label: spec.label, keys: keys, error: error.message });
+      }
+    }
+  }
+  log.info('directory search indexes ensured');
+});

--- a/package.json
+++ b/package.json
@@ -64,7 +64,8 @@
     "test:smart-launch": "node --experimental-detect-module --test tests/unit/imports/lib/SmartLaunch.test.mjs",
     "test:analytics-scrub": "node --experimental-detect-module --test tests/unit/imports/lib/scrubAnalyticsPath.test.mjs",
     "test:update-check": "node --experimental-detect-module --test tests/unit/imports/lib/updateCheck.test.mjs",
-    "test:search-shadow": "node --experimental-detect-module --test tests/unit/npmPackages/provider-directory/searchShadow.test.mjs"
+    "test:search-shadow": "node --experimental-detect-module --test tests/unit/npmPackages/provider-directory/searchShadow.test.mjs",
+    "test:org-linkage": "node --experimental-detect-module --test tests/unit/npmPackages/provider-directory/OrgEndpointLinkage.test.mjs"
   },
   "dependencies": {
     "@accounts/client": "0.33.1",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,8 @@
     "test:conformance-probe": "node --experimental-detect-module --test tests/unit/imports/lib/EndpointConformanceProbe.test.mjs",
     "test:smart-launch": "node --experimental-detect-module --test tests/unit/imports/lib/SmartLaunch.test.mjs",
     "test:analytics-scrub": "node --experimental-detect-module --test tests/unit/imports/lib/scrubAnalyticsPath.test.mjs",
-    "test:update-check": "node --experimental-detect-module --test tests/unit/imports/lib/updateCheck.test.mjs"
+    "test:update-check": "node --experimental-detect-module --test tests/unit/imports/lib/updateCheck.test.mjs",
+    "test:search-shadow": "node --experimental-detect-module --test tests/unit/npmPackages/provider-directory/searchShadow.test.mjs"
   },
   "dependencies": {
     "@accounts/client": "0.33.1",

--- a/tests/unit/npmPackages/provider-directory/OrgEndpointLinkage.test.mjs
+++ b/tests/unit/npmPackages/provider-directory/OrgEndpointLinkage.test.mjs
@@ -1,0 +1,138 @@
+// tests/unit/npmPackages/provider-directory/OrgEndpointLinkage.test.mjs
+//
+// node --test tests/unit/npmPackages/provider-directory/OrgEndpointLinkage.test.mjs
+//
+// Tier-1 org→endpoint linkage: exact normalized-name membership only,
+// precision over recall. The named traps these tests pin down:
+//   - Beth Israel Deaconess must NEVER link via a Deaconess-Evansville name
+//   - Spokane's "Deaconess Hospital" (athena lantern list) vs Evansville's
+//     NPPES org of the same name → lantern-list evidence carries a locality
+//     guard (refused when the org name spans multiple states)
+//   - generic names ("clinic", "family medicine") never link
+//   - vendor system names (epic-open/cerner) are preferred over lantern lists
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  normalizeOrgName,
+  splitEndpointDisplayNames,
+  buildEndpointNameIndex,
+  matchOrgTier1,
+  passesLocalityGuard,
+  GENERIC_NAMES
+} from '../../../../npmPackages/provider-directory/lib/OrgEndpointLinkage.js';
+
+test('normalizeOrgName casefolds, strips punctuation and stacked legal suffixes', () => {
+  assert.equal(normalizeOrgName('DEACONESS HOSPITAL, INC.'), 'deaconess hospital');
+  assert.equal(normalizeOrgName('Deaconess Health System'), 'deaconess health system');
+  assert.equal(normalizeOrgName('Acme Medical Group, LLC, Inc'), 'acme medical group');
+  assert.equal(normalizeOrgName('Smith & Jones, P.C.'), 'smith and jones');
+  assert.equal(normalizeOrgName('  Waco   Family  Medicine  '), 'waco family medicine');
+  assert.equal(normalizeOrgName(''), '');
+  assert.equal(normalizeOrgName(null), '');
+  // suffix token alone never empties a real name
+  assert.equal(normalizeOrgName('INC'), 'inc');
+});
+
+test('splitEndpointDisplayNames handles the three lineage shapes', () => {
+  const lantern = {
+    _id: 'l1',
+    name: 'Deaconess Hospital; LIBERTY LAKE; VALLEY HOSPITAL AND MEDICAL CENTER',
+    meta: { tag: [{ code: 'lantern' }] }
+  };
+  assert.deepEqual(splitEndpointDisplayNames(lantern), [
+    { raw: 'Deaconess Hospital', normalized: 'deaconess hospital' },
+    { raw: 'LIBERTY LAKE', normalized: 'liberty lake' },
+    { raw: 'VALLEY HOSPITAL AND MEDICAL CENTER', normalized: 'valley hospital and medical center' }
+  ]);
+
+  const epic = { _id: 'e1', name: 'Deaconess Health System', meta: { tag: [{ code: 'epic-open' }] } };
+  assert.deepEqual(splitEndpointDisplayNames(epic), [
+    { raw: 'Deaconess Health System', normalized: 'deaconess health system' }
+  ]);
+
+  const cerner = {
+    _id: 'c1',
+    name: 'Centra Health, Inc.',
+    alias: ['Centra'],
+    managingOrganization: { display: 'Centra Health, Inc.' },
+    meta: { tag: [{ code: 'cerner-ignite' }] }
+  };
+  const cernerNames = splitEndpointDisplayNames(cerner).map(function (n) { return n.normalized; });
+  assert.deepEqual(cernerNames.sort(), ['centra', 'centra health']);
+});
+
+test('buildEndpointNameIndex maps names and prefers vendor entries at match time', () => {
+  const endpoints = [
+    { _id: 'epicDeac', name: 'Deaconess Health System', meta: { tag: [{ code: 'epic-open' }] }, conformance: { patientLaunchable: true } },
+    // The same system name also appears inside an athena lantern list
+    { _id: 'athena13205', name: 'Ardmore Ortho Plus, LLC; Deaconess Health System; Diesselhorst', meta: { tag: [{ code: 'lantern' }] } },
+    // Spokane's Deaconess Hospital in a different athena list
+    { _id: 'athena11921', name: 'Deaconess Hospital; LIBERTY LAKE; VALLEY HOSPITAL', meta: { tag: [{ code: 'lantern' }] } }
+  ];
+  const index = buildEndpointNameIndex(endpoints);
+
+  // Vendor system-name evidence wins over the lantern list containing the same name.
+  const system = matchOrgTier1('deaconess health system', index);
+  assert.equal(system.endpointId, 'epicDeac');
+  assert.equal(system.evidence, 'vendor-name');
+  assert.equal(system.requiresLocalityGuard, false);
+  assert.ok(system.confidence >= 0.9);
+
+  // Lantern-list-only evidence links, but flagged for the locality guard.
+  const listOnly = matchOrgTier1('deaconess hospital', index);
+  assert.equal(listOnly.endpointId, 'athena11921');
+  assert.equal(listOnly.evidence, 'lantern-list');
+  assert.equal(listOnly.requiresLocalityGuard, true);
+
+  // Beth Israel Deaconess: exact equality means NO entry matches.
+  assert.equal(matchOrgTier1('beth israel deaconess medical center', index), null);
+});
+
+test('ambiguous lantern names (same name in multiple lantern endpoints) are refused', () => {
+  const endpoints = [
+    { _id: 'a1', name: 'Sunrise Family Practice; Other One', meta: { tag: [{ code: 'lantern' }] } },
+    { _id: 'a2', name: 'Sunrise Family Practice; Different Group', meta: { tag: [{ code: 'lantern' }] } }
+  ];
+  const index = buildEndpointNameIndex(endpoints);
+  assert.equal(matchOrgTier1('sunrise family practice', index), null);
+});
+
+test('generic and short names never link', () => {
+  const endpoints = [
+    { _id: 'g1', name: 'Clinic; The Medical Center; Family Medicine', meta: { tag: [{ code: 'lantern' }] } },
+    { _id: 'g2', name: 'Acme', meta: { tag: [{ code: 'epic-open' }] } }
+  ];
+  const index = buildEndpointNameIndex(endpoints);
+  assert.ok(GENERIC_NAMES.has('clinic'));
+  assert.equal(matchOrgTier1('clinic', index), null);               // generic
+  assert.equal(matchOrgTier1('medical center', index), null);       // generic (article stripped upstream is fine either way)
+  assert.equal(matchOrgTier1('acme', index), null);                 // too short (<5)
+});
+
+test('vendor multi-endpoint same name prefers patientLaunchable, then tag rank', () => {
+  const endpoints = [
+    { _id: 'cernerX', name: 'Mercy Health System', meta: { tag: [{ code: 'cerner-ignite' }] }, conformance: { patientLaunchable: true } },
+    { _id: 'epicX', name: 'Mercy Health System', meta: { tag: [{ code: 'epic-open' }] } }
+  ];
+  const index = buildEndpointNameIndex(endpoints);
+  const hit = matchOrgTier1('mercy health system', index);
+  // launchable cerner beats unprobed epic
+  assert.equal(hit.endpointId, 'cernerX');
+
+  const endpoints2 = [
+    { _id: 'cernerY', name: 'Mercy Health System', meta: { tag: [{ code: 'cerner-ignite' }] } },
+    { _id: 'epicY', name: 'Mercy Health System', meta: { tag: [{ code: 'epic-open' }] } }
+  ];
+  const hit2 = matchOrgTier1('mercy health system', buildEndpointNameIndex(endpoints2));
+  // neither probed → epic-open outranks cerner-ignite
+  assert.equal(hit2.endpointId, 'epicY');
+});
+
+test('passesLocalityGuard: single-state groups pass, multi-state homonyms fail', () => {
+  assert.equal(passesLocalityGuard(['IN', 'IN', 'IN']), true);
+  assert.equal(passesLocalityGuard(['IN']), true);
+  assert.equal(passesLocalityGuard([]), true);                       // no state data at all → nothing contradicts locality
+  assert.equal(passesLocalityGuard(['IN', undefined, 'IN']), true);  // missing states ignored
+  assert.equal(passesLocalityGuard(['WA', 'IN']), false);            // Spokane vs Evansville
+});

--- a/tests/unit/npmPackages/provider-directory/searchShadow.test.mjs
+++ b/tests/unit/npmPackages/provider-directory/searchShadow.test.mjs
@@ -1,0 +1,101 @@
+// tests/unit/npmPackages/provider-directory/searchShadow.test.mjs
+//
+// node --test tests/unit/npmPackages/provider-directory/searchShadow.test.mjs
+//
+// The nameLower shadow field powers index-bounded case-sensitive prefix
+// search in omniSearch (case-insensitive $regex cannot use a B-tree index,
+// and Mongo collation does not apply to $regex). These are the pure shapes:
+// per-doc stamping for writers, the updateMany aggregation pipeline for
+// backfill, and the missing-docs filter that drives both backfill and the
+// readiness check.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  toNameLower,
+  stampNameShadow,
+  nameLowerPipeline,
+  backfillFilter
+} from '../../../../npmPackages/provider-directory/lib/searchShadow.js';
+
+test('toNameLower lowercases strings and refuses everything else', () => {
+  assert.equal(toNameLower('DEACONESS HOSPITAL INC'), 'deaconess hospital inc');
+  assert.equal(toNameLower('Waco Family Medicine'), 'waco family medicine');
+  assert.equal(toNameLower(''), undefined);
+  assert.equal(toNameLower(null), undefined);
+  assert.equal(toNameLower(undefined), undefined);
+  assert.equal(toNameLower(42), undefined);
+  assert.equal(toNameLower({ div: 'x' }), undefined);
+});
+
+test('stampNameShadow stamps scalar collections from name', () => {
+  const org = { name: 'DEACONESS HOSPITAL INC' };
+  stampNameShadow('Organization', org);
+  assert.equal(org.nameLower, 'deaconess hospital inc');
+
+  const endpoint = { name: 'Deaconess Health System', address: 'https://x' };
+  stampNameShadow('Endpoint', endpoint);
+  assert.equal(endpoint.nameLower, 'deaconess health system');
+
+  // nameless doc → no field (never null — the field is simply absent)
+  const bare = { address: 'https://y' };
+  stampNameShadow('Endpoint', bare);
+  assert.equal('nameLower' in bare, false);
+
+  // non-string name → no field
+  const junk = { name: { weird: true } };
+  stampNameShadow('Location', junk);
+  assert.equal('nameLower' in junk, false);
+});
+
+test('stampNameShadow builds the multikey array for Practitioner', () => {
+  const practitioner = {
+    name: [
+      { text: 'Dr. Jane Doe', family: 'Doe', given: ['Jane'] },
+      { family: 'DOE-SMITH' },
+      { given: ['NoFamily'] },        // no text/family → contributes nothing
+      null                             // junk entry tolerated
+    ]
+  };
+  stampNameShadow('Practitioner', practitioner);
+  assert.deepEqual(practitioner.nameLower, ['dr. jane doe', 'doe', 'doe-smith']);
+
+  const empty = { name: [] };
+  stampNameShadow('Practitioner', empty);
+  assert.equal('nameLower' in empty, false);
+
+  const missing = {};
+  stampNameShadow('Practitioner', missing);
+  assert.equal('nameLower' in missing, false);
+});
+
+test('nameLowerPipeline scalar shape guards $type and uses $$REMOVE', () => {
+  const pipeline = nameLowerPipeline('Organization');
+  assert.ok(Array.isArray(pipeline) && pipeline.length === 1);
+  const setStage = pipeline[0].$set.nameLower;
+  assert.deepEqual(setStage.$cond[0], { $eq: [{ $type: '$name' }, 'string'] });
+  assert.deepEqual(setStage.$cond[1], { $toLower: '$name' });
+  assert.equal(setStage.$cond[2], '$$REMOVE');
+});
+
+test('nameLowerPipeline Practitioner shape tolerates missing arrays and fields', () => {
+  const pipeline = nameLowerPipeline('Practitioner');
+  const expr = pipeline[0].$set.nameLower;
+  // Must guard non-array name and filter out empty strings.
+  const asJson = JSON.stringify(expr);
+  assert.ok(asJson.includes('$isArray'), 'guards non-array name');
+  assert.ok(asJson.includes('$filter'), 'filters empty contributions');
+  assert.ok(asJson.includes('$$n.text') && asJson.includes('$$n.family'), 'covers text and family');
+});
+
+test('backfillFilter selects docs with a string name but no shadow', () => {
+  assert.deepEqual(backfillFilter('Organization'), {
+    name: { $type: 'string' },
+    nameLower: { $exists: false }
+  });
+  // Practitioner: name is an array of HumanName
+  assert.deepEqual(backfillFilter('Practitioner'), {
+    name: { $type: 'array', $ne: [] },
+    nameLower: { $exists: false }
+  });
+});


### PR DESCRIPTION
## Summary

Provider-directory hardening, verified live against the full 4.78M-record national dataset. Three workstreams plus a bug fix, all E2E-proven tonight:

### 1. Endpoint band silenced by postal facets (`c750601e`)

The precision-scan city/state facets were applied to every omniSearch band — but `Endpoint.address` is a URL, so `address.city` could never match and any geographic facet guaranteed "BAND SILENT." Endpoints now ride the free text only. (This was the "can't find Deaconess" mystery: the data was there all along.)

### 2. Indexed prefix search — `nameLower` shadow field (`db3d1cb9`)

Case-insensitive `$regex` can't use B-tree indexes and collation doesn't apply to `$regex`, so omniSearch was scanning millions of rows per keystroke. Now: a lowercased shadow field (scalar; multikey on Practitioner), indexed, queried case-sensitively.

- Pure stamping/pipeline/filter lib (`lib/searchShadow.js`), 6/6 `node --test` on node 25 **and CI's node 20 binary**
- Startup `createIndexAsync` + button-triggered background backfill (idempotent updateMany-with-pipeline per collection) + panel card
- Writers stamp going forward: NPPES `installResource` (replaceOne wipes shadows — mandatory) + lantern hydration (companion commit `lantern@9ecbe18`)
- omniSearch: per-collection readiness cache (60s TTL) — indexed selectors when ready, byte-identical legacy behavior until then

**Measured**: "Deaconess" 7,036ms → 232ms warm (30×). Backfill stamped 4.98M docs in ~5.8 min. Bonus fix: the old unindexed count was silently timing out — `Organization: 8` was really `Organization: 495`.

### 3. Conformance sweep (companion `lantern@c3d8590`)

The deferred bulk half of the Endpoint Conformance Spider: pure DI'd `runSweepLoop` (bounded pool, per-host interleave, oldest-first cursor, 7-day re-probe skip, failures written as `healthTag:'down'` + `consecutiveFailures`), worker + methods + panel buttons + weekly cron (default OFF). 13/13 lantern tests incl. fake-collection smoke.

**Measured**: Epic 449/449 probed in ~2.5 min → 434 reachable, **431 patient-launchable** (incl. Deaconess Health System with its real authorize URL). Cerner 1,323/1,323 → **1,260 patient-launchable**. The connect picker went from 3 endpoints this morning to ~1,700 (now saturating its 200-row cap — follow-up: make the picker searchable).

### 4. Tier-1 org→endpoint linkage (`95c2f92e`)

NPPES orgs linked to connectable endpoints by **exact normalized-name membership** (precision over recall — a wrong link sends a patient to the wrong login). Pure matcher (7/7 tests) pins the named traps: Beth Israel Deaconess can never link via a Deaconess-Evansville name, and the Spokane-vs-Evansville "Deaconess Hospital" homonym is caught by the **locality guard** (lantern-list evidence refused when orgs sharing the name span multiple states; vendor system names skip the guard). FHIR-native writes (`Organization.endpoint` + `_linkage` provenance with runId), dry-run/prune/clear, streaming worker, panel card. Console renders **CONNECT VIA <endpoint>** on org rows gated on `patientLaunchable`, reusing the existing probe/connect bridge.

**Measured**: 2.8M orgs scanned in ~4.5 min. Dry run: 83,172 would-link, 40,794 refused by the locality guard (37% of lantern candidates — the guard earns its keep). Real run: 83,172 written, **12,429 orgs now carry a working CONNECT VIA chip** (verified live: Boulder Community Health org row → chip → probe/connect panel). Deaconess-Evansville orgs deliberately unlinked (homonym + no exact system-name match) — correct tier-1 behavior; tier-2 fuzzy matching is future work behind a dry-run gate.

## Test plan

- [x] `npm run test:search-shadow` — 6/6 (node 25 + real v20.11.0 binary)
- [x] `npm run test:org-linkage` — 7/7 (both nodes)
- [x] lantern `npm test` — 13/13
- [x] Live E2E on the 4.78M-record dev database: backfill → 30× search speedup; Epic+Cerner sweeps → 1,691 launchable; linkage dry-run → link → CONNECT VIA chip click-path
- [ ] CI green (both new suites are wired into `lib-unit-tests`)

Companion commits (already pushed): `orbital-health-systems/lantern@9ecbe18` (nameLower stamping) + `@c3d8590` (sweep).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
