### PR TITLE
Go-live UI polish: ambiance experience zones, IPS + sign-in + directory theming, dcmjs SAX parsing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -674,6 +674,9 @@ jobs:
           name: Ambiance image analysis (focus/ink/scrim/palette)
           command: npm run test:ambiance-analysis
       - run:
+          name: Ambiance composition contract
+          command: npm run test:ambiance-composition
+      - run:
           name: Directory search shadow (nameLower)
           command: npm run test:search-shadow
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -648,9 +648,10 @@ jobs:
       - run:
           name: global.Collections contract audit
           command: npm run audit:collections
-      # ESM-subject unit tests (imports/lib, zero imports — bare-checkout
-      # safe). Subjects use `export` in .js, so the scripts carry
-      # --experimental-detect-module for this job's node 20 (default-on ≥22).
+      # ESM-subject unit tests (imports/lib + imports/ui/theme + npmPackages,
+      # zero imports — bare-checkout safe). Subjects use `export` in .js, so
+      # the scripts carry --experimental-detect-module for this job's node 20
+      # (default-on ≥22).
       - run:
           name: SMART launch builders (PKCE)
           command: npm run test:smart-launch
@@ -968,7 +969,7 @@ workflows:
       - test-group:
           name: framework
           group-name: framework
-          test-files: "tests/nightwatch/honeycomb/enable_autopublish/simple-sorting-test.js tests/nightwatch/honeycomb/dev_auto_login/my.profile.js tests/nightwatch/honeycomb/default/localhost.js tests/nightwatch/honeycomb/enable_autopublish/crud.endpoints.js"
+          test-files: "tests/nightwatch/honeycomb/enable_autopublish/simple-sorting-test.js tests/nightwatch/honeycomb/dev_auto_login/my.profile.js tests/nightwatch/honeycomb/default/localhost.js tests/nightwatch/honeycomb/enable_autopublish/crud.endpoints.js tests/nightwatch/honeycomb/theme/ambianceControls.js"
       
       # ONC Health IT Certification test groups
       - test-group:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -677,6 +677,9 @@ jobs:
           name: Ambiance composition contract
           command: npm run test:ambiance-composition
       - run:
+          name: Ambiance surface styles
+          command: npm run test:surface-styles
+      - run:
           name: Directory search shadow (nameLower)
           command: npm run test:search-shadow
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -670,6 +670,9 @@ jobs:
           name: Ambiance background-value helpers
           command: npm run test:background-value
       - run:
+          name: Ambiance image analysis (focus/ink/scrim/palette)
+          command: npm run test:ambiance-analysis
+      - run:
           name: Directory search shadow (nameLower)
           command: npm run test:search-shadow
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -664,6 +664,9 @@ jobs:
           name: Release-feed update check
           command: npm run test:update-check
       - run:
+          name: Logger PHI redaction walker (bounded on arbitrary graphs)
+          command: npm run test:logger-redact
+      - run:
           name: Directory search shadow (nameLower)
           command: npm run test:search-shadow
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -667,6 +667,9 @@ jobs:
           name: Logger PHI redaction walker (bounded on arbitrary graphs)
           command: npm run test:logger-redact
       - run:
+          name: Ambiance background-value helpers
+          command: npm run test:background-value
+      - run:
           name: Directory search shadow (nameLower)
           command: npm run test:search-shadow
       - run:

--- a/client/main.css
+++ b/client/main.css
@@ -168,3 +168,13 @@ footer {
     display: none !important;
   }
 }
+/* RouteAnnouncer (imports/ui/a11y/RouteAnnouncer.jsx) programmatically focuses
+   #mainAppRouter on every navigation (WCAG 2.4.3). The focus itself is the
+   accessibility feature; the browser's default ring around the entire main
+   region is pure noise (2.4.7 applies to operable components, and a
+   tabindex="-1" container is not one) — it painted a full-page blue rectangle
+   on load until the first click. Suppress the ring, keep the focus. */
+#mainAppRouter:focus,
+#mainAppRouter:focus-visible {
+  outline: none;
+}

--- a/client/main.css
+++ b/client/main.css
@@ -144,6 +144,12 @@ footer {
     print-color-adjust: exact;
   }
 
+  /* Ambiance never prints: photo/solid canvas and zone scrims stay screen-only */
+  #mainAppRouter {
+    background-image: none !important;
+    background-color: #ffffff !important;
+  }
+
   /* Force dark-mode surfaces back to paper-white with readable text */
   .MuiCard-root,
   .MuiPaper-root,

--- a/docs/superpowers/plans/2026-08-03-ambiance-phase1-2-theme-axes-and-console-polish.md
+++ b/docs/superpowers/plans/2026-08-03-ambiance-phase1-2-theme-axes-and-console-polish.md
@@ -1,0 +1,1023 @@
+# Ambiance Phases 1+2: Theme Axes, Curation Records & Console Polish — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship Phases 1+2 of the Ambiance Experience Zone spec (`docs/superpowers/specs/2026-08-03-ambiance-experience-zone-design.md`): solid-color + curated backgrounds, `pageMode`/`cardSurface` persistence axes, the restructured Theme & Palette dialog, the ambiance analysis module, and the DirectoryConsole legibility/padding polish.
+
+**Architecture:** Pure helper modules (`backgroundValue.js`, `ambianceAnalysis.js`) carry the testable logic; `themePresets.js`/`themePersistence.js` gain two persisted axes surfaced through a reordered `ThemeControls`; `StyledMainRouter` learns to paint `color:`-prefixed backgrounds; DirectoryConsole consumes the persisted `pageMode` and gets its scrim/padding pass. No route flags yet — that is Phase 3.
+
+**Tech Stack:** Meteor v3 + React 18 + MUI v5, `node --test` unit tests (ESM subjects via `--experimental-detect-module`), Nightwatch E2E.
+
+## Global Constraints
+
+- Coding style (root `CLAUDE.md`): `function() {}` over arrow functions where `this`/readability matters; lodash `get()` for defensive reads; first line of every new file is its commented path; no `index.js` files.
+- File naming (`.claude/rules/conventions/file-naming.md`): camelCase for function-export modules (`backgroundValue.js`, `ambianceAnalysis.js`, `pageModeTheme.js`).
+- Theming (`.claude/rules/ui/theming.md`): no unconditional hardcoded surface colors in components; the modules built here ARE the theme system and may define color constants (earth tones) as data.
+- Unit tests live in `tests/unit/` mirroring source (`.claude/rules/testing/test-organization.md`); ESM subjects need `node --experimental-detect-module --test` (precedent: `test:session-key-groups`).
+- New unit-test npm scripts get CI steps in the same job that runs `test:logger-redact` (`.circleci/config.yml` ~line 652 — the "ESM-subject unit tests" block; these subjects are dependency-free so the bare checkout is fine).
+- Session keys that cross files use constants from `imports/lib/SessionKeys.js` (`.claude/rules/meteor/session-keys.md`).
+- Earth-tone palette (from spec): clay `#a67b5b`, sand `#d9c7a7`, terracotta `#b0674b`, moss `#6b7d5a`, sage `#a3b18a`, stone `#8d8578`, ochre `#c49a3c`, espresso `#4a3728`.
+- The working tree already carries uncommitted DirectoryConsole changes (`?align`, `?page-theme`, census filter, transparent root). Task 8 builds on and commits them — do NOT revert or stash them.
+- `git add` specific paths only — never `git add -A` (concurrent-session safety).
+
+---
+
+### Task 1: `backgroundValue.js` — solid-color background helpers
+
+**Files:**
+- Create: `imports/ui/theme/backgroundValue.js`
+- Test: `tests/unit/imports/ui/theme/backgroundValue.test.mjs`
+- Modify: `package.json` (scripts block, after `"test:session-key-groups"`)
+- Modify: `.circleci/config.yml` (add run step after the `test:logger-redact` step, ~line 668)
+
+**Interfaces:**
+- Consumes: nothing (pure module, zero imports)
+- Produces: `COLOR_BACKGROUND_PREFIX` (string `'color:'`), `isColorBackground(value) → boolean`, `colorFromBackground(value) → string|null` (extracts `'#a67b5b'` from `'color:#a67b5b'`), `makeColorBackground(hex) → string` (`'#a67b5b'` → `'color:#a67b5b'`). Tasks 3, 4, 7 import these.
+
+- [ ] **Step 1: Write the failing test**
+
+```javascript
+// tests/unit/imports/ui/theme/backgroundValue.test.mjs
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  COLOR_BACKGROUND_PREFIX, isColorBackground, colorFromBackground, makeColorBackground
+} from '../../../../../imports/ui/theme/backgroundValue.js';
+
+test('prefix constant is stable (persisted strings depend on it)', function() {
+  assert.equal(COLOR_BACKGROUND_PREFIX, 'color:');
+});
+
+test('isColorBackground distinguishes color entries from image paths', function() {
+  assert.equal(isColorBackground('color:#a67b5b'), true);
+  assert.equal(isColorBackground('/backgrounds/ambiance/Zen.jpg'), false);
+  assert.equal(isColorBackground(''), false);
+  assert.equal(isColorBackground(null), false);
+  assert.equal(isColorBackground(undefined), false);
+});
+
+test('colorFromBackground extracts the hex, null otherwise', function() {
+  assert.equal(colorFromBackground('color:#a67b5b'), '#a67b5b');
+  assert.equal(colorFromBackground('/backgrounds/ambiance/Zen.jpg'), null);
+  assert.equal(colorFromBackground(null), null);
+});
+
+test('makeColorBackground round-trips with colorFromBackground', function() {
+  const stored = makeColorBackground('#4a3728');
+  assert.equal(stored, 'color:#4a3728');
+  assert.equal(colorFromBackground(stored), '#4a3728');
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `node --experimental-detect-module --test tests/unit/imports/ui/theme/backgroundValue.test.mjs`
+Expected: FAIL — `Cannot find module` for `backgroundValue.js`
+
+- [ ] **Step 3: Write the implementation**
+
+```javascript
+// imports/ui/theme/backgroundValue.js
+//
+// Pure helpers for the extended background axis: an ambiance background is
+// either an image path ('/backgrounds/ambiance/Zen.jpg') or a solid color
+// stored as a 'color:'-prefixed string ('color:#a67b5b') on the SAME
+// persistence axis (themePersistence backgroundImagePath). Spec:
+// docs/superpowers/specs/2026-08-03-ambiance-experience-zone-design.md
+// Zero imports — bare-checkout node --test safe.
+
+export const COLOR_BACKGROUND_PREFIX = 'color:';
+
+export function isColorBackground(value) {
+  return typeof value === 'string' && value.indexOf(COLOR_BACKGROUND_PREFIX) === 0;
+}
+
+export function colorFromBackground(value) {
+  if (!isColorBackground(value)) { return null; }
+  return value.slice(COLOR_BACKGROUND_PREFIX.length);
+}
+
+export function makeColorBackground(hex) {
+  return COLOR_BACKGROUND_PREFIX + hex;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `node --experimental-detect-module --test tests/unit/imports/ui/theme/backgroundValue.test.mjs`
+Expected: PASS (4 tests)
+
+- [ ] **Step 5: Register the script + CI step**
+
+In `package.json` scripts, after `"test:session-key-groups"`:
+
+```json
+"test:background-value": "node --experimental-detect-module --test tests/unit/imports/ui/theme/backgroundValue.test.mjs",
+```
+
+In `.circleci/config.yml`, after the `test:logger-redact` run step (keep the surrounding "ESM-subject unit tests" comment block accurate):
+
+```yaml
+      - run:
+          name: Ambiance background-value helpers
+          command: npm run test:background-value
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add imports/ui/theme/backgroundValue.js tests/unit/imports/ui/theme/backgroundValue.test.mjs package.json .circleci/config.yml
+git commit -m "feat(theme): color-prefixed solid backgrounds share the ambiance axis"
+```
+
+---
+
+### Task 2: `ambianceAnalysis.js` — palette extraction + neutral-space analysis
+
+**Files:**
+- Create: `imports/ui/theme/ambianceAnalysis.js`
+- Test: `tests/unit/imports/ui/theme/ambianceAnalysis.test.mjs`
+- Modify: `package.json` + `.circleci/config.yml` (same pattern as Task 1)
+
+**Interfaces:**
+- Consumes: nothing (pure math + one browser-only wrapper)
+- Produces:
+  - `analyzeImageData({ data, width, height }) → { focus, recommendedPageMode, scrimStrength, palette }` — `data` is an RGBA byte array (`Uint8ClampedArray` or plain array), `focus ∈ 'left'|'center'|'right'`, `recommendedPageMode ∈ 'light'|'dark'`, `scrimStrength ∈ [0.35, 0.8]`, `palette` = up to 3 hex strings.
+  - `analyzeAmbianceImage(src) → Promise<record>` — browser wrapper (Image + canvas downsample to ≤96px wide), NOT unit-tested (DOM), used at curation time and later by the Tuning HUD / adaptive scrim.
+- Used by: curation of the default library (Task 3 seed values cite it), Phase 3 HUD, Phase 3.5 adaptive scrim.
+
+- [ ] **Step 1: Write the failing test**
+
+Synthetic-image helper + behavioral assertions (no image fixtures — deterministic arrays):
+
+```javascript
+// tests/unit/imports/ui/theme/ambianceAnalysis.test.mjs
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { analyzeImageData } from '../../../../../imports/ui/theme/ambianceAnalysis.js';
+
+// Build a width×height RGBA array from a per-column color function.
+function makeImage(width, height, colorAt) {
+  const data = new Uint8ClampedArray(width * height * 4);
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      const [r, g, b] = colorAt(x, y);
+      const i = (y * width + x) * 4;
+      data[i] = r; data[i + 1] = g; data[i + 2] = b; data[i + 3] = 255;
+    }
+  }
+  return { data, width, height };
+}
+
+test('bright image → light page mode; dark image → dark page mode', function() {
+  const bright = analyzeImageData(makeImage(30, 12, function() { return [235, 230, 220]; }));
+  assert.equal(bright.recommendedPageMode, 'light');
+  const dark = analyzeImageData(makeImage(30, 12, function() { return [18, 20, 24]; }));
+  assert.equal(dark.recommendedPageMode, 'dark');
+});
+
+test('focus lands on the lowest-variance (calmest) third', function() {
+  // Left third: flat gray. Center+right thirds: harsh checkerboard.
+  const img = makeImage(30, 12, function(x, y) {
+    if (x < 10) { return [128, 128, 128]; }
+    return ((x + y) % 2 === 0) ? [255, 255, 255] : [0, 0, 0];
+  });
+  assert.equal(analyzeImageData(img).focus, 'left');
+
+  const imgRight = makeImage(30, 12, function(x, y) {
+    if (x >= 20) { return [128, 128, 128]; }
+    return ((x + y) % 2 === 0) ? [255, 255, 255] : [0, 0, 0];
+  });
+  assert.equal(analyzeImageData(imgRight).focus, 'right');
+});
+
+test('scrimStrength is clamped to [0.35, 0.8] and grows with busyness', function() {
+  const calm = analyzeImageData(makeImage(30, 12, function() { return [128, 128, 128]; }));
+  const busy = analyzeImageData(makeImage(30, 12, function(x, y) {
+    return ((x + y) % 2 === 0) ? [255, 255, 255] : [0, 0, 0];
+  }));
+  assert.ok(calm.scrimStrength >= 0.35 && calm.scrimStrength <= 0.8);
+  assert.ok(busy.scrimStrength >= 0.35 && busy.scrimStrength <= 0.8);
+  assert.ok(busy.scrimStrength > calm.scrimStrength, 'busy image needs a stronger scrim');
+});
+
+test('palette returns up to 3 dominant hex colors', function() {
+  // Two dominant colors: warm amber left half, deep blue right half.
+  const img = makeImage(30, 12, function(x) {
+    return x < 15 ? [232, 165, 75] : [20, 40, 90];
+  });
+  const palette = analyzeImageData(img).palette;
+  assert.ok(Array.isArray(palette) && palette.length >= 2 && palette.length <= 3);
+  palette.forEach(function(hex) { assert.match(hex, /^#[0-9a-f]{6}$/); });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `node --experimental-detect-module --test tests/unit/imports/ui/theme/ambianceAnalysis.test.mjs`
+Expected: FAIL — `Cannot find module` for `ambianceAnalysis.js`
+
+- [ ] **Step 3: Write the implementation**
+
+```javascript
+// imports/ui/theme/ambianceAnalysis.js
+//
+// Palette extraction + neutral-space analysis for ambiance backgrounds.
+// analyzeImageData() is pure math over an RGBA byte array (unit-tested,
+// dependency-free); analyzeAmbianceImage() is the browser wrapper that
+// downsamples an <img> through a canvas and feeds it in. Outputs a draft
+// curation record for the background library. Curated values in the library
+// always win over these computed suggestions. Spec:
+// docs/superpowers/specs/2026-08-03-ambiance-experience-zone-design.md
+
+// Rec. 709 relative luminance, 0..1.
+function luminance(r, g, b) {
+  return (0.2126 * r + 0.7152 * g + 0.0722 * b) / 255;
+}
+
+// Mean + variance of luminance for pixels whose x falls in [x0, x1).
+function thirdStats(img, x0, x1) {
+  const { data, width, height } = img;
+  let sum = 0, sumSq = 0, n = 0;
+  for (let y = 0; y < height; y++) {
+    for (let x = x0; x < x1; x++) {
+      const i = (y * width + x) * 4;
+      const l = luminance(data[i], data[i + 1], data[i + 2]);
+      sum += l; sumSq += l * l; n++;
+    }
+  }
+  const mean = n ? sum / n : 0;
+  return { mean: mean, variance: n ? (sumSq / n) - (mean * mean) : 0 };
+}
+
+function toHex(v) {
+  const s = Math.round(v).toString(16);
+  return s.length === 1 ? '0' + s : s;
+}
+
+// Dominant colors: quantize to 4 bits/channel, count buckets, return the top
+// 3 distinct buckets as hex (bucket-center color).
+function dominantColors(img) {
+  const { data, width, height } = img;
+  const counts = {};
+  for (let p = 0; p < width * height; p++) {
+    const i = p * 4;
+    const key = ((data[i] >> 4) << 8) | ((data[i + 1] >> 4) << 4) | (data[i + 2] >> 4);
+    counts[key] = (counts[key] || 0) + 1;
+  }
+  return Object.keys(counts)
+    .sort(function(a, b) { return counts[b] - counts[a]; })
+    .slice(0, 3)
+    .map(function(key) {
+      const k = parseInt(key, 10);
+      const r = ((k >> 8) & 0xf) * 16 + 8;
+      const g = ((k >> 4) & 0xf) * 16 + 8;
+      const b = (k & 0xf) * 16 + 8;
+      return '#' + toHex(r) + toHex(g) + toHex(b);
+    });
+}
+
+export function analyzeImageData(img) {
+  const w = img.width;
+  const t1 = Math.floor(w / 3);
+  const t2 = Math.floor((2 * w) / 3);
+  const thirds = [
+    { focus: 'left', stats: thirdStats(img, 0, t1) },
+    { focus: 'center', stats: thirdStats(img, t1, t2) },
+    { focus: 'right', stats: thirdStats(img, t2, w) }
+  ];
+
+  // Neutral space = the calmest (lowest-variance) third.
+  const calmest = thirds.reduce(function(best, cur) {
+    return cur.stats.variance < best.stats.variance ? cur : best;
+  });
+
+  // Overall luminance decides which ink family survives the image.
+  const overallMean = (thirds[0].stats.mean + thirds[1].stats.mean + thirds[2].stats.mean) / 3;
+
+  // Scrim scales with the busyness of the third content will sit on.
+  // Variance of luminance tops out at 0.25 (half-black/half-white).
+  const scrim = Math.min(0.8, Math.max(0.35, 0.35 + (calmest.stats.variance / 0.25) * 0.45));
+
+  return {
+    focus: calmest.focus,
+    recommendedPageMode: overallMean >= 0.5 ? 'light' : 'dark',
+    scrimStrength: Math.round(scrim * 100) / 100,
+    palette: dominantColors(img)
+  };
+}
+
+// Browser wrapper: downsample via canvas (≤96px wide keeps this O(10k) pixels)
+// and analyze. Resolves null on any failure — callers treat null as
+// "no suggestions", never as an error.
+export function analyzeAmbianceImage(src) {
+  return new Promise(function(resolve) {
+    if (typeof document === 'undefined') { resolve(null); return; }
+    const image = new Image();
+    image.crossOrigin = 'anonymous';
+    image.onload = function() {
+      try {
+        const scale = Math.min(1, 96 / image.naturalWidth);
+        const w = Math.max(3, Math.round(image.naturalWidth * scale));
+        const h = Math.max(3, Math.round(image.naturalHeight * scale));
+        const canvas = document.createElement('canvas');
+        canvas.width = w; canvas.height = h;
+        const ctx = canvas.getContext('2d');
+        ctx.drawImage(image, 0, 0, w, h);
+        resolve(analyzeImageData(ctx.getImageData(0, 0, w, h)));
+      } catch (error) {
+        resolve(null); // tainted canvas / decode failure — no suggestions
+      }
+    };
+    image.onerror = function() { resolve(null); };
+    image.src = src;
+  });
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `node --experimental-detect-module --test tests/unit/imports/ui/theme/ambianceAnalysis.test.mjs`
+Expected: PASS (4 tests)
+
+- [ ] **Step 5: Register script + CI step** (same pattern as Task 1)
+
+`package.json`:
+
+```json
+"test:ambiance-analysis": "node --experimental-detect-module --test tests/unit/imports/ui/theme/ambianceAnalysis.test.mjs",
+```
+
+`.circleci/config.yml` (after the Task 1 step):
+
+```yaml
+      - run:
+          name: Ambiance image analysis (focus/ink/scrim/palette)
+          command: npm run test:ambiance-analysis
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add imports/ui/theme/ambianceAnalysis.js tests/unit/imports/ui/theme/ambianceAnalysis.test.mjs package.json .circleci/config.yml
+git commit -m "feat(theme): ambiance analysis module — neutral-space focus, ink mode, scrim, palette"
+```
+
+---
+
+### Task 3: Curation records + earth tones in the background library
+
+**Files:**
+- Modify: `imports/ui/themeBackgrounds.js`
+
+**Interfaces:**
+- Consumes: `makeColorBackground` from Task 1.
+- Produces: `DEFAULT_BACKGROUND_LIBRARY` entries with optional `focus` / `recommendedPageMode` / `scrimStrength` fields; new export `EARTH_TONES` = `[{ name, value }]` where `value` is a `color:`-prefixed string. `getBackgroundLibrary()` unchanged (passes records through, including operator-supplied ones). Task 7 renders `EARTH_TONES`; Task 8 reads the active entry's `scrimStrength`/`focus`.
+
+- [ ] **Step 1: Extend the library with curation records + earth tones**
+
+Replace `DEFAULT_BACKGROUND_LIBRARY` and append `EARTH_TONES` (keep the file header and `getBackgroundLibrary` as-is; update the file's doc comment to mention curation records + the spec path):
+
+```javascript
+import { makeColorBackground } from './theme/backgroundValue.js';
+
+// Default library (code fallback). Curated spa / zen / medical / gradient set.
+// Entries are CURATION RECORDS: beyond name/src, optional focus (where the
+// image's neutral space is: left|center|right), recommendedPageMode (which
+// ink family survives it), and scrimStrength (0-1 content-column scrim).
+// Seed values below were drafted with ambianceAnalysis.analyzeAmbianceImage()
+// and eyeballed; refine with the Tuning HUD (Phase 3). Omitted fields fall
+// back to: focus 'center', pageMode unset (app mode stands), scrim 0.55.
+export const DEFAULT_BACKGROUND_LIBRARY = [
+  { name: 'Zen Rocks',   src: BASE + '/Zen-Rocks.jpg',          focus: 'right',  recommendedPageMode: 'light', scrimStrength: 0.5 },
+  { name: 'Zen Garden',  src: BASE + '/Zen.jpg',                focus: 'center', recommendedPageMode: 'light', scrimStrength: 0.5 },
+  { name: 'Large Zen',   src: BASE + '/LargeZenRocks.jpg',      focus: 'right',  recommendedPageMode: 'light', scrimStrength: 0.55 },
+  { name: 'Bamboo',      src: BASE + '/BambooIllustration.jpg', focus: 'left',   recommendedPageMode: 'light', scrimStrength: 0.45 },
+  { name: 'Yoga Ocean',  src: BASE + '/Yoga-Ocean.jpg',         focus: 'left',   recommendedPageMode: 'dark',  scrimStrength: 0.6 },
+  { name: 'Spa Candles', src: BASE + '/Candles.jpg',            focus: 'center', recommendedPageMode: 'dark',  scrimStrength: 0.55 },
+  { name: 'Spa Beds',    src: BASE + '/SpaBeds.jpg',            focus: 'center', recommendedPageMode: 'light', scrimStrength: 0.55 },
+  { name: 'Bath Petals', src: BASE + '/BathPetals.jpg',         focus: 'center', recommendedPageMode: 'light', scrimStrength: 0.55 },
+  { name: 'Massage',     src: BASE + '/Massage.jpg',            focus: 'center', recommendedPageMode: 'dark',  scrimStrength: 0.55 },
+  { name: 'Med Bay',     src: BASE + '/MedBay.jpg',             focus: 'center', recommendedPageMode: 'dark',  scrimStrength: 0.6 },
+  { name: 'Plasmid',     src: BASE + '/PlasmidBlue.jpg',        focus: 'center', recommendedPageMode: 'dark',  scrimStrength: 0.55 },
+  { name: 'Gradient',    src: BASE + '/Gradient.jpg',           focus: 'center', recommendedPageMode: 'light', scrimStrength: 0.4 }
+];
+
+// Solid earth-tone backgrounds — row 2 of the dialog's Ambiance section.
+// Values ride the SAME persistence axis as images ('color:'-prefixed).
+export const EARTH_TONES = [
+  { name: 'Clay',       value: makeColorBackground('#a67b5b') },
+  { name: 'Sand',       value: makeColorBackground('#d9c7a7') },
+  { name: 'Terracotta', value: makeColorBackground('#b0674b') },
+  { name: 'Moss',       value: makeColorBackground('#6b7d5a') },
+  { name: 'Sage',       value: makeColorBackground('#a3b18a') },
+  { name: 'Stone',      value: makeColorBackground('#8d8578') },
+  { name: 'Ochre',      value: makeColorBackground('#c49a3c') },
+  { name: 'Espresso',   value: makeColorBackground('#4a3728') }
+];
+
+// Look up the active IMAGE background's curation record. Solid 'color:'
+// entries and unknown/operator paths return null — callers fall back to
+// defaults (focus 'center', scrim 0.55), which is correct for solids.
+export function getBackgroundEntry(activeValue) {
+  if (!activeValue) { return null; }
+  return getBackgroundLibrary().find(function(entry) { return entry.src === activeValue; }) || null;
+}
+```
+
+(`getBackgroundEntry` lives below `getBackgroundLibrary` so it can call it.)
+
+- [ ] **Step 2: Verify nothing broke at parse level**
+
+Run: `node --experimental-detect-module --check imports/ui/themeBackgrounds.js && echo PARSE-OK`
+Expected: `PARSE-OK` (the file imports Meteor so it can't *execute* under plain node — syntax check only; runtime verification comes with Task 7's dialog work).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add imports/ui/themeBackgrounds.js
+git commit -m "feat(theme): curation records + earth-tone solids in the background library"
+```
+
+---
+
+### Task 4: StyledMainRouter paints solid-color backgrounds
+
+**Files:**
+- Modify: `imports/ui/App.jsx` (the ambiance block inside `StyledMainRouter`, ~lines 1891-1898)
+
+**Interfaces:**
+- Consumes: `isColorBackground` / `colorFromBackground` from Task 1.
+- Produces: `#mainAppRouter` renders a flat color when the persisted background is `color:`-prefixed, the image otherwise. (Route gating comes in Phase 3 — for now behavior parity: backgrounds still show on all routes.)
+
+- [ ] **Step 1: Add the import and branch the painter**
+
+Add to App.jsx imports (near the other `./theme/` imports):
+
+```javascript
+import { isColorBackground, colorFromBackground } from './theme/backgroundValue.js';
+```
+
+Replace the ambiance block:
+
+```javascript
+  const ambianceBackground = get(Meteor, 'settings.public.theme.backgroundImagePath', '');
+  if (ambianceBackground) {
+    if (isColorBackground(ambianceBackground)) {
+      // Solid ambiance: override the canvas color, no image layer.
+      mainAppStyle.backgroundColor = colorFromBackground(ambianceBackground);
+    } else {
+      mainAppStyle.backgroundImage = 'url(' + ambianceBackground + ')';
+      mainAppStyle.backgroundSize = 'cover';
+      mainAppStyle.backgroundPosition = 'center';
+      mainAppStyle.backgroundAttachment = 'fixed';
+    }
+  }
+```
+
+(Keep the existing explanatory comment above the block; extend its last line with: `Solid 'color:' entries (themeBackgrounds EARTH_TONES) paint backgroundColor instead.`)
+
+- [ ] **Step 2: Manual verify**
+
+Run the app (`meteor run --settings settings/settings.honeycomb.localhost.json`), open DevTools console:
+
+```javascript
+require('/imports/ui/themePresets.js').setThemeBackground('color:#a67b5b');
+```
+
+Expected: page canvas turns clay; no broken-image artifacts. Then `setThemeBackground('')` restores the theme canvas.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add imports/ui/App.jsx
+git commit -m "feat(theme): StyledMainRouter paints color-prefixed solid ambiance backgrounds"
+```
+
+---
+
+### Task 5: `pageMode` + `cardSurface` persistence axes
+
+**Files:**
+- Modify: `imports/lib/SessionKeys.js` (App chrome / display toggles section)
+- Modify: `imports/ui/themePresets.js` (new setters + boot restore)
+- Modify: `imports/lib/themePersistence.js` (doc-comment shape only)
+
+**Interfaces:**
+- Consumes: existing `saveThemeChoice` / `loadThemeChoice`, `Session`.
+- Produces:
+  - `SessionKeys.js`: `export const PAGE_MODE = 'pageMode';` and `export const CARD_SURFACE = 'cardSurface';`
+  - `themePresets.js`: `setPageMode(mode)` (`'light'|'dark'|null`; null clears) and `setCardSurface(surface)` (`'solid'|'glass'|'flat'`; anything else → `'solid'`). Both write Session (reactive consumers) + `saveThemeChoice` + `pokeRefresh()`.
+  - `applyThemeChoiceAtBoot()` restores both into Session, treating unknown persisted values as unset (spec: persistence robustness).
+- Task 7 calls the setters; Task 8 reads `Session.get(PAGE_MODE)`; Phase 3 reads `CARD_SURFACE`.
+
+- [ ] **Step 1: Add the Session key constants**
+
+In `imports/lib/SessionKeys.js`, in the app-chrome/display group:
+
+```javascript
+export const PAGE_MODE    = 'pageMode';    // ambiance content-ink override: 'light' | 'dark' | undefined
+export const CARD_SURFACE = 'cardSurface'; // card surface state: 'solid' | 'glass' | 'flat'
+```
+
+- [ ] **Step 2: Add setters to themePresets.js** (below `setThemeBackground`)
+
+```javascript
+import { PAGE_MODE, CARD_SURFACE } from '/imports/lib/SessionKeys.js';
+
+const CARD_SURFACES = ['solid', 'glass', 'flat'];
+
+// Live control: content-ink mode for ambiance-enabled pages ('light'|'dark');
+// null/undefined clears the override (app mode stands). Chrome keeps Session('theme').
+export function setPageMode(mode) {
+  const next = (mode === 'light' || mode === 'dark') ? mode : null;
+  Session.set(PAGE_MODE, next || undefined);
+  saveThemeChoice({ pageMode: next });
+  pokeRefresh();
+}
+
+// Live control: card surface state. Unknown values coerce to 'solid'.
+export function setCardSurface(surface) {
+  const next = CARD_SURFACES.indexOf(surface) !== -1 ? surface : 'solid';
+  Session.set(CARD_SURFACE, next);
+  saveThemeChoice({ cardSurface: next });
+  pokeRefresh();
+}
+```
+
+- [ ] **Step 3: Restore at boot**
+
+In `applyThemeChoiceAtBoot()`, after the `backgroundImagePath` block:
+
+```javascript
+  // Ambiance axes — unknown persisted values are treated as unset
+  // (forward/backward compat per the ambiance spec).
+  if (choice.pageMode === 'light' || choice.pageMode === 'dark') {
+    Session.set(PAGE_MODE, choice.pageMode);
+  }
+  if (['solid', 'glass', 'flat'].indexOf(choice.cardSurface) !== -1) {
+    Session.set(CARD_SURFACE, choice.cardSurface);
+  }
+```
+
+- [ ] **Step 4: Update the persistence doc comment**
+
+In `imports/lib/themePersistence.js`, extend the shape comment:
+
+```javascript
+//   { presetId, accentHue, fontFamily, mode, backgroundImagePath,
+//     pageMode, cardSurface,
+//     paletteOverrides: { <paletteKey>: <hex> } }
+// pageMode ('light'|'dark') is the ambiance content-ink override; cardSurface
+// ('solid'|'glass'|'flat') is the card surface state. Both consumed only by
+// ambiance/fluid routes (see the 2026-08-03 ambiance spec).
+```
+
+- [ ] **Step 5: Manual verify**
+
+With the app running, in DevTools:
+
+```javascript
+var tp = require('/imports/ui/themePresets.js');
+tp.setPageMode('light');
+JSON.parse(localStorage.getItem('honeycomb.theme')).pageMode  // → 'light'
+tp.setCardSurface('glass');
+JSON.parse(localStorage.getItem('honeycomb.theme')).cardSurface  // → 'glass'
+Session.get('pageMode')     // → 'light'
+Session.get('cardSurface')  // → 'glass'
+```
+
+Reload the page; `Session.get('pageMode')` → `'light'` again (boot restore).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add imports/lib/SessionKeys.js imports/ui/themePresets.js imports/lib/themePersistence.js
+git commit -m "feat(theme): pageMode + cardSurface persisted axes with boot restore"
+```
+
+---
+
+### Task 6: `pageModeTheme.js` — shared content-ink theme helper
+
+**Files:**
+- Create: `imports/ui/theme/pageModeTheme.js`
+
+**Interfaces:**
+- Consumes: `createTheme` from `@mui/material/styles`.
+- Produces: `buildPageModeTheme(appTheme, forcedMode) → muiTheme` — returns `appTheme` unchanged when `forcedMode` is falsy or equals the app mode; otherwise a rebuilt theme with the app's accent palette + typography and only mode-dependent tokens flipped. This is the DirectoryConsole inline override (uncommitted diff, `DirectoryConsole.jsx` ~lines 692-707), promoted verbatim so Task 8 and every future zone page share one implementation.
+
+- [ ] **Step 1: Create the helper**
+
+```javascript
+// imports/ui/theme/pageModeTheme.js
+//
+// Build the "content ink" theme for ambiance pages: same brand accents +
+// typography as the app theme, but with the mode-dependent tokens
+// (text/background/divider) flipped to the forced mode. The app chrome
+// (header/footer/dialogs) keeps the real mode — only zone page content
+// consumes this. Promoted from DirectoryConsole's inline override.
+// Spec: docs/superpowers/specs/2026-08-03-ambiance-experience-zone-design.md
+
+import { createTheme } from '@mui/material/styles';
+
+export function buildPageModeTheme(appTheme, forcedMode) {
+  if (!forcedMode || !appTheme || forcedMode === appTheme.palette.mode) { return appTheme; }
+  return createTheme({
+    palette: {
+      mode: forcedMode,
+      primary: appTheme.palette.primary,
+      secondary: appTheme.palette.secondary,
+      error: appTheme.palette.error,
+      warning: appTheme.palette.warning,
+      info: appTheme.palette.info,
+      success: appTheme.palette.success
+    },
+    typography: appTheme.typography
+  });
+}
+```
+
+- [ ] **Step 2: Verify via consumer swap** (done in Task 8 — this file has no standalone runtime; parse-check only)
+
+Run: `node --experimental-detect-module --check imports/ui/theme/pageModeTheme.js && echo PARSE-OK`
+Expected: `PARSE-OK`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add imports/ui/theme/pageModeTheme.js
+git commit -m "feat(theme): shared buildPageModeTheme helper (ambiance content ink)"
+```
+
+---
+
+### Task 7: ThemeControls restructure — Ambiance under Preset, Basic Theme Controls, Page Mode, Card Surface
+
+**Files:**
+- Modify: `imports/ui/theme/ThemeControls.jsx`
+
+**Interfaces:**
+- Consumes: `EARTH_TONES`, `getBackgroundLibrary` (Task 3); `colorFromBackground`, `isColorBackground` (Task 1); `setPageMode`, `setCardSurface` (Task 5); `PAGE_MODE`, `CARD_SURFACE` from SessionKeys; existing `setThemeBackground`, `applyThemePreset`, `setAccentHue`, `setThemeFont`.
+- Produces: the dialog + `/theming` page render the new order. Element ids for tests: `themePageModeToggle`, `themeCardSurfaceGroup`, `themeCardSurface-solid|glass|flat`, `themeEarthTone-<name>` (kebab name), existing `themePreset-*`, `themeModeToggle`, `themeFontSelect` unchanged.
+
+- [ ] **Step 1: Update imports and reactive state**
+
+Add to the imports:
+
+```javascript
+import ToggleButton from '@mui/material/ToggleButton';
+import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
+import { getBackgroundLibrary, EARTH_TONES } from '../themeBackgrounds.js';
+import { colorFromBackground } from './backgroundValue.js';
+import { setPageMode, setCardSurface } from '../themePresets.js';
+import { PAGE_MODE, CARD_SURFACE } from '/imports/lib/SessionKeys.js';
+```
+
+(Remove the now-duplicated `getBackgroundLibrary` import line.) Inside `ThemeControls`, next to the existing `mode` tracker:
+
+```javascript
+  const pageMode = useTracker(function() { return Session.get(PAGE_MODE); }, []);
+  const cardSurface = useTracker(function() { return Session.get(CARD_SURFACE) || 'solid'; }, []);
+```
+
+- [ ] **Step 2: Reorder the JSX**
+
+New render order inside the root `<Box>` (preset tiles block stays first, unchanged). Move the ambiance section directly after the preset grid and extend it with the earth-tone row; then the relabeled controls group:
+
+```jsx
+      {/* Ambiance background — images row + earth-tone solids row */}
+      <Typography variant="overline" color="text.secondary">Ambiance background</Typography>
+      <Box sx={{ display: 'flex', gap: 1.5, overflowX: 'auto', pb: 1, mt: 1 }}>
+        <ButtonBase
+          onClick={function() { setThemeBackground(''); }}
+          sx={{
+            flex: '0 0 auto', width: 96, height: 60, borderRadius: '6px',
+            border: '2px solid', borderColor: !activeBg ? 'primary.main' : 'divider',
+            bgcolor: 'background.default', fontSize: 11, color: 'text.secondary'
+          }}
+        >
+          None
+        </ButtonBase>
+        {getBackgroundLibrary().map(function(bg) {
+          const selected = activeBg === bg.src;
+          return (
+            <Tooltip key={bg.src} title={bg.name}>
+              <ButtonBase
+                onClick={function() { setThemeBackground(bg.src); }}
+                sx={{
+                  flex: '0 0 auto', width: 96, height: 60, borderRadius: '6px', overflow: 'hidden',
+                  border: '2px solid', borderColor: selected ? 'primary.main' : 'divider',
+                  backgroundImage: 'url(' + bg.src + ')', backgroundSize: 'cover', backgroundPosition: 'center',
+                  transition: 'transform 0.15s ease', '&:hover': { transform: 'scale(1.04)' }
+                }}
+              />
+            </Tooltip>
+          );
+        })}
+      </Box>
+      <Box sx={{ display: 'flex', gap: 1.5, overflowX: 'auto', pb: 1, mt: 1, mb: 3 }}>
+        {EARTH_TONES.map(function(tone) {
+          const selected = activeBg === tone.value;
+          return (
+            <Tooltip key={tone.value} title={tone.name}>
+              <ButtonBase
+                id={'themeEarthTone-' + tone.name.toLowerCase()}
+                onClick={function() { setThemeBackground(tone.value); }}
+                sx={{
+                  flex: '0 0 auto', width: 96, height: 36, borderRadius: '6px',
+                  border: '2px solid', borderColor: selected ? 'primary.main' : 'divider',
+                  bgcolor: colorFromBackground(tone.value)
+                }}
+              />
+            </Tooltip>
+          );
+        })}
+      </Box>
+
+      <Divider sx={{ mb: 3 }} />
+
+      {/* Basic theme controls: font, mode(s), accent hue, card surface */}
+      <Typography variant="overline" color="text.secondary">Basic theme controls</Typography>
+```
+
+The existing Font/Mode/Accent-hue grid follows (unchanged layout), with two additions inside it. Next to the Mode block, add Page Mode (renders only when a background is active — image or solid):
+
+```jsx
+          {activeBg ? (
+            <Box>
+              <Typography variant="overline" color="text.secondary">Page mode</Typography>
+              <Box>
+                <Tooltip title="Content ink over the ambiance background (chrome keeps the app mode)">
+                  <Button
+                    id="themePageModeToggle"
+                    variant="outlined" size="small"
+                    startIcon={pageMode === 'dark' ? <DarkModeIcon /> : <LightModeIcon />}
+                    onClick={function() { setPageMode(pageMode === 'dark' ? 'light' : 'dark'); }}
+                  >
+                    {pageMode ? (pageMode === 'dark' ? 'Dark' : 'Light') : 'Auto'}
+                  </Button>
+                </Tooltip>
+              </Box>
+            </Box>
+          ) : null}
+```
+
+After the accent-hue block (still inside the controls grid), the Card Surface control:
+
+```jsx
+        <Box>
+          <Typography variant="overline" color="text.secondary">Card surface</Typography>
+          <Box sx={{ mt: 1 }}>
+            <ToggleButtonGroup
+              id="themeCardSurfaceGroup"
+              exclusive size="small" value={cardSurface}
+              onChange={function(event, next) { if (next) { setCardSurface(next); } }}
+            >
+              <ToggleButton id="themeCardSurface-solid" value="solid">Solid</ToggleButton>
+              <ToggleButton id="themeCardSurface-glass" value="glass">Glass</ToggleButton>
+              <ToggleButton id="themeCardSurface-flat" value="flat">Flat</ToggleButton>
+            </ToggleButtonGroup>
+            <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 0.5 }}>
+              Applies on ambiance/fluid pages (rolling out per page).
+            </Typography>
+          </Box>
+        </Box>
+```
+
+Delete the old trailing ambiance carousel section (it moved up).
+
+- [ ] **Step 3: Manual verify (dialog + page parity)**
+
+App running → Ctrl+Shift+T: order is Preset → Ambiance (2 rows) → Basic theme controls (Font, Mode, [Page mode when bg active], Accent hue, Card surface) → Advanced collapsible. Select Sand: canvas turns sand, Page-mode button appears. Select None: Page-mode button disappears. Toggle Glass: reload, control still shows Glass. Visit `/theming`: identical controls.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add imports/ui/theme/ThemeControls.jsx
+git commit -m "feat(theme): dialog restructure — ambiance under preset, earth tones, page mode + card surface controls"
+```
+
+---
+
+### Task 8: DirectoryConsole polish — xl padding, persisted pageMode, scrim system
+
+**Files:**
+- Modify: `npmPackages/provider-directory/client/DirectoryConsole.jsx` (includes committing the pre-existing uncommitted `?align`/`?page-theme`/census-filter work — do not revert it)
+
+**Interfaces:**
+- Consumes: `buildPageModeTheme` (Task 6), `PAGE_MODE` SessionKey + persisted value (Task 5), `getBackgroundEntry` (Task 3).
+- Produces: the zone reference implementation — Phase 3 extracts its var recipe.
+
+- [ ] **Step 1: Swap the inline theme override for the shared helper + persisted pageMode**
+
+Replace the `?page-theme` block (the `forcedMode`/`useMemo(createTheme...)` section from the uncommitted diff) with:
+
+```javascript
+  // Content-ink override: URL param (dev/demo) wins over the persisted
+  // Page Mode choice (Theme & Palette dialog). Falsy → app mode stands.
+  const pageThemeParam = (searchParams.get('page-theme') || '').toLowerCase();
+  const persistedPageMode = useTracker(function() { return Session.get(PAGE_MODE); }, []);
+  const paramMode = (pageThemeParam === 'light' || pageThemeParam === 'dark') ? pageThemeParam : null;
+  const forcedMode = paramMode || persistedPageMode || null;
+  const theme = useMemo(function() {
+    return buildPageModeTheme(appMuiTheme, forcedMode);
+  }, [appMuiTheme, forcedMode]);
+```
+
+Imports to add: `import { buildPageModeTheme } from '/imports/ui/theme/pageModeTheme.js';`, `import { PAGE_MODE } from '/imports/lib/SessionKeys.js';`, `import { getBackgroundEntry } from '/imports/ui/themeBackgrounds.js';`, plus `useTracker` from `meteor/react-meteor-data` and `Session` from `meteor/session` (check existing imports first — the file already imports Meteor). Remove the now-unused `createTheme` import.
+
+- [ ] **Step 2: Focus + scrim vars from the active background's curation record**
+
+Where `consoleVars` is built (after the theme), resolve the active entry and derive defaults:
+
+```javascript
+  // Curation record for the active ambiance (scrim strength + focus).
+  const activeBg = useTracker(function() {
+    return get(Meteor, 'settings.public.theme.backgroundImagePath', '');
+  }, []);
+  const bgEntry = getBackgroundEntry(activeBg);
+  const scrimStrength = get(bgEntry, 'scrimStrength', 0.55);
+
+  // ?align param wins; otherwise the image's curated focus; otherwise center.
+  const alignParam = (searchParams.get('align') || '').toLowerCase();
+  const focus = ['left', 'center', 'right'].indexOf(alignParam) !== -1
+    ? alignParam
+    : (get(bgEntry, 'focus') || 'center');
+  const bodyAlign = focus === 'left' ? { ml: 0, mr: 'auto' }
+    : focus === 'right' ? { ml: 'auto', mr: 0 }
+    : { mx: 'auto' };
+```
+
+(This replaces the existing `alignParam`/`bodyAlign` block from the uncommitted diff — same output shape, new default source.)
+
+- [ ] **Step 3: xl padding + column scrim**
+
+On the console body container (currently `maxWidth: '1180px', ...bodyAlign, px: { xs: 2.5, md: 5 }`):
+
+```javascript
+        <Box sx={{
+          maxWidth: '1180px', ...bodyAlign,
+          px: { xs: 2.5, md: 5 },
+          pt: { xs: 3, md: 5 }, pb: 8,
+          // Column scrim: a soft canvas-tinted backdrop so content survives
+          // bright photos. Strength comes from the image's curation record.
+          background: `linear-gradient(180deg,
+            ${alpha(theme.palette.background.default, scrimStrength)} 0%,
+            ${alpha(theme.palette.background.default, scrimStrength * 0.85)} 100%)`,
+          backdropFilter: 'blur(2px)',
+          borderRadius: '4px'
+        }}>
+```
+
+And on the outer scroll Box add the wide-viewport easement:
+
+```javascript
+      <Box sx={{ flex: 1, minHeight: 0, overflow: 'auto', position: 'relative', zIndex: 2, px: { xl: '200px' } }}>
+```
+
+(The 200px rides MUI's standard `xl` = 1536px breakpoint per the spec.)
+
+- [ ] **Step 4: Row/chip/telemetry legibility**
+
+In the module-scope CSS string (the `.grid-console` block at the top of the file):
+
+```css
+/* Result rows get a panel backing so org names never sit naked on the photo */
+.gc-row { background: color-mix(in srgb, var(--panel-hard) 45%, transparent); }
+.gc-row:hover { background: color-mix(in srgb, var(--panel-hard) 70%, transparent); }
+```
+
+(Adjust the selector to the actual result-row class in `ResultBand` — the row `ButtonBase`/`Box` carries the border-left hover treatment around line 103; add the class `gc-row` to that element if it lacks one.) Bump the small telemetry text (`RETURN IN`, `UPLINK`, band counts) from `var(--stone)`/`var(--stone-dim)` to `var(--ink)` at their usage sites, and give the ACTIVE chip its panel backing: in the chip style (`.gc-chip-btn` and the status chip in `ResultBand`), add `background: color-mix(in srgb, var(--panel-hard) 60%, transparent);`.
+
+- [ ] **Step 5: Manual verify across the matrix**
+
+App running, Yoga Ocean selected, visit `/provider-directory`:
+- Column sits LEFT (curated focus) without any `?align` param; `?align=right` overrides.
+- Stats, ACTIVE chips, and telemetry text readable over the sunset (scrim visible behind the column).
+- Page-mode toggle in the dialog flips the console ink without touching header/footer.
+- At a ≥1600px window the console keeps ~200px side breathing room; at laptop width the old paddings apply.
+- Zen Rocks: column sits RIGHT, light ink.
+- Background None: page renders like a normal themed page (scrim over plain canvas is invisible-ish; verify no dark band artifact — if the scrim reads as a gray slab on None, gate it: `background: activeBg ? linear-gradient(...) : 'transparent'`).
+
+- [ ] **Step 6: Commit (includes the pre-existing uncommitted console work)**
+
+```bash
+git add npmPackages/provider-directory/client/DirectoryConsole.jsx
+git commit -m "feat(provider-directory): console-over-ambiance polish — curated focus, scrim system, xl easement, persisted page mode"
+```
+
+---
+
+### Task 9: Nightwatch coverage — dialog controls persist
+
+**Files:**
+- Create: `tests/nightwatch/honeycomb/theme/ambianceControls.js`
+
+**Interfaces:**
+- Consumes: element ids from Task 7 (`themeEarthTone-sand`, `themePageModeToggle`, `themeCardSurface-glass`), Session keys, `honeycomb.theme` localStorage.
+- Produces: regression coverage for the spec's "dialog controls persist across reload" requirement.
+
+- [ ] **Step 1: Write the test file**
+
+```javascript
+// tests/nightwatch/honeycomb/theme/ambianceControls.js
+// E2E: Theme & Palette ambiance controls persist across reload.
+// Spec: docs/superpowers/specs/2026-08-03-ambiance-experience-zone-design.md
+
+module.exports = {
+  '01. Open dialog, pick an earth tone': function(browser) {
+    browser.url('http://localhost:3000/');
+    browser.pause(2000);
+    browser.execute(function() { Session.set('themeDialogOpen', true); });
+    browser.pause(1000);
+    browser.expect.element('#themeEarthTone-sand').to.be.present;
+    browser.execute(function() { document.querySelector('#themeEarthTone-sand').click(); });
+    browser.pause(500);
+    browser.execute(function() {
+      return JSON.parse(localStorage.getItem('honeycomb.theme') || '{}').backgroundImagePath;
+    }, [], function(result) {
+      browser.assert.equal(result.value, 'color:#d9c7a7', 'sand persisted on the background axis');
+    });
+  },
+
+  '02. Page-mode toggle appears with a background and persists': function(browser) {
+    browser.expect.element('#themePageModeToggle').to.be.present;
+    browser.execute(function() { document.querySelector('#themePageModeToggle').click(); });
+    browser.pause(500);
+    browser.execute(function() {
+      return JSON.parse(localStorage.getItem('honeycomb.theme') || '{}').pageMode;
+    }, [], function(result) {
+      browser.assert.ok(result.value === 'light' || result.value === 'dark', 'pageMode persisted');
+    });
+  },
+
+  '03. Card surface persists across reload': function(browser) {
+    browser.execute(function() { document.querySelector('#themeCardSurface-glass').click(); });
+    browser.pause(500);
+    browser.refresh();
+    browser.pause(3000);
+    browser.execute(function() { return Session.get('cardSurface'); }, [], function(result) {
+      browser.assert.equal(result.value, 'glass', 'cardSurface restored at boot');
+    });
+  },
+
+  '04. None hides page-mode control and clears the axis': function(browser) {
+    browser.execute(function() { Session.set('themeDialogOpen', true); });
+    browser.pause(1000);
+    browser.execute(function() {
+      var buttons = document.querySelectorAll('.MuiDialog-root button');
+      for (var i = 0; i < buttons.length; i++) {
+        if (buttons[i].textContent.trim() === 'None') { buttons[i].click(); return; }
+      }
+    });
+    browser.pause(500);
+    browser.expect.element('#themePageModeToggle').to.not.be.present;
+    browser.end();
+  }
+};
+```
+
+- [ ] **Step 2: Run locally**
+
+App running with the localhost settings, then:
+
+Run: `npx nightwatch tests/nightwatch/honeycomb/theme/ambianceControls.js --config nightwatch.conf.js`
+Expected: 4 passing tests. (If Chrome/driver versions mismatch locally, use the `CHROMEDRIVER_PATH` recipe from the project memory.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/nightwatch/honeycomb/theme/ambianceControls.js
+git commit -m "test(theme): ambiance dialog controls persist across reload (e2e)"
+```
+
+---
+
+### Task 10: Verification sweep
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Unit suite**
+
+Run: `npm run test:background-value && npm run test:ambiance-analysis`
+Expected: all PASS.
+
+- [ ] **Step 2: Theme audits**
+
+Run `/audit-theme` and `/audit-print` (Claude commands) over the touched files — expected: no new unconditional hardcoded surface colors flagged in components (EARTH_TONES data constants are exempt as theme-system data); print path unaffected (scrim/solid backgrounds live behind the global `@media print` white-surface rules — spot-check a print preview of `/provider-directory`).
+
+- [ ] **Step 3: Regression spot-checks**
+
+- Unflagged behavior parity: visit `/fhir-graph` and `/patients` with Yoga Ocean active — rendering identical to before this branch (route gating is Phase 3; nothing should have changed on these pages).
+- Preset switching still works (Limestone → Tron → Vaporwave), accent wheel live-tracks, font select applies.
+- `localStorage.removeItem('honeycomb.theme')` + reload → clean defaults, no console errors.
+
+- [ ] **Step 4: Update the spec status line**
+
+In `docs/superpowers/specs/2026-08-03-ambiance-experience-zone-design.md`, change the Status line to `Phases 1-2 implemented (<commit range>); Phase 3 pending`. Commit:
+
+```bash
+git add docs/superpowers/specs/2026-08-03-ambiance-experience-zone-design.md
+git commit -m "docs(specs): mark ambiance phases 1-2 implemented"
+```

--- a/docs/superpowers/plans/2026-08-04-ambiance-phase3-zone-plumbing.md
+++ b/docs/superpowers/plans/2026-08-04-ambiance-phase3-zone-plumbing.md
@@ -1,0 +1,1049 @@
+# Ambiance Phase 3: Zone Plumbing, Surface System & Curation Tools — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship Phase 3 of the Ambiance Experience Zone spec (`docs/superpowers/specs/2026-08-03-ambiance-experience-zone-design.md`): `enableAmbiance`/`enableFluidInterface` route flags, the AmbianceZone wrapper with composition contract + theme-override net, `Meteor.StyledCard`/`Meteor.StyledContainer`, hotkey graduations (Ctrl+Shift+L cycle, Ctrl+Shift+K per-route card↔full-height), the Ambiance Tuning HUD (Ctrl+Shift+E), Card Surface mini-preview, print hardening, and the three initial zone routes.
+
+**Architecture:** Two new pure modules (`ambianceComposition.js`, `surfaceStyles.js`) carry the testable logic. `AmbianceZone` (a guard like PatientGuard) assembles the composition object, provides it via `useAmbiance()` context + CSS vars, and wraps children in a page-mode theme carrying MuiCard/MuiPaper overrides so raw MUI cards stay legible. `StyledMainRouter` gates ambiance painting per-route and composes the zone into the guard chain. StyledCard/StyledContainer are the premium consumers, Meteor-object-distributed like `Meteor.useTheme`.
+
+**Tech Stack:** Meteor v3 + React 18 + MUI v5, `node --experimental-detect-module --test` for pure modules.
+
+## Global Constraints
+
+- Coding style (root `CLAUDE.md`): `function() {}` declarations, lodash `get()` defensive reads, first line of every new file = its commented path, no `index.js`, camelCase filenames for function modules / PascalCase for components.
+- **HANDS OFF the running app**: the user's dev server may be running on :3000 with HMR — never start, stop, restart, or kill any process; never install anything outside the repo. Verification = unit tests, syntax checks (`node --experimental-detect-module --check` for non-JSX; `npx esbuild --loader=jsx` transform for JSX), and careful re-reads. The controller does live browser checks separately.
+- Unit tests in `tests/unit/` mirroring source; scripts registered in `package.json` after `"test:ambiance-analysis"`; CI run steps in `.circleci/config.yml` immediately after the "Ambiance image analysis" step (same bare-checkout job — subjects must have ZERO imports).
+- Session keys via constants in `imports/lib/SessionKeys.js`; new cross-file keys also join the `chrome` group in `imports/lib/sessionKeyGroups.js`.
+- `git add` specific paths only — NEVER `git add -A` (working tree carries an unrelated dirty `libraries/dcmjs` submodule pointer; leave it).
+- `extensions/*` are SEPARATE nested git repos (gitignored from the monorepo): edits there are committed IN that extension's repo (plain `git -C extensions/<name> add <file> && git -C extensions/<name> commit`), never pushed, never staged in the monorepo.
+- Persisted-choice contract (`imports/lib/themePersistence.js`): flat JSON via merge-writes; unknown values must be treated as unset at boot.
+- Existing interfaces consumed here (all shipped in Phases 1-2): `isColorBackground/colorFromBackground` (`imports/ui/theme/backgroundValue.js`), `getBackgroundLibrary/getBackgroundEntry/EARTH_TONES` (`imports/ui/themeBackgrounds.js`), `buildPageModeTheme(appTheme, forcedMode)` (`imports/ui/theme/pageModeTheme.js`), `setPageMode/setCardSurface` (`imports/ui/themePresets.js`), `PAGE_MODE`/`CARD_SURFACE` (`imports/lib/SessionKeys.js`).
+- `Meteor.settings.public.theme.backgroundImagePath` is read as a PLAIN render read — NEVER wrapped in useTracker (zero reactive deps; the CustomThemeProvider rebuild re-renders consumers).
+
+---
+
+### Task 1: `ambianceComposition.js` — the composition contract (TDD)
+
+**Files:**
+- Create: `imports/ui/theme/ambianceComposition.js`
+- Test: `tests/unit/imports/ui/theme/ambianceComposition.test.mjs`
+- Modify: `package.json`, `.circleci/config.yml` (script + CI step per Global Constraints)
+
+**Interfaces:**
+- Consumes: nothing (pure, zero imports — reimplements the `color:` prefix check locally to stay dependency-free for the bare-checkout CI job).
+- Produces: `resolveComposition({ background, entry, pageMode, cardSurface, surfaceOverride })` → `{ background, kind: 'image'|'color'|'none', focus, scrimStrength, pageMode, cardSurface }`. Rules: `kind` from the background string (`''`/falsy → `'none'`, `'color:'` prefix → `'color'`, else `'image'`); `focus` = entry.focus if `'left'|'center'|'right'` else `'center'`; `scrimStrength` = entry.scrimStrength clamped [0,1] else `0.55`; `pageMode` = explicit pageMode if `'light'|'dark'`, else entry.recommendedPageMode if valid, else `null` — **both forced to `null` when kind is `'none'`**; `cardSurface` = surfaceOverride if `'solid'|'glass'|'flat'`, else cardSurface if valid, else `'solid'`. Tasks 3, 8, 9 consume this.
+
+- [ ] **Step 1: Write the failing test**
+
+```javascript
+// tests/unit/imports/ui/theme/ambianceComposition.test.mjs
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { resolveComposition } from '../../../../../imports/ui/theme/ambianceComposition.js';
+
+test('no background → kind none, no forced ink, defaults', function() {
+  const c = resolveComposition({ background: '', entry: null, pageMode: 'dark', cardSurface: 'glass' });
+  assert.deepEqual(c, { background: '', kind: 'none', focus: 'center', scrimStrength: 0.55, pageMode: null, cardSurface: 'glass' });
+});
+
+test('image with full curation record resolves verbatim', function() {
+  const c = resolveComposition({
+    background: '/backgrounds/ambiance/Yoga-Ocean.jpg',
+    entry: { focus: 'left', recommendedPageMode: 'dark', scrimStrength: 0.6 },
+    pageMode: null, cardSurface: 'flat'
+  });
+  assert.equal(c.kind, 'image');
+  assert.equal(c.focus, 'left');
+  assert.equal(c.scrimStrength, 0.6);
+  assert.equal(c.pageMode, 'dark');       // curated fallback when user pageMode unset
+  assert.equal(c.cardSurface, 'flat');
+});
+
+test('explicit pageMode beats curated recommendation', function() {
+  const c = resolveComposition({
+    background: '/x.jpg', entry: { recommendedPageMode: 'dark' }, pageMode: 'light', cardSurface: 'solid'
+  });
+  assert.equal(c.pageMode, 'light');
+});
+
+test('solid color → kind color, center focus, entry ignored', function() {
+  const c = resolveComposition({ background: 'color:#a67b5b', entry: null, pageMode: 'light', cardSurface: 'solid' });
+  assert.equal(c.kind, 'color');
+  assert.equal(c.focus, 'center');
+  assert.equal(c.pageMode, 'light');      // solids still take forced ink
+});
+
+test('surfaceOverride wins over global cardSurface; junk values fall back', function() {
+  const c = resolveComposition({ background: '/x.jpg', entry: {}, pageMode: 'purple', cardSurface: 'wobbly', surfaceOverride: 'flat' });
+  assert.equal(c.cardSurface, 'flat');
+  assert.equal(c.pageMode, null);
+  const d = resolveComposition({ background: '/x.jpg', entry: {}, pageMode: null, cardSurface: 'wobbly' });
+  assert.equal(d.cardSurface, 'solid');
+});
+
+test('scrimStrength clamps to [0,1] and defaults to 0.55', function() {
+  assert.equal(resolveComposition({ background: '/x.jpg', entry: { scrimStrength: 7 } }).scrimStrength, 1);
+  assert.equal(resolveComposition({ background: '/x.jpg', entry: { scrimStrength: -2 } }).scrimStrength, 0);
+  assert.equal(resolveComposition({ background: '/x.jpg', entry: {} }).scrimStrength, 0.55);
+});
+```
+
+- [ ] **Step 2: Run to verify FAIL** — `node --experimental-detect-module --test tests/unit/imports/ui/theme/ambianceComposition.test.mjs` → `Cannot find module`.
+
+- [ ] **Step 3: Implement**
+
+```javascript
+// imports/ui/theme/ambianceComposition.js
+//
+// The zone composition contract: resolve the active background + curation
+// record + persisted axes into the single layout object every enableAmbiance
+// route receives ("a background choice never arrives blank" — defaults fill
+// every gap). Pure and zero-import (bare-checkout node --test safe); the
+// 'color:' check is duplicated from backgroundValue.js deliberately to keep
+// this module dependency-free. Spec:
+// docs/superpowers/specs/2026-08-03-ambiance-experience-zone-design.md
+
+const FOCUS_VALUES = ['left', 'center', 'right'];
+const SURFACE_VALUES = ['solid', 'glass', 'flat'];
+const MODE_VALUES = ['light', 'dark'];
+
+function backgroundKind(background) {
+  if (!background || typeof background !== 'string') { return 'none'; }
+  if (background.indexOf('color:') === 0) { return 'color'; }
+  return 'image';
+}
+
+export function resolveComposition(options) {
+  const opts = options || {};
+  const background = (typeof opts.background === 'string') ? opts.background : '';
+  const entry = opts.entry || {};
+  const kind = backgroundKind(background);
+
+  const focus = FOCUS_VALUES.indexOf(entry.focus) !== -1 ? entry.focus : 'center';
+
+  let scrim = typeof entry.scrimStrength === 'number' ? entry.scrimStrength : 0.55;
+  scrim = Math.min(1, Math.max(0, scrim));
+
+  let pageMode = MODE_VALUES.indexOf(opts.pageMode) !== -1 ? opts.pageMode : null;
+  if (!pageMode && MODE_VALUES.indexOf(entry.recommendedPageMode) !== -1) {
+    pageMode = entry.recommendedPageMode;
+  }
+  if (kind === 'none') { pageMode = null; }
+
+  let cardSurface = SURFACE_VALUES.indexOf(opts.surfaceOverride) !== -1 ? opts.surfaceOverride
+    : (SURFACE_VALUES.indexOf(opts.cardSurface) !== -1 ? opts.cardSurface : 'solid');
+
+  return {
+    background: background,
+    kind: kind,
+    focus: kind === 'image' ? focus : 'center',
+    scrimStrength: scrim,
+    pageMode: pageMode,
+    cardSurface: cardSurface
+  };
+}
+```
+
+- [ ] **Step 4: Run to verify PASS** (6 tests).
+
+- [ ] **Step 5: Wire script + CI step**
+
+`package.json` after `"test:ambiance-analysis"`:
+```json
+"test:ambiance-composition": "node --experimental-detect-module --test tests/unit/imports/ui/theme/ambianceComposition.test.mjs",
+```
+`.circleci/config.yml` after the "Ambiance image analysis" run step:
+```yaml
+      - run:
+          name: Ambiance composition contract
+          command: npm run test:ambiance-composition
+```
+
+- [ ] **Step 6: Commit**
+```bash
+git add imports/ui/theme/ambianceComposition.js tests/unit/imports/ui/theme/ambianceComposition.test.mjs package.json .circleci/config.yml
+git commit -m "feat(theme): composition contract — resolveComposition for ambiance zones"
+```
+
+---
+
+### Task 2: `surfaceStyles.js` — shared glass/flat/solid card styles (TDD)
+
+**Files:**
+- Create: `imports/ui/theme/surfaceStyles.js`
+- Test: `tests/unit/imports/ui/theme/surfaceStyles.test.mjs`
+- Modify: `package.json`, `.circleci/config.yml` (same pattern as Task 1)
+
+**Interfaces:**
+- Consumes: nothing (pure; local hex-alpha helper instead of @mui `alpha`).
+- Produces:
+  - `SURFACE_TRANSITION` — string: `'background-color 0.35s ease, backdrop-filter 0.35s ease, border-color 0.35s ease, box-shadow 0.35s ease, opacity 0.35s ease'`
+  - `hexAlpha(hex, alpha)` → `'rgba(r, g, b, a)'` (accepts `#rgb`/`#rrggbb`; non-hex input returned unchanged)
+  - `buildSurfaceStyles({ surface, paperColor, dividerColor })` → `{ root }` where `root` is a plain style object for MuiCard/MuiPaper overrides: `solid` → `{ transition: SURFACE_TRANSITION }`; `glass` → panel at 0.72 alpha + `backdropFilter: 'blur(8px)'` + hairline border + no shadow (the DirectoryConsole `--panel` recipe, generalized); `flat` → fully transparent, no border/shadow (the melt-into-negative-space state). All include the transition so state changes animate.
+- Tasks 3 and 5 consume this.
+
+- [ ] **Step 1: Write the failing test**
+
+```javascript
+// tests/unit/imports/ui/theme/surfaceStyles.test.mjs
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { buildSurfaceStyles, hexAlpha, SURFACE_TRANSITION } from '../../../../../imports/ui/theme/surfaceStyles.js';
+
+test('hexAlpha converts 6- and 3-digit hex; passes through non-hex', function() {
+  assert.equal(hexAlpha('#18181a', 0.72), 'rgba(24, 24, 26, 0.72)');
+  assert.equal(hexAlpha('#fff', 0.5), 'rgba(255, 255, 255, 0.5)');
+  assert.equal(hexAlpha('teal', 0.5), 'teal');
+});
+
+test('solid keeps the surface opaque (only the transition is added)', function() {
+  const s = buildSurfaceStyles({ surface: 'solid', paperColor: '#18181a', dividerColor: '#333' });
+  assert.deepEqual(Object.keys(s.root), ['transition']);
+  assert.equal(s.root.transition, SURFACE_TRANSITION);
+});
+
+test('glass is translucent paper + blur + hairline, shadowless', function() {
+  const s = buildSurfaceStyles({ surface: 'glass', paperColor: '#18181a', dividerColor: '#333' });
+  assert.equal(s.root.backgroundColor, 'rgba(24, 24, 26, 0.72)');
+  assert.equal(s.root.backdropFilter, 'blur(8px)');
+  assert.equal(s.root.border, '1px solid #333');
+  assert.equal(s.root.boxShadow, 'none');
+  assert.equal(s.root.transition, SURFACE_TRANSITION);
+});
+
+test('flat melts into negative space', function() {
+  const s = buildSurfaceStyles({ surface: 'flat', paperColor: '#18181a', dividerColor: '#333' });
+  assert.equal(s.root.backgroundColor, 'transparent');
+  assert.equal(s.root.border, 'none');
+  assert.equal(s.root.boxShadow, 'none');
+  assert.equal(s.root.backgroundImage, 'none');
+  assert.equal(s.root.transition, SURFACE_TRANSITION);
+});
+
+test('unknown surface behaves as solid', function() {
+  const s = buildSurfaceStyles({ surface: 'wobbly', paperColor: '#18181a', dividerColor: '#333' });
+  assert.deepEqual(Object.keys(s.root), ['transition']);
+});
+```
+
+- [ ] **Step 2: Run to verify FAIL.**
+
+- [ ] **Step 3: Implement**
+
+```javascript
+// imports/ui/theme/surfaceStyles.js
+//
+// Shared card-surface styles for the three states (solid | glass | flat) —
+// the DirectoryConsole overlay recipe generalized so AmbianceZone's
+// MuiCard/MuiPaper overrides and Meteor.StyledCard share one source of
+// truth. Pure and zero-import (bare-checkout node --test safe); hexAlpha is
+// a local helper so we don't pull in @mui utilities. Spec:
+// docs/superpowers/specs/2026-08-03-ambiance-experience-zone-design.md
+
+export const SURFACE_TRANSITION =
+  'background-color 0.35s ease, backdrop-filter 0.35s ease, border-color 0.35s ease, box-shadow 0.35s ease, opacity 0.35s ease';
+
+export function hexAlpha(hex, alpha) {
+  if (typeof hex !== 'string' || hex[0] !== '#') { return hex; }
+  let h = hex.slice(1);
+  if (h.length === 3) { h = h[0] + h[0] + h[1] + h[1] + h[2] + h[2]; }
+  if (h.length !== 6 || /[^0-9a-fA-F]/.test(h)) { return hex; }
+  const r = parseInt(h.slice(0, 2), 16);
+  const g = parseInt(h.slice(2, 4), 16);
+  const b = parseInt(h.slice(4, 6), 16);
+  return 'rgba(' + r + ', ' + g + ', ' + b + ', ' + alpha + ')';
+}
+
+export function buildSurfaceStyles(options) {
+  const opts = options || {};
+  const surface = opts.surface;
+
+  if (surface === 'glass') {
+    return {
+      root: {
+        backgroundColor: hexAlpha(opts.paperColor, 0.72),
+        backgroundImage: 'none',
+        backdropFilter: 'blur(8px)',
+        border: '1px solid ' + (opts.dividerColor || 'rgba(128,128,128,0.3)'),
+        boxShadow: 'none',
+        transition: SURFACE_TRANSITION
+      }
+    };
+  }
+  if (surface === 'flat') {
+    return {
+      root: {
+        backgroundColor: 'transparent',
+        backgroundImage: 'none',
+        border: 'none',
+        boxShadow: 'none',
+        transition: SURFACE_TRANSITION
+      }
+    };
+  }
+  return { root: { transition: SURFACE_TRANSITION } };
+}
+```
+
+- [ ] **Step 4: Run to verify PASS** (5 tests).
+
+- [ ] **Step 5: Wire script + CI step** (`"test:surface-styles"` after `"test:ambiance-composition"`; CI step "Ambiance surface styles" after "Ambiance composition contract").
+
+- [ ] **Step 6: Commit**
+```bash
+git add imports/ui/theme/surfaceStyles.js tests/unit/imports/ui/theme/surfaceStyles.test.mjs package.json .circleci/config.yml
+git commit -m "feat(theme): shared surface styles — solid/glass/flat card recipes with animated transitions"
+```
+
+---
+
+### Task 3: AmbianceZone guard + `useAmbiance()` context
+
+**Files:**
+- Create: `imports/ui/guards/AmbianceZone.jsx`
+- Create: `imports/ui/theme/AmbianceContext.js`
+- Modify: `imports/lib/SessionKeys.js` (+ `PAGE_SURFACE_OVERRIDES`), `imports/lib/sessionKeyGroups.js` (chrome group)
+
+**Interfaces:**
+- Consumes: `resolveComposition` (Task 1), `buildSurfaceStyles` (Task 2), `buildPageModeTheme`, `getBackgroundEntry`, `PAGE_MODE`/`CARD_SURFACE` SessionKeys, `useLocation`.
+- Produces:
+  - `AmbianceContext.js`: `export const AmbianceContext = React.createContext(null);` and `export function useAmbiance()` returning the composition object or `null` when outside a zone.
+  - `AmbianceZone.jsx`: `<AmbianceZone ambiance={bool} fluid={bool}>{children}</AmbianceZone>` — the guard StyledMainRouter composes. Renders children unchanged when neither flag applies. Otherwise: assembles the composition, provides context, sets `--ambiance-focus`/`--ambiance-scrim` CSS vars on a full-height wrapper div, and wraps children in a ThemeProvider whose theme = `buildPageModeTheme(appTheme, composition.pageMode)` extended with MuiCard/MuiPaper `styleOverrides.root` from `buildSurfaceStyles` (only when surface ≠ solid).
+  - New Session key: `PAGE_SURFACE_OVERRIDES = 'pageSurfaceOverrides'` (object map `{ [pathname]: 'solid'|'flat' }`, Task 8 writes it).
+
+- [ ] **Step 1: Create AmbianceContext.js**
+
+```javascript
+// imports/ui/theme/AmbianceContext.js
+//
+// React context carrying the zone composition object (see
+// ambianceComposition.js). Provided by AmbianceZone on enableAmbiance /
+// enableFluidInterface routes; useAmbiance() returns null everywhere else,
+// so shared components (StyledCard/StyledContainer) can fall back to
+// Session/global reads outside a zone.
+
+import React from 'react';
+
+export const AmbianceContext = React.createContext(null);
+
+export function useAmbiance() {
+  return React.useContext(AmbianceContext);
+}
+```
+
+- [ ] **Step 2: Add the Session key**
+
+`imports/lib/SessionKeys.js`, next to `CARD_SURFACE` (and add to the default export + `sessionKeyGroups.js` chrome group `exact` list):
+```javascript
+export const PAGE_SURFACE_OVERRIDES = 'pageSurfaceOverrides'; // { [pathname]: 'solid'|'flat' } — Ctrl+Shift+K per-route card↔full-height
+```
+
+- [ ] **Step 3: Create AmbianceZone.jsx**
+
+```jsx
+// imports/ui/guards/AmbianceZone.jsx
+//
+// Router-level zone wrapper (composes like AuthGuard/PatientGuard — see
+// App.jsx StyledMainRouter). On routes declaring enableAmbiance or
+// enableFluidInterface it: (1) assembles the composition object from the
+// active background's curation record + persisted axes, (2) provides it via
+// AmbianceContext + --ambiance-* CSS vars, and (3) wraps children in a
+// page-mode theme carrying MuiCard/MuiPaper overrides for the active card
+// surface — so even raw MUI cards render legibly over ambiance
+// (correctness by construction; discipline not required). With neither flag
+// it renders children unchanged. Spec:
+// docs/superpowers/specs/2026-08-03-ambiance-experience-zone-design.md
+
+import React, { useMemo } from 'react';
+import { useLocation } from 'react-router-dom';
+import { ThemeProvider, useTheme, createTheme } from '@mui/material/styles';
+import { Meteor } from 'meteor/meteor';
+import { Session } from 'meteor/session';
+import { useTracker } from 'meteor/react-meteor-data';
+import { get } from 'lodash';
+
+import { resolveComposition } from '../theme/ambianceComposition.js';
+import { buildSurfaceStyles } from '../theme/surfaceStyles.js';
+import { buildPageModeTheme } from '../theme/pageModeTheme.js';
+import { getBackgroundEntry } from '../themeBackgrounds.js';
+import { AmbianceContext } from '../theme/AmbianceContext.js';
+import { PAGE_MODE, CARD_SURFACE, PAGE_SURFACE_OVERRIDES } from '/imports/lib/SessionKeys.js';
+
+export function AmbianceZone(props) {
+  const ambiance = !!props.ambiance;
+  const fluid = !!props.fluid || ambiance;   // enableAmbiance implies fluid
+  const appTheme = useTheme();
+  const location = useLocation();
+
+  // Reactive axes (Session); background is a PLAIN read — the provider
+  // rebuild re-renders us (never useTracker a bare settings read).
+  const pageMode = useTracker(function() { return Session.get(PAGE_MODE); }, []);
+  const cardSurface = useTracker(function() { return Session.get(CARD_SURFACE); }, []);
+  const surfaceOverride = useTracker(function() {
+    const overrides = Session.get(PAGE_SURFACE_OVERRIDES) || {};
+    return overrides[location.pathname];
+  }, [location.pathname]);
+
+  const activeBg = get(Meteor, 'settings.public.theme.backgroundImagePath', '');
+
+  const composition = resolveComposition({
+    background: ambiance ? activeBg : '',   // fluid-only routes paint their own backdrop
+    entry: ambiance ? getBackgroundEntry(activeBg) : null,
+    pageMode: pageMode,
+    cardSurface: cardSurface,
+    surfaceOverride: surfaceOverride
+  });
+
+  const zoneTheme = useMemo(function() {
+    const base = buildPageModeTheme(appTheme, composition.pageMode) || appTheme;
+    if (composition.cardSurface === 'solid') { return base; }
+    const surface = buildSurfaceStyles({
+      surface: composition.cardSurface,
+      paperColor: get(base, 'palette.background.paper', '#ffffff'),
+      dividerColor: get(base, 'palette.divider', 'rgba(128,128,128,0.3)')
+    });
+    return createTheme(base, {
+      components: {
+        MuiCard: { styleOverrides: { root: surface.root } },
+        MuiPaper: { styleOverrides: { root: surface.root } }
+      }
+    });
+  }, [appTheme, composition.pageMode, composition.cardSurface]);
+
+  // Early return AFTER all hooks (React hooks-order rule); fluid is a
+  // static route capability, but keep the hook order unconditional anyway.
+  if (!fluid) { return props.children; }
+
+  return (
+    <AmbianceContext.Provider value={composition}>
+      <ThemeProvider theme={zoneTheme}>
+        <div style={{
+          height: '100%',
+          '--ambiance-focus': composition.focus,
+          '--ambiance-scrim': String(composition.scrimStrength)
+        }}>
+          {props.children}
+        </div>
+      </ThemeProvider>
+    </AmbianceContext.Provider>
+  );
+}
+
+export default AmbianceZone;
+```
+
+⚠️ React hooks note for the implementer: the `if (!fluid) return children` sits AFTER every hook call (including the `useMemo`) — keep it that way (hooks must run unconditionally).
+
+- [ ] **Step 4: Verify** — `npx esbuild imports/ui/guards/AmbianceZone.jsx --loader=jsx > /dev/null && echo JSX-OK`; `node --experimental-detect-module --check imports/ui/theme/AmbianceContext.js`.
+
+- [ ] **Step 5: Commit**
+```bash
+git add imports/ui/guards/AmbianceZone.jsx imports/ui/theme/AmbianceContext.js imports/lib/SessionKeys.js imports/lib/sessionKeyGroups.js
+git commit -m "feat(theme): AmbianceZone guard + useAmbiance composition context"
+```
+
+---
+
+### Task 4: StyledMainRouter — per-route painting + zone composition
+
+**Files:**
+- Modify: `imports/ui/App.jsx` (StyledMainRouter, ~lines 1824-1948)
+
+**Interfaces:**
+- Consumes: `AmbianceZone` (Task 3), existing `isColorBackground/colorFromBackground` imports, `matchPath`/`useLocation` from react-router-dom (check existing imports — App.jsx already imports from react-router-dom; extend that import if needed).
+- Produces: ambiance backgrounds paint ONLY when the active route declares `enableAmbiance`; `AmbianceZone` composes into the guard chain (inside PatientGuard, outside ErrorBoundary): `AuthGuard > PatientGuard > AmbianceZone > ErrorBoundary > page`.
+
+- [ ] **Step 1: Gate the painter on the active route**
+
+In `StyledMainRouter`, after `allRoutes` is computed and before `mainAppStyle`, resolve the active route (add `useLocation`/`matchPath` to the react-router-dom import at the top of App.jsx if absent):
+
+```javascript
+  // Active-route capability lookup: ambiance paints ONLY on routes that
+  // declare enableAmbiance (the constraint that makes ambiance safe — spec
+  // docs/superpowers/specs/2026-08-03-ambiance-experience-zone-design.md).
+  // This also ends the historical leak where every route showed the photo
+  // through canvas gaps.
+  const routerLocation = useLocation();
+  const activeRoute = allRoutes.find(function(r) {
+    return r.path && matchPath({ path: r.path, end: true }, routerLocation.pathname);
+  }) || null;
+  const activeAllowsAmbiance = !!get(activeRoute, 'enableAmbiance');
+```
+
+Then wrap the existing ambiance block:
+
+```javascript
+  const ambianceBackground = get(Meteor, 'settings.public.theme.backgroundImagePath', '');
+  if (ambianceBackground && activeAllowsAmbiance) {
+    // ... existing isColorBackground branch, unchanged ...
+  }
+```
+
+- [ ] **Step 2: Compose the zone into the guard chain**
+
+Add the import near the other guard imports: `import AmbianceZone from './guards/AmbianceZone.jsx';`
+In the route-mapping block (the "Guards compose from the inside out" section, ~line 1929), after the ErrorBoundary wrap and BEFORE the `requirePatient` wrap:
+
+```javascript
+        if (route.enableAmbiance || route.enableFluidInterface) {
+          element = (
+            <AmbianceZone ambiance={!!route.enableAmbiance} fluid={!!route.enableFluidInterface}>
+              {element}
+            </AmbianceZone>
+          );
+        }
+```
+
+(Update the composition comment above it to read `requireAuth > requirePatient > AmbianceZone > ErrorBoundary > page`.)
+
+- [ ] **Step 3: Verify** — `npx esbuild imports/ui/App.jsx --loader=jsx > /dev/null && echo JSX-OK` (App.jsx is large; esbuild transform is the syntax gate).
+
+- [ ] **Step 4: Commit**
+```bash
+git add imports/ui/App.jsx
+git commit -m "feat(theme): route-gated ambiance painting + AmbianceZone in the guard chain"
+```
+
+---
+
+### Task 5: `Meteor.StyledCard` + `Meteor.StyledContainer`
+
+**Files:**
+- Create: `imports/ui/components/StyledCard.jsx`
+- Create: `imports/ui/components/StyledContainer.jsx`
+- Modify: `imports/ui/CustomThemeProvider.jsx` (attach both to Meteor next to `Meteor.useTheme = useTheme;` at line 18)
+
+**Interfaces:**
+- Consumes: `useAmbiance` (Task 3), `buildSurfaceStyles`/`SURFACE_TRANSITION` (Task 2), `CARD_SURFACE` SessionKey.
+- Produces: `Meteor.StyledCard` (surface-aware Card: props `surface` override, else zone composition, else Session, else solid) and `Meteor.StyledContainer` (focus-aware column: props `focus` override, else zone focus; maxWidth default `'lg'`; xl 200px easement; optional `scrim` bool painting the zone scrim behind its content). Consumers use the `Meteor.StyledCard || Card` degradation idiom.
+
+- [ ] **Step 1: Create StyledCard.jsx**
+
+```jsx
+// imports/ui/components/StyledCard.jsx
+//
+// Surface-aware Card, Meteor-object-distributed (Meteor.StyledCard) like
+// Meteor.useTheme — workflow packages consume it without import-path
+// coupling: `const Card = Meteor.StyledCard || MuiCard;`. Resolves its
+// surface from (in order) the `surface` prop, the ambiance zone
+// composition, the global Session axis, then 'solid'. Transitions between
+// states are animated (glass fades, flat melts into negative space). Spec:
+// docs/superpowers/specs/2026-08-03-ambiance-experience-zone-design.md
+
+import React from 'react';
+import Card from '@mui/material/Card';
+import { useTheme } from '@mui/material/styles';
+import { Session } from 'meteor/session';
+import { useTracker } from 'meteor/react-meteor-data';
+import { get } from 'lodash';
+
+import { useAmbiance } from '../theme/AmbianceContext.js';
+import { buildSurfaceStyles } from '../theme/surfaceStyles.js';
+import { CARD_SURFACE } from '/imports/lib/SessionKeys.js';
+
+export function StyledCard(props) {
+  const { surface, sx, children, ...rest } = props;
+  const theme = useTheme();
+  const composition = useAmbiance();
+  const sessionSurface = useTracker(function() { return Session.get(CARD_SURFACE); }, []);
+
+  const active = surface || get(composition, 'cardSurface') || sessionSurface || 'solid';
+  const styles = buildSurfaceStyles({
+    surface: active,
+    paperColor: get(theme, 'palette.background.paper', '#ffffff'),
+    dividerColor: get(theme, 'palette.divider', 'rgba(128,128,128,0.3)')
+  });
+
+  return (
+    <Card {...rest} sx={Object.assign({}, styles.root, sx)}>
+      {children}
+    </Card>
+  );
+}
+
+export default StyledCard;
+```
+
+- [ ] **Step 2: Create StyledContainer.jsx**
+
+```jsx
+// imports/ui/components/StyledContainer.jsx
+//
+// Focus-aware content column, Meteor-object-distributed
+// (Meteor.StyledContainer). Places its column into the ambiance image's
+// neutral space (left | center | right — from the zone composition, or the
+// `focus` prop), with the wide-viewport 200px easement at the xl
+// breakpoint and an optional scrim backdrop. Pages using vanilla
+// <Container> swap one import and inherit placement:
+//   const Wrap = Meteor.StyledContainer || Container;
+// Spec: docs/superpowers/specs/2026-08-03-ambiance-experience-zone-design.md
+
+import React from 'react';
+import Box from '@mui/material/Box';
+import { useTheme, alpha } from '@mui/material/styles';
+import { get } from 'lodash';
+
+import { useAmbiance } from '../theme/AmbianceContext.js';
+
+const WIDTHS = { xs: '444px', sm: '600px', md: '900px', lg: '1200px', xl: '1536px' };
+
+export function StyledContainer(props) {
+  const { focus, scrim, maxWidth, sx, children, ...rest } = props;
+  const theme = useTheme();
+  const composition = useAmbiance();
+
+  const activeFocus = focus || get(composition, 'focus') || 'center';
+  const align = activeFocus === 'left' ? { ml: 0, mr: 'auto' }
+    : activeFocus === 'right' ? { ml: 'auto', mr: 0 }
+    : { mx: 'auto' };
+
+  const scrimStrength = get(composition, 'scrimStrength', 0.55);
+  const showScrim = !!scrim && !!get(composition, 'background');
+
+  return (
+    <Box {...rest} sx={Object.assign({
+      width: '100%',
+      maxWidth: WIDTHS[maxWidth || 'lg'] || WIDTHS.lg,
+      px: { xs: 2, md: 3, xl: '200px' },
+      boxSizing: 'content-box'
+    }, align, showScrim ? {
+      background: alpha(theme.palette.background.default, scrimStrength),
+      backdropFilter: 'blur(2px)',
+      borderRadius: '4px'
+    } : {}, sx)}>
+      {children}
+    </Box>
+  );
+}
+
+export default StyledContainer;
+```
+
+- [ ] **Step 3: Attach to the Meteor object**
+
+`imports/ui/CustomThemeProvider.jsx`, next to `Meteor.useTheme = useTheme;` (line 18), with imports at top:
+```javascript
+import StyledCard from './components/StyledCard.jsx';
+import StyledContainer from './components/StyledContainer.jsx';
+// ...
+Meteor.StyledCard = StyledCard;           // surface-aware Card (solid|glass|flat)
+Meteor.StyledContainer = StyledContainer; // focus-aware content column
+```
+
+- [ ] **Step 4: Verify** — esbuild JSX transform on all three touched files.
+
+- [ ] **Step 5: Commit**
+```bash
+git add imports/ui/components/StyledCard.jsx imports/ui/components/StyledContainer.jsx imports/ui/CustomThemeProvider.jsx
+git commit -m "feat(theme): Meteor.StyledCard + Meteor.StyledContainer surface/focus consumers"
+```
+
+---
+
+### Task 6: Flag the tracked-repo zone routes + Patient Chart placement
+
+**Files:**
+- Modify: `imports/ui/App.jsx` (`/patient-chart` route literal, ~line 702)
+- Modify: `npmPackages/provider-directory/client.js` (route literal, ~line 68)
+- Modify: `imports/patient/AutoDashboard.jsx` (root Container, line ~981)
+
+**Interfaces:**
+- Consumes: route flags (Task 4 reads them), `Meteor.StyledContainer` (Task 5).
+- Produces: `/patient-chart` and `/provider-directory` are live `enableAmbiance` routes; the patient chart column lands in the image's neutral space.
+
+- [ ] **Step 1: Flag the routes**
+
+`imports/ui/App.jsx` (~702):
+```javascript
+  }, {
+    path: "/patient-chart",
+    element: <PatientChart />,
+    enableAmbiance: true
+  }, {
+```
+`npmPackages/provider-directory/client.js` (~68):
+```javascript
+let DynamicRoutes = [{
+  name: 'ProviderDirectory',
+  path: '/provider-directory',
+  element: <DirectoryConsole />,
+  requireAuth: true,
+  enableAmbiance: true
+}, {
+```
+
+- [ ] **Step 2: Patient Chart placement via StyledContainer**
+
+`imports/patient/AutoDashboard.jsx` line ~981 — swap the root Container with the degradation idiom (add NO new imports; Meteor is already imported in the file — verify, and if not, add `import { Meteor } from 'meteor/meteor';`):
+
+```javascript
+            const AmbientColumn = Meteor.StyledContainer || Container;
+```
+```jsx
+            <AmbientColumn maxWidth="lg" sx={{ mt: 4, mb: 10, pb: '100px' }}>
+```
+(and the matching closing tag at ~line 1579 → `</AmbientColumn>`). Place the `const AmbientColumn` line immediately above the `return` that renders it, inside the component body.
+
+- [ ] **Step 3: Verify** — esbuild JSX transform on all three files.
+
+- [ ] **Step 4: Commit**
+```bash
+git add imports/ui/App.jsx npmPackages/provider-directory/client.js imports/patient/AutoDashboard.jsx
+git commit -m "feat(theme): enableAmbiance on /patient-chart + /provider-directory; chart column lands in neutral space"
+```
+
+---
+
+### Task 7: Timelines extension — flag `/timeline-vertical` (NESTED REPO)
+
+**Files:**
+- Modify: `extensions/timelines/client.js` (route literal at ~line 54)
+
+**Interfaces:** Produces the third zone route. **This file is in a separate git repo** — commit there, not in the monorepo.
+
+- [ ] **Step 1:** Add `enableAmbiance: true` to the `/timeline-vertical` route object literal in `extensions/timelines/client.js` (same shape as the provider-directory edit; read the surrounding object and match its quoting style — this file uses quoted keys like `'path'`).
+- [ ] **Step 2:** Verify with esbuild JSX transform (the file may be .js with JSX — use `--loader=jsx`).
+- [ ] **Step 3: Commit IN THE EXTENSION REPO** (never `git add` this path in the monorepo):
+```bash
+git -C extensions/timelines add client.js
+git -C extensions/timelines commit -m "feat(theme): enableAmbiance on /timeline-vertical (honeycomb ambiance zone phase 3)"
+```
+
+---
+
+### Task 8: Hotkey graduations — Ctrl+Shift+L cycle + Ctrl+Shift+K per-route toggle
+
+**Files:**
+- Modify: `imports/ui/themePresets.js` (new `cycleCardSurface()` + `togglePageSurfaceOverride(pathname)` + boot restore for overrides)
+- Modify: `imports/startup/client/hotkeys.js` (L handler replaced; K handler added)
+- Modify: `imports/ui/extensible/NotFoundPage.jsx` (migrate off the CustomEvent)
+- Modify: `extensions/life-support-systems/client/LifeSupportDashboard.jsx` (migrate off the CustomEvent — NESTED REPO commit)
+- Modify: `imports/lib/themePersistence.js` (doc comment: add `pageSurfaceOverrides`)
+
+**Interfaces:**
+- Consumes: `CARD_SURFACE`/`PAGE_SURFACE_OVERRIDES` SessionKeys, existing `setCardSurface`.
+- Produces: `cycleCardSurface()` → advances solid→glass→flat→solid via `setCardSurface`; `togglePageSurfaceOverride(pathname)` → flips `{ [pathname]: 'flat' }` ↔ absent in the Session map + persists via `saveThemeChoice({ pageSurfaceOverrides })`; boot restore validates the map (object; values `'solid'|'flat'`; junk dropped).
+
+- [ ] **Step 1: themePresets.js additions** (below `setCardSurface`)
+
+```javascript
+// Live control: advance the card surface one step (Ctrl+Shift+L).
+export function cycleCardSurface() {
+  const current = Session.get(CARD_SURFACE) || 'solid';
+  const order = ['solid', 'glass', 'flat'];
+  const next = order[(order.indexOf(current) + 1) % order.length];
+  setCardSurface(next);
+}
+
+// Live control: per-route card <-> full-height override (Ctrl+Shift+K).
+// Toggles the active pathname between 'flat' (one-page/full-height) and no
+// override (global cardSurface stands). Spec: onePageLayout revival.
+export function togglePageSurfaceOverride(pathname) {
+  if (!pathname) { return; }
+  const overrides = Object.assign({}, Session.get(PAGE_SURFACE_OVERRIDES) || {});
+  if (overrides[pathname]) {
+    delete overrides[pathname];
+  } else {
+    overrides[pathname] = 'flat';
+  }
+  Session.set(PAGE_SURFACE_OVERRIDES, overrides);
+  saveThemeChoice({ pageSurfaceOverrides: overrides });
+  pokeRefresh();
+}
+```
+Import `PAGE_SURFACE_OVERRIDES` alongside the existing SessionKeys import. In `applyThemeChoiceAtBoot()`, after the cardSurface restore:
+```javascript
+  // Per-route surface overrides — keep only well-formed entries.
+  const rawOverrides = choice.pageSurfaceOverrides;
+  if (rawOverrides && typeof rawOverrides === 'object' && !Array.isArray(rawOverrides)) {
+    const clean = {};
+    Object.keys(rawOverrides).forEach(function(path) {
+      if (rawOverrides[path] === 'flat' || rawOverrides[path] === 'solid') { clean[path] = rawOverrides[path]; }
+    });
+    if (Object.keys(clean).length) { Session.set(PAGE_SURFACE_OVERRIDES, clean); }
+  }
+```
+`themePersistence.js` shape comment gains `pageSurfaceOverrides: { <pathname>: 'solid'|'flat' }`.
+
+- [ ] **Step 2: hotkeys.js**
+
+Replace the Ctrl+Shift+L body (keep the comment style):
+```javascript
+    // Cmd/Ctrl + Shift + L — Cycle card surface (solid → glass → flat)
+    if ((event.metaKey || event.ctrlKey) && event.shiftKey && (event.key === 'L' || event.key === 'l')) {
+      event.preventDefault();
+      import('/imports/ui/themePresets.js').then(function(tp) { tp.cycleCardSurface(); });
+    }
+
+    // Cmd/Ctrl + Shift + K — Toggle this route between card and full-height (flat) layout
+    if ((event.metaKey || event.ctrlKey) && event.shiftKey && (event.key === 'K' || event.key === 'k')) {
+      event.preventDefault();
+      import('/imports/ui/themePresets.js').then(function(tp) { tp.togglePageSurfaceOverride(window.location.pathname); });
+    }
+```
+(Dynamic import keeps hotkeys.js free of a static UI-module dependency at startup, matching its current zero-import-besides-Session posture.)
+
+- [ ] **Step 3: Migrate the two CustomEvent listeners**
+
+`imports/ui/extensible/NotFoundPage.jsx`: replace the `useState(false)` + `toggleFlatCards` listener pair with a Session read (imports: `Session` from meteor/session, `useTracker` from meteor/react-meteor-data, `CARD_SURFACE` from SessionKeys):
+```javascript
+  const flatCardMode = useTracker(function() { return Session.get(CARD_SURFACE) === 'flat'; }, []);
+```
+Delete the `handleToggleFlatCards`/addEventListener/removeEventListener block. All downstream `flatCardMode` conditionals stay untouched.
+
+`extensions/life-support-systems/client/LifeSupportDashboard.jsx` (~lines 132, 193-194, and the `flatCardMode` state): same substitution. **Commit in the extension repo:**
+```bash
+git -C extensions/life-support-systems add client/LifeSupportDashboard.jsx
+git -C extensions/life-support-systems commit -m "refactor(cards): read the persisted cardSurface axis instead of the toggleFlatCards event"
+```
+
+- [ ] **Step 4: Verify** — esbuild transforms + `node --experimental-detect-module --check imports/ui/themePresets.js` is not possible (imports Meteor) → careful re-read + esbuild; run `npm run test:background-value && npm run test:ambiance-analysis && npm run test:ambiance-composition && npm run test:surface-styles` (regression: all green).
+
+- [ ] **Step 5: Commit (monorepo part)**
+```bash
+git add imports/ui/themePresets.js imports/startup/client/hotkeys.js imports/ui/extensible/NotFoundPage.jsx imports/lib/themePersistence.js
+git commit -m "feat(theme): Ctrl+Shift+L surface cycle + Ctrl+Shift+K per-route flat toggle; retire toggleFlatCards event"
+```
+
+---
+
+### Task 9: Ambiance Tuning HUD (Cmd/Ctrl+Shift+E)
+
+**Files:**
+- Create: `imports/ui/theme/AmbianceTuningHud.jsx`
+- Modify: `imports/lib/SessionKeys.js` (+ `AMBIANCE_HUD_OPEN = 'ambianceHudOpen'`; add to sessionKeyGroups chrome group)
+- Modify: `imports/startup/client/hotkeys.js` (E handler)
+- Modify: `imports/ui/App.jsx` (render `<AmbianceTuningHud />` next to `<ThemeDialog />`, ~line 1801)
+
+**Interfaces:**
+- Consumes: `useAmbiance` is NOT available here (HUD renders at app root, outside zones) — it reads the same inputs the zone does: active background (plain read), `getBackgroundEntry`, Session axes; `setPageMode`/`setCardSurface`/`setAccentHue` for live controls.
+- Produces: a dev overlay (MUI Dialog, `hideBackdrop`, positioned bottom-right, non-modal so the page stays interactive) with: scrim-strength slider, focus select, page-mode select, card-surface select, accent-hue text field — each applying live (focus/scrim apply via a Session-held draft the HUD copies from; they affect the copied JSON, and scrim/focus also preview live ONLY on pages reading the curation record fresh — note this honestly in the HUD's caption) — and a **Copy as JSON** button emitting the curation record for the background library. Clipboard out only; no persistence of its own.
+
+- [ ] **Step 1: Create the HUD**
+
+```jsx
+// imports/ui/theme/AmbianceTuningHud.jsx
+//
+// Dev-tool overlay (Cmd/Ctrl+Shift+E) for authoring ambiance curation
+// records against the live page: tune focus / scrim / ink / surface /
+// accent, then Copy as JSON to paste into themeBackgrounds.js or
+// settings.public.theme.backgroundLibrary. Session Inspector posture: no
+// PHI, no persistence of its own (clipboard out only), hidden behind the
+// hotkey. Spec: docs/superpowers/specs/2026-08-03-ambiance-experience-zone-design.md
+
+import React from 'react';
+import {
+  Paper, Typography, Slider, Select, MenuItem, TextField, Button, Stack, IconButton
+} from '@mui/material';
+import CloseIcon from '@mui/icons-material/Close';
+import ContentCopyIcon from '@mui/icons-material/ContentCopy';
+import { Meteor } from 'meteor/meteor';
+import { Session } from 'meteor/session';
+import { useTracker } from 'meteor/react-meteor-data';
+import { get } from 'lodash';
+
+import { getBackgroundEntry } from '../themeBackgrounds.js';
+import { setPageMode, setCardSurface, setAccentHue } from '../themePresets.js';
+import { AMBIANCE_HUD_OPEN, PAGE_MODE, CARD_SURFACE } from '/imports/lib/SessionKeys.js';
+
+export function AmbianceTuningHud() {
+  const open = useTracker(function() { return !!Session.get(AMBIANCE_HUD_OPEN); }, []);
+  const pageMode = useTracker(function() { return Session.get(PAGE_MODE) || ''; }, []);
+  const cardSurface = useTracker(function() { return Session.get(CARD_SURFACE) || 'solid'; }, []);
+
+  const activeBg = get(Meteor, 'settings.public.theme.backgroundImagePath', '');
+  const entry = getBackgroundEntry(activeBg);
+
+  const [focus, setFocus] = React.useState(get(entry, 'focus', 'center'));
+  const [scrim, setScrim] = React.useState(get(entry, 'scrimStrength', 0.55));
+  const [accent, setAccent] = React.useState(get(Meteor, 'settings.public.theme.palette.primaryColor', ''));
+  const [copied, setCopied] = React.useState(false);
+
+  // Re-seed the draft when the background changes while open.
+  React.useEffect(function() {
+    setFocus(get(entry, 'focus', 'center'));
+    setScrim(get(entry, 'scrimStrength', 0.55));
+    setCopied(false);
+  }, [activeBg]);
+
+  if (!open) { return null; }
+
+  function curationRecord() {
+    return {
+      name: get(entry, 'name', '(unnamed)'),
+      src: activeBg,
+      focus: focus,
+      recommendedPageMode: pageMode || get(entry, 'recommendedPageMode', undefined),
+      scrimStrength: Math.round(scrim * 100) / 100
+    };
+  }
+
+  async function handleCopy() {
+    try {
+      await navigator.clipboard.writeText(JSON.stringify(curationRecord(), null, 2));
+      setCopied(true);
+    } catch (error) {
+      setCopied(false);
+    }
+  }
+
+  return (
+    <Paper elevation={8} sx={{
+      position: 'fixed', right: 16, bottom: 80, width: 300, p: 2, zIndex: 1400,
+      bgcolor: 'background.paper'
+    }}>
+      <Stack direction="row" sx={{ alignItems: 'center', justifyContent: 'space-between', mb: 1 }}>
+        <Typography variant="overline">Ambiance tuning</Typography>
+        <IconButton size="small" id="ambianceHudClose" onClick={function() { Session.set(AMBIANCE_HUD_OPEN, false); }}>
+          <CloseIcon fontSize="small" />
+        </IconButton>
+      </Stack>
+      <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 1 }}>
+        {activeBg ? (get(entry, 'name') || activeBg) : 'No ambiance background active'}
+      </Typography>
+
+      <Typography variant="caption">Scrim strength — {Math.round(scrim * 100)}%</Typography>
+      <Slider id="ambianceHudScrim" size="small" min={0} max={1} step={0.05} value={scrim}
+        onChange={function(e, v) { setScrim(v); }} sx={{ mb: 1 }} />
+
+      <Stack spacing={1} sx={{ mb: 1 }}>
+        <Select id="ambianceHudFocus" size="small" value={focus}
+          onChange={function(e) { setFocus(e.target.value); }}>
+          <MenuItem value="left">Focus: left</MenuItem>
+          <MenuItem value="center">Focus: center</MenuItem>
+          <MenuItem value="right">Focus: right</MenuItem>
+        </Select>
+        <Select id="ambianceHudPageMode" size="small" value={pageMode} displayEmpty
+          onChange={function(e) { setPageMode(e.target.value || null); }}>
+          <MenuItem value="">Ink: auto</MenuItem>
+          <MenuItem value="light">Ink: light</MenuItem>
+          <MenuItem value="dark">Ink: dark</MenuItem>
+        </Select>
+        <Select id="ambianceHudSurface" size="small" value={cardSurface}
+          onChange={function(e) { setCardSurface(e.target.value); }}>
+          <MenuItem value="solid">Surface: solid</MenuItem>
+          <MenuItem value="glass">Surface: glass</MenuItem>
+          <MenuItem value="flat">Surface: flat</MenuItem>
+        </Select>
+        <TextField id="ambianceHudAccent" size="small" label="Accent hex" value={accent}
+          onChange={function(e) { setAccent(e.target.value); }}
+          onBlur={function() { if (/^#[0-9a-fA-F]{6}$/.test(accent)) { setAccentHue(accent); } }} />
+      </Stack>
+
+      <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 1 }}>
+        Ink/surface/accent apply live. Focus + scrim land in the copied
+        record — paste into the background library to take effect.
+      </Typography>
+      <Button id="ambianceHudCopy" fullWidth size="small" variant="contained"
+        startIcon={<ContentCopyIcon />} onClick={handleCopy} disabled={!activeBg}>
+        {copied ? 'Copied' : 'Copy as JSON'}
+      </Button>
+    </Paper>
+  );
+}
+
+export default AmbianceTuningHud;
+```
+
+- [ ] **Step 2: Session key + hotkey + mount**
+
+SessionKeys: `export const AMBIANCE_HUD_OPEN = 'ambianceHudOpen'; // Cmd/Ctrl+Shift+E ambiance curation HUD` (+ default export + sessionKeyGroups chrome). hotkeys.js (E is unclaimed — verify by reading the file first):
+```javascript
+    // Cmd/Ctrl + Shift + E — Toggle Ambiance Tuning HUD (curation dev tool)
+    if ((event.metaKey || event.ctrlKey) && event.shiftKey && (event.key === 'E' || event.key === 'e')) {
+      event.preventDefault();
+      Session.set('ambianceHudOpen', !Session.get('ambianceHudOpen'));
+    }
+```
+App.jsx ~1801: `<AmbianceTuningHud />` rendered adjacent to `<ThemeDialog />`, import at top with the other ui/theme imports. Add Escape-close: extend the existing Escape handler in hotkeys.js with `Session.set('ambianceHudOpen', false);`.
+
+- [ ] **Step 3: Verify** — esbuild transforms on the HUD + App.jsx; re-read hotkeys.js diff.
+
+- [ ] **Step 4: Commit**
+```bash
+git add imports/ui/theme/AmbianceTuningHud.jsx imports/lib/SessionKeys.js imports/lib/sessionKeyGroups.js imports/startup/client/hotkeys.js imports/ui/App.jsx
+git commit -m "feat(theme): Ambiance Tuning HUD (Cmd/Ctrl+Shift+E) — live curation authoring with Copy-as-JSON"
+```
+
+---
+
+### Task 10: Card Surface mini-preview in ThemeControls
+
+**Files:**
+- Modify: `imports/ui/theme/ThemeControls.jsx` (the Card Surface block)
+
+**Interfaces:** Consumes `buildSurfaceStyles` (Task 2). Produces the spec'd "live mini-preview" beside the toggle group.
+
+- [ ] **Step 1:** Under the existing `ToggleButtonGroup` (id `themeCardSurfaceGroup`), add a preview row — three 72×44 chips labeled by state, each styled by `buildSurfaceStyles` against the current theme, the active one ring-highlighted:
+
+```jsx
+            <Box id="themeCardSurfacePreview" sx={{ display: 'flex', gap: 1, mt: 1 }}>
+              {['solid', 'glass', 'flat'].map(function(s) {
+                const preview = buildSurfaceStyles({
+                  surface: s,
+                  paperColor: muiTheme.palette.background.paper,
+                  dividerColor: muiTheme.palette.divider
+                });
+                return (
+                  <Box key={s} sx={Object.assign({
+                    width: 72, height: 44, borderRadius: '6px', display: 'flex',
+                    alignItems: 'center', justifyContent: 'center', fontSize: 10,
+                    color: 'text.secondary', bgcolor: 'background.paper',
+                    border: '1px solid', borderColor: 'divider',
+                    outline: cardSurface === s ? '2px solid' : 'none',
+                    outlineColor: 'primary.main'
+                  }, preview.root)}>
+                    {s}
+                  </Box>
+                );
+              })}
+            </Box>
+```
+Imports to add: `buildSurfaceStyles` from `./surfaceStyles.js`; `const muiTheme = useMuiTheme();` via `import { useTheme as useMuiTheme } from '@mui/material/styles';` (the file's `useTheme` name is taken by the app-mode context import — keep both).
+
+- [ ] **Step 2: Verify** — esbuild transform.
+- [ ] **Step 3: Commit**
+```bash
+git add imports/ui/theme/ThemeControls.jsx
+git commit -m "feat(theme): card-surface mini-preview chips in Theme & Palette"
+```
+
+---
+
+### Task 11: Print hardening
+
+**Files:**
+- Modify: `client/main.css` (the `@media print` block at ~line 129)
+- Modify: `npmPackages/provider-directory/client/DirectoryConsole.jsx` (scrim `@media print` off-switch)
+
+**Interfaces:** Closes the final-review deferred finding: ambiance images/solids and the console scrim must not reach paper.
+
+- [ ] **Step 1:** In `client/main.css`'s `@media print` block, add alongside the existing white-forcing rules:
+```css
+  /* Ambiance never prints: photo/solid canvas and zone scrims stay screen-only */
+  #mainAppRouter {
+    background-image: none !important;
+    background-color: #ffffff !important;
+  }
+```
+- [ ] **Step 2:** In DirectoryConsole's scrim'd column `sx` (the `activeBg ? linear-gradient(...) : 'transparent'` block), add:
+```javascript
+          '@media print': { background: 'transparent', backdropFilter: 'none' },
+```
+- [ ] **Step 3: Verify** — esbuild transform on DirectoryConsole; visual CSS re-read.
+- [ ] **Step 4: Commit**
+```bash
+git add client/main.css npmPackages/provider-directory/client/DirectoryConsole.jsx
+git commit -m "fix(theme): ambiance backgrounds and scrims never reach print"
+```
+
+---
+
+### Task 12: Verification sweep, docs, final review
+
+**Files:** spec status line; ledger; no code unless findings.
+
+- [ ] **Step 1:** Full unit sweep: `npm run test:background-value && npm run test:ambiance-analysis && npm run test:ambiance-composition && npm run test:surface-styles && npm run test:session-key-groups` — all green.
+- [ ] **Step 2:** Controller live checks IF the user's app is up (read-only browsing; NEVER touch processes): `/patient-chart` with Zen Rocks → column right + glass/flat toggles visible on cards (the Phase 3 acceptance criterion); `/provider-directory` unchanged behavior; an unflagged route (e.g. `/fhir-graph`) shows NO ambiance photo anymore (the leak is closed — this is an intentional, spec'd behavior change worth flagging to the user); Ctrl+Shift+L cycles surfaces; HUD opens on Ctrl+Shift+E. If the app is down: record a morning checklist in the ledger instead.
+- [ ] **Step 3:** Update the spec Status line to `Phases 1-3 implemented; Phase 3.5/4 pending`, commit as `docs(specs): mark ambiance phase 3 implemented`.
+- [ ] **Step 4:** Final whole-branch review (most capable model) over the Phase 3 range; fix batch if findings; ledger everything.

--- a/docs/superpowers/specs/2026-08-03-ambiance-experience-zone-design.md
+++ b/docs/superpowers/specs/2026-08-03-ambiance-experience-zone-design.md
@@ -2,7 +2,7 @@
 
 **Date**: 2026-08-03
 **Branch**: `go-live-ui-polish`
-**Status**: Approved design, pending implementation plan
+**Status**: Phases 1-2 implemented (faba0c86..3bfe474a, 2026-08-04); Phase 3 pending
 
 ## Vision
 

--- a/docs/superpowers/specs/2026-08-03-ambiance-experience-zone-design.md
+++ b/docs/superpowers/specs/2026-08-03-ambiance-experience-zone-design.md
@@ -2,7 +2,7 @@
 
 **Date**: 2026-08-03
 **Branch**: `go-live-ui-polish`
-**Status**: Phases 1-2 implemented (faba0c86..3bfe474a, 2026-08-04); Phase 3 pending
+**Status**: Phases 1-3 implemented (Phase 3: 35274b0b..1c401015, 2026-08-04); Phase 3.5/4 pending
 
 ## Vision
 

--- a/docs/superpowers/specs/2026-08-03-ambiance-experience-zone-design.md
+++ b/docs/superpowers/specs/2026-08-03-ambiance-experience-zone-design.md
@@ -162,6 +162,31 @@ persisted `cardSurface` (solid → glass → flat → solid).
 `LifeSupportDashboard` and `NotFoundPage` migrate from the event listener to
 reading the setting.
 
+### Card ↔ full-height toggle (`onePageLayout` revival)
+
+Heritage: the Meteor-2 app had a per-page toggle (icon button + hotkey)
+flipping a list between a bounded Card and a full-height panel. Its fossils
+survive — per-page `<Page>.onePageLayout` Session keys (`setDefault(true)`,
+read but never flipped) and `LayoutHelpers.getCardLayoutIcon()`
+(`ic_filter_1`/`ic_filter_2`, zero callers) — but the trigger stayed behind
+in the v2 upstream during the reseed. Phase 3 revives the behavior on the
+new axis instead of resurrecting those keys:
+
+- **Flat implies one-page.** On zone routes, `cardSurface: 'flat'` renders
+  the page's primary list/panel as the greedy-height treatment
+  (`.claude/rules/ui/layout-patterns.md` flex cascade — full height minus
+  chrome), with `Meteor.StyledCard` animating the melt between bounded card
+  and full-height panel.
+- **Cmd/Ctrl+Shift+K** — per-page card ↔ full-height toggle (K is
+  unclaimed in `hotkeys.js`). Scoped to the ACTIVE route: flips that page
+  between `solid` and `flat` without touching the global `cardSurface`
+  choice. Persisted as a per-route override map in the theme choice
+  (`pageSurfaceOverrides: { [routePath]: 'solid' | 'flat' }`); route
+  override wins over the global axis on that page. Global Ctrl+Shift+L
+  cycling remains the app-wide control.
+- Legacy `*.onePageLayout` Session keys and `getCardLayoutIcon` retire
+  opportunistically as pages adopt StyledCard (no dedicated cleanup PR).
+
 ## Architecture
 
 ### AmbianceZone route wrapper — correctness by construction
@@ -328,8 +353,10 @@ New section order (both dialog and `/theming`, via shared `ThemeControls`):
    context/CSS-var exposure, shared glass/flat tokens extracted from
    DirectoryConsole, `Meteor.StyledCard` + `Meteor.StyledContainer`, the
    **Ambiance Tuning HUD** (Cmd/Ctrl+Shift+E), Ctrl+Shift+L graduation,
-   flag the two initial routes. **Acceptance: Glass and Flat toggles
-   visibly work on cards on the `enableAmbiance` routes.**
+   the **card ↔ full-height revival** (flat-implies-one-page +
+   Cmd/Ctrl+Shift+K per-route override), flag the two initial routes.
+   **Acceptance: Glass and Flat toggles visibly work on cards on the
+   `enableAmbiance` routes.**
 3.5. **Runtime net + review harness (deferred, designed-for)** — adaptive
    scrim for uncurated images, Playwright screenshot matrix, contrast
    auditor (see Curation toolkit).

--- a/docs/superpowers/specs/2026-08-03-ambiance-experience-zone-design.md
+++ b/docs/superpowers/specs/2026-08-03-ambiance-experience-zone-design.md
@@ -1,0 +1,247 @@
+# Ambiance Experience Zone — Design Spec
+
+**Date**: 2026-08-03
+**Branch**: `go-live-ui-polish`
+**Status**: Approved design, pending implementation plan
+
+## Vision
+
+Honeycomb serves patients who seek very different caring environments — zen
+garden, ICU, cyberpunk, refugee camp, desert nomad, eco resort, blue lagoon,
+catholic sanctuary. The app expresses this through **ambiance backgrounds**
+(full-bleed photos or solid earth tones) with a **glass/AR-style digital
+interface** layered over them. Design goals, in priority order:
+
+1. Patient education and trust through aesthetic + cultural framing
+2. Calm/peacefulness — the interface reads as a digital layer over an
+   environment, not a form over a gray canvas
+3. Integration of medical illustration (future)
+
+Not every page participates. Clinical/analytic pages (`/fhir-graph`,
+`/clinical-story`, the timeline) own their full-page presentation. A small,
+curated set of routes — initially **Provider Directory** and **Vertical
+Timeline** — form the *patient-experience zone* where ambiance renders.
+
+## Current state (what exists today)
+
+- **Ambiance leaks everywhere.** `StyledMainRouter` (`imports/ui/App.jsx`
+  ~1824) paints `background.default` AND the ambiance `backgroundImage` on the
+  same `#mainAppRouter` element; the image layers over the color, so every
+  route shows the photo through canvas gaps whether designed for it or not.
+- **DirectoryConsole prototype** (uncommitted, `npmPackages/provider-directory/
+  client/DirectoryConsole.jsx`): transparent root deferring to the router
+  background, `?align=left|center|right` and `?page-theme=light|dark` URL
+  params, per-page `createTheme` mode override. Legibility over bright photos
+  is poor (washed-out stats, invisible chips/telemetry, naked result rows).
+- **ThemeControls** (`imports/ui/theme/ThemeControls.jsx`): shared by the
+  Theme & Palette dialog (Ctrl+Shift+T) and `/theming`. Order today: Preset →
+  Font/Mode/Accent hue → Ambiance carousel.
+- **Persistence**: `saveThemeChoice()`/`loadThemeChoice()`
+  (`imports/lib/themePersistence.js`, localStorage) carries `{ presetId,
+  accentHue, fontFamily, mode, backgroundImagePath }`.
+- **Background library** (`imports/ui/themeBackgrounds.js`): settings-driven
+  (`settings.public.theme.backgroundLibrary`), code fallback of 12 images.
+- **Flat cards precursor**: Cmd/Ctrl+Shift+L dispatches a `toggleFlatCards`
+  CustomEvent consumed locally by `LifeSupportDashboard` and `NotFoundPage`
+  (ephemeral, per-page state).
+- **Meteor-object distribution precedent**: `Meteor.useTheme`
+  (`imports/ui/CustomThemeProvider.jsx:18`), `Meteor.Logger`, `Meteor.rpc`.
+- **StyledCard prior art**: a private component inside
+  `imports/patient/AutoDashboard.jsx:131` — concept proven, never extracted.
+  (A previous extraction attempt via the fhir-starter npm package was judged
+  the wrong distribution channel.)
+
+## Core semantics
+
+### `allowAmbiance` — a capability gate, not a preference
+
+Route entries declare `allowAmbiance: true` (workflow.json → client.js route
+mapper → route object → `StyledMainRouter`), riding the exact pipeline
+`requireAuth`/`requirePatient` already use. The flag means *"this page's
+layout stays legible over an arbitrary photo"* — a developer statement of
+competence. It never turns ambiance on.
+
+|                          | Background = None | Background = image/solid |
+|--------------------------|-------------------|--------------------------|
+| **Route not flagged**    | normal page       | normal page — opaque canvas suppresses the ambiance |
+| **Route flagged**        | normal page       | ambiance visible; Page Mode + Card Surface active |
+
+This *tightens* current behavior: unflagged routes stop leaking the photo
+through canvas gaps. The user/org choice of background (Theme & Palette
+dialog / `settings.public.theme.backgroundImagePath` seed) remains the actual
+on-switch and stays global.
+
+Initial flag list: Provider Directory (`/provider-directory`), Vertical
+Timeline. Package-specific ambiance pages opt in via their own workflow.json.
+
+### Three persisted theme axes (new + extended)
+
+All global, all through `saveThemeChoice()`:
+
+| Axis | Values | Consumed by |
+|------|--------|-------------|
+| `pageMode` | `'light'` / `'dark'` / unset | Zone routes only — forces the content-ink palette over ambiance while the chrome (header/footer/dialogs) keeps the app `mode`. Promotes DirectoryConsole's inline `createTheme` override into a shared helper. |
+| `cardSurface` | `'solid'` / `'glass'` / `'flat'` | Zone routes now; anywhere later. |
+| `backgroundImagePath` (extended) | image `src` **or** solid-color entry | App root. A solid earth tone is just another background choice — mutually exclusive with an image, same axis, same persistence. |
+
+Solid-color entries are stored as a `color:` prefixed string on the existing
+axis (e.g. `color:#a67b5b`) — keeps `themePersistence` a flat string shape,
+backward compatible with stored image paths. `setThemeBackground()` accepts
+both forms; the App.jsx painter branches: image paths set `backgroundImage`,
+`color:` values set `backgroundColor` only.
+
+### Card surface — three distinct states, not a toggle
+
+- **Solid** — today's opaque `background.paper`. Default everywhere.
+- **Glass** — translucent panel + backdrop blur + hairline border. The
+  DirectoryConsole overlay recipe (`--panel` at ~0.72 paper-alpha, hairlines,
+  scrims), extracted into shared tokens.
+- **Flat** — no surface at all; content melts in from pure negative space
+  (the Ctrl+Shift+L effect, graduated).
+
+They are separate effects and both survive: transitions between states are
+animated (CSS transitions on background-color / backdrop-filter / border /
+opacity), enabling solid→glass fades and the flat melt-in.
+
+Cmd/Ctrl+Shift+L graduates from a per-page CustomEvent to cycling the
+persisted `cardSurface` (solid → glass → flat → solid).
+`LifeSupportDashboard` and `NotFoundPage` migrate from the event listener to
+reading the setting.
+
+## Architecture
+
+### AmbianceZone route wrapper — correctness by construction
+
+A new wrapper composing exactly like the existing guards:
+
+```
+AuthGuard > PatientGuard > AmbianceZone > ErrorBoundary > page
+```
+
+When the route is flagged AND a background is active, `AmbianceZone`:
+
+1. Wraps the page in a **Page-Mode-derived `ThemeProvider`** (the shared
+   helper promoted from DirectoryConsole: rebuild with the app's accent
+   palette + typography, flip only mode-dependent tokens).
+2. Carries **MuiCard/MuiPaper component overrides** implementing the active
+   `cardSurface` — so even a raw MUI `<Card>` in the zone renders legible
+   glass/flat treatment with correct ink. Enforcement that depends on
+   developer discipline breaks; a theme override at the zone boundary cannot
+   be forgotten.
+3. Maintains the shared CSS vars (`--panel`, `--panel-hard`, `--ink`,
+   `--hairline`, scrim gradients) that bespoke pages consume directly.
+
+When the route is unflagged or background is None, AmbianceZone renders
+children unchanged (zero cost, zero behavior change).
+
+### StyledMainRouter changes
+
+- Match the active route (`useLocation` + `matchPath` against `allRoutes`)
+  and include the ambiance `backgroundImage`/solid `backgroundColor` in
+  `mainAppStyle` **only when the active route is flagged**. One decision
+  point, in the file that already owns both the background and the route
+  table.
+- Compose `AmbianceZone` into the guard chain per route flag.
+
+### `Meteor.StyledCard` — the premium surface component
+
+Extracted shared component (`imports/ui/components/StyledCard.jsx`), attached
+to the Meteor object at provider setup following the `Meteor.useTheme`
+precedent. Workflow packages consume it without import-path coupling:
+
+```javascript
+const Card = Meteor.StyledCard || MuiCard;   // graceful degradation
+```
+
+StyledCard is surface-aware (`cardSurface`), animates state transitions
+(glass fades, flat melt-in from negative space), and inherits zone ink
+automatically. It is the **convention** for zone pages — the raw-MUI theme
+override above is the **net** underneath it. The private
+`AutoDashboard.jsx` StyledCard migrates to (or is superseded by) the shared
+one opportunistically.
+
+## Theme & Palette dialog restructure
+
+New section order (both dialog and `/theming`, via shared `ThemeControls`):
+
+1. **PRESET** — unchanged (Limestone / Tron / Vaporwave tiles).
+2. **AMBIANCE BACKGROUND** — moved directly under Preset.
+   - Row 1: None + image thumbnails (existing library).
+   - Row 2: 8 solid earth-tone swatches, same selection semantics as
+     images. Provisional values (tunable at review, not at implementation
+     time): clay `#a67b5b`, sand `#d9c7a7`, terracotta `#b0674b`, moss
+     `#6b7d5a`, sage `#a3b18a`, stone `#8d8578`, ochre `#c49a3c`, espresso
+     `#4a3728`.
+3. **BASIC THEME CONTROLS** (new group label) — Font · Mode · **Page Mode** ·
+   Accent hue · **Card Surface**.
+   - **Page Mode** renders next to Mode *only when background ≠ None*.
+     Light/Dark toggle, persisted as `pageMode`.
+   - **Card Surface** — three-button segmented control (Solid / Glass /
+     Flat) with a live mini-preview.
+4. **Advanced — per-field palette** — unchanged.
+
+## DirectoryConsole polish (zone reference implementation)
+
+- **Padding**: 200px side padding at the `xl` breakpoint (MUI standard
+  1536px), stepping down to existing responsive values (`md: 5`, `xs: 2.5`)
+  below. Applies in all `?align` placements.
+- **Legibility scrim system**: soft column-wide canvas-fade behind the
+  content column; stronger `--panel` backing behind census stats, result
+  rows, ACTIVE chips, and small telemetry text ("UPLINK NOMINAL",
+  "495 CONTACTS", "RETURN IN…") so all of it survives bright photos.
+- **Params**: `?align` and `?page-theme` survive as dev/demo overrides; the
+  persisted `pageMode` is the real control (URL param wins when present).
+- Its overlay recipe is the source of the shared glass tokens (extraction is
+  Phase 3; the polish itself must not wait on it).
+
+## Phases / build order
+
+1. **Theme & Palette dialog restructure + persistence axes** — dialog
+   reorder, earth-tone row, Page Mode + Card Surface controls, `pageMode` /
+   `cardSurface` / solid-background persistence. No page consumes the new
+   axes yet beyond what already exists.
+2. **DirectoryConsole polish** — `xl` padding, scrim/legibility pass,
+   `pageMode` consumption (replacing its inline override with the shared
+   helper when Phase 3 lands, inline until then).
+3. **Zone plumbing** — `allowAmbiance` flag through the route pipeline,
+   StyledMainRouter conditional painting, `AmbianceZone` wrapper with theme
+   override net, shared glass/flat tokens extracted from DirectoryConsole,
+   `Meteor.StyledCard`, Ctrl+Shift+L graduation, flag the two initial routes.
+4. **Theme packs (future — seams only)** — a pack is a named macro over the
+   axes above: `{ preset palette, font, ambiance background, cardSurface
+   default, pageMode default }`, delivered via `settings.public.theme.packs`
+   (the settings-driven `backgroundLibrary` proves the pattern), selectable
+   per patient later. Medical illustration and patient-education content
+   integration follow the same seam. Nothing in Phases 1–3 blocks this.
+
+## Scope guardrails
+
+- Phase 3 tokens activate **only on flagged routes**; the flag list starts
+  at two pages. No app-wide restyling.
+- Unflagged routes must render pixel-identical to today (except no longer
+  leaking the ambiance photo through canvas gaps).
+- No mass migration of existing cards to StyledCard; opportunistic only.
+- Printing always uses the light theme (existing rule); ambiance
+  images/solids and glass/flat surfaces must not survive into print — the
+  existing `@media print` global block plus the zone override deferring to
+  `createDynamicTheme('light')` cover this; verify during Phase 3.
+
+## Error handling & testing
+
+- **Graceful degradation**: `Meteor.StyledCard || MuiCard` idiom; zone
+  wrapper no-ops when background is None; missing/invalid background values
+  fall back to no ambiance (never a broken image over content).
+- **Persistence robustness**: unknown `cardSurface`/`pageMode` values in
+  localStorage are treated as unset (forward/backward compat).
+- **E2E**: existing Nightwatch suites must pass untouched on unflagged
+  routes (the pixel-identity guarantee). New coverage: dialog controls
+  persist across reload; DirectoryConsole renders legibly with a bright
+  ambiance + `pageMode` both ways; Ctrl+Shift+L cycles surfaces.
+- **Theme audit**: run `/audit-theme` and `/audit-print` after Phases 2–3.
+
+## Out of scope
+
+- Theme pack authoring/selection UI (Phase 4 seam only)
+- Medical illustration assets and patient-education content
+- Migrating existing pages beyond the two initial zone routes
+- AR/spatial interfaces beyond the glass visual language

--- a/docs/superpowers/specs/2026-08-03-ambiance-experience-zone-design.md
+++ b/docs/superpowers/specs/2026-08-03-ambiance-experience-zone-design.md
@@ -91,8 +91,10 @@ dialog / `settings.public.theme.backgroundImagePath` seed) remains the actual
 on-switch and stays global.
 
 Initial flag list: Provider Directory (`/provider-directory`), Vertical
-Timeline — both `enableAmbiance`. Package-specific pages opt in via their
-own workflow.json.
+Timeline, and Patient Chart (`/patient-chart` — right components already,
+needs the zone to land right-aligned like the directory) — all
+`enableAmbiance`. Package-specific pages opt in via their own
+workflow.json.
 
 ### Focus — curated imagery declares its neutral space
 
@@ -121,9 +123,20 @@ therefore **a property of the curated image, not a user preference**:
   no focus (treated as `center`). Future focus values reserved for
   multi-panel layouts (`'split-2'`, `'split-3'`) — the library shape allows
   them; v1 pages treat unknown values as `center`.
-- `AmbianceZone` exposes the active focus to the page (React context hook +
-  a `--ambiance-focus` CSS var) so both bespoke pages and shared components
-  can align their content column into the neutral space.
+- `AmbianceZone` assembles the **composition object** — the zone's single
+  layout contract, resolved from the active curation record + persisted
+  axes with defaults filling every gap (a background choice never arrives
+  "blank"):
+
+  ```js
+  { background, focus, scrimStrength, pageMode, cardSurface }
+  ```
+
+  Exposed to pages via a `useAmbiance()` context hook + CSS vars
+  (`--ambiance-focus`, `--ambiance-scrim`). This is the "param object"
+  every `enableAmbiance` route receives; `Meteor.StyledContainer` is its
+  default consumer, so pages currently using vanilla `<Container>` swap one
+  import and inherit placement/easement/scrim without bespoke code.
 - DirectoryConsole maps focus to its column alignment (the `?align`
   prototype, generalized). The `?align` URL param survives as a dev/demo
   override that wins over library metadata.

--- a/docs/superpowers/specs/2026-08-03-ambiance-experience-zone-design.md
+++ b/docs/superpowers/specs/2026-08-03-ambiance-experience-zone-design.md
@@ -102,11 +102,25 @@ left of the figure; the zen stones' is right of the stones). Focus is
 therefore **a property of the curated image, not a user preference**:
 
 - Background library entries (`themeBackgrounds.js` /
-  `settings.public.theme.backgroundLibrary`) gain a `focus` field:
-  `'left' | 'center' | 'right'` (v1). Solid colors and None have no focus
-  (treated as `center`). Future values reserved for multi-panel layouts
-  (`'split-2'`, `'split-3'`) — the library shape allows them; v1 pages may
-  treat unknown values as `center`.
+  `settings.public.theme.backgroundLibrary`) grow from `{ name, src }` into
+  **curation records**:
+
+  ```js
+  {
+    name: 'Yoga Ocean',
+    src: '/backgrounds/ambiance/Yoga-Ocean.jpg',
+    focus: 'left',                    // neutral-space placement (v1: left|center|right)
+    recommendedPageMode: 'light',     // ink that survives this image
+    scrimStrength: 0.55,              // 0–1, content-column scrim opacity
+    palette: ['#e8a54b', '#c2703e', '#7a5a8c']  // extracted dominant hues (accent candidates)
+  }
+  ```
+
+  All fields beyond `name`/`src` are optional — uncurated entries behave as
+  today (focus `center`, defaults for the rest). Solid colors and None have
+  no focus (treated as `center`). Future focus values reserved for
+  multi-panel layouts (`'split-2'`, `'split-3'`) — the library shape allows
+  them; v1 pages treat unknown values as `center`.
 - `AmbianceZone` exposes the active focus to the page (React context hook +
   a `--ambiance-focus` CSS var) so both bespoke pages and shared components
   can align their content column into the neutral space.
@@ -205,6 +219,63 @@ override above is the **net** underneath it. The private
 `AutoDashboard.jsx` StyledCard migrates to (or is superseded by) the shared
 one opportunistically.
 
+### `Meteor.StyledContainer` — focus-aware layout primitive
+
+Sibling of StyledCard, same Meteor-object distribution. A Container/Box that
+reads `--ambiance-focus` (context hook under the hood) and places its
+content column into the image's neutral space — `left | center | right`,
+with the `xl`-breakpoint 200px side easement built in and `split-2` /
+`split-3` reserved. Pages stop hand-rolling `ml: 'auto'` math;
+DirectoryConsole's `?align` logic becomes this component's shared
+implementation. "Align with the photo" becomes a prop (auto from the
+library's focus metadata; overridable per instance).
+
+## Curation toolkit
+
+The gaps observed while hand-tuning page × background × mode combinations
+(inverted ink over bright photos, no palette tweaking, no focus alignment)
+are all steps of one **curation loop**. These tools make polishing a layout
+repeatable instead of lucky.
+
+### Palette extraction + neutral-space analysis (Phase 1 foundation)
+
+A small client-side analysis module (`imports/ui/theme/ambianceAnalysis.js`):
+downsample an image to a canvas, compute dominant colors and a luminance
+histogram **per horizontal third**. Outputs a draft curation record:
+
+- lowest-variance third → suggested `focus` (neutral-space detection)
+- overall/per-third luminance → suggested `recommendedPageMode`
+- dominant hues → `palette` accent candidates
+- luminance behind the content column → suggested `scrimStrength`
+
+Deterministic, dependency-free, runs once per image (results cached in the
+library entry — curated values always win over computed ones).
+
+### Ambiance Tuning HUD (Cmd/Ctrl+Shift+E)
+
+A dev overlay in the Session Inspector tradition, available on zone routes:
+live sliders for **scrim opacity · panel alpha · blur radius · ink mode ·
+focus · accent hue**, writing the zone CSS vars in real time so tuning
+happens against the actual photo on the actual page. A **Copy as JSON**
+button emits the curation record for the background library / settings
+file. This replaces the edit-reload-screenshot loop with direct
+manipulation; every future theme pack is authored with it. Dev-tool
+posture: no PHI, no persistence of its own (clipboard out only), hidden
+from end users behind the hotkey.
+
+### Phase 3.5 — runtime net + review harness (deferred, designed-for)
+
+- **Adaptive scrim**: run the analysis module at background load for
+  operator-supplied images that arrive uncurated; auto-scale scrim/ink for
+  the content column specifically. Curated values always win. This
+  structurally prevents the ghost-text failure class (dark-mode ink over a
+  light illustration) instead of fixing it per page.
+- **Screenshot matrix**: a Playwright script capturing routes × backgrounds
+  × mode/pageMode into a contact sheet — one command instead of hand-made
+  screenshot sweeps.
+- **Contrast auditor**: samples rendered text vs. effective backdrop on
+  zone pages, flags WCAG failures — `/audit-theme`'s runtime sibling.
+
 ## Theme & Palette dialog restructure
 
 New section order (both dialog and `/theming`, via shared `ThemeControls`):
@@ -243,24 +314,32 @@ New section order (both dialog and `/theming`, via shared `ThemeControls`):
 
 1. **Theme & Palette dialog restructure + persistence axes** — dialog
    reorder, earth-tone row, Page Mode + Card Surface controls, `pageMode` /
-   `cardSurface` / solid-background persistence. No page consumes the new
-   axes yet beyond what already exists.
+   `cardSurface` / solid-background persistence. Includes the
+   **curation-record library shape** and the **palette extraction /
+   neutral-space analysis module** (used at curation time; its suggestions
+   seed the default library's records). No page consumes the new axes yet
+   beyond what already exists.
 2. **DirectoryConsole polish** — `xl` padding, scrim/legibility pass,
    `pageMode` consumption (replacing its inline override with the shared
    helper when Phase 3 lands, inline until then).
 3. **Zone plumbing** — `enableAmbiance` + `enableFluidInterface` flags
    through the route pipeline, StyledMainRouter conditional painting,
-   `AmbianceZone` wrapper with theme-override net, `focus` metadata on the
-   background library + context/CSS-var exposure, shared glass/flat tokens
-   extracted from DirectoryConsole, `Meteor.StyledCard`, Ctrl+Shift+L
-   graduation, flag the two initial routes. **Acceptance: Glass and Flat
-   toggles visibly work on cards on the `enableAmbiance` routes.**
+   `AmbianceZone` wrapper with theme-override net, `focus` metadata
+   context/CSS-var exposure, shared glass/flat tokens extracted from
+   DirectoryConsole, `Meteor.StyledCard` + `Meteor.StyledContainer`, the
+   **Ambiance Tuning HUD** (Cmd/Ctrl+Shift+E), Ctrl+Shift+L graduation,
+   flag the two initial routes. **Acceptance: Glass and Flat toggles
+   visibly work on cards on the `enableAmbiance` routes.**
+3.5. **Runtime net + review harness (deferred, designed-for)** — adaptive
+   scrim for uncurated images, Playwright screenshot matrix, contrast
+   auditor (see Curation toolkit).
 4. **Theme packs (future — seams only)** — a pack is a named macro over the
    axes above: `{ preset palette, font, ambiance background, cardSurface
    default, pageMode default }`, delivered via `settings.public.theme.packs`
    (the settings-driven `backgroundLibrary` proves the pattern), selectable
    per patient later. Medical illustration and patient-education content
-   integration follow the same seam. Nothing in Phases 1–3 blocks this.
+   integration follow the same seam. Packs are authored with the Tuning
+   HUD + analysis module. Nothing in Phases 1–3 blocks this.
 
 ## Scope guardrails
 

--- a/docs/superpowers/specs/2026-08-03-ambiance-experience-zone-design.md
+++ b/docs/superpowers/specs/2026-08-03-ambiance-experience-zone-design.md
@@ -53,18 +53,37 @@ Timeline** — form the *patient-experience zone* where ambiance renders.
 
 ## Core semantics
 
-### `allowAmbiance` — a capability gate, not a preference
+### Design thesis: constraint puts the best face forward
 
-Route entries declare `allowAmbiance: true` (workflow.json → client.js route
-mapper → route object → `StyledMainRouter`), riding the exact pipeline
-`requireAuth`/`requirePatient` already use. The flag means *"this page's
-layout stays legible over an arbitrary photo"* — a developer statement of
-competence. It never turns ambiance on.
+The ambiance system builds on a decade of background attempts by
+*constraining* the existing background functionality: it renders only on
+pages that have been vetted for it. When ambiance looks good it looks
+great; unvetted it goes wonky and out of alignment fast. Less is more — the
+flags below are the constraint mechanism.
+
+### Two capability flags — `enableAmbiance` and `enableFluidInterface`
+
+Route entries declare capabilities (workflow.json → client.js route mapper →
+route object → `StyledMainRouter`), riding the exact pipeline
+`requireAuth`/`requirePatient` already use. Neither flag turns anything on —
+they are developer statements of page competence.
+
+- **`enableFluidInterface: true`** — the Card Surface axis is active on this
+  route: Glass/Flat toggles work, the AmbianceZone theme-override net
+  applies, shared surface tokens are maintained. The router does **not**
+  paint any ambiance background — the page supplies its own backdrop (video,
+  animation, canvas render, game engine, or nothing).
+- **`enableAmbiance: true`** — everything `enableFluidInterface` grants,
+  **plus** the router paints the globally-selected ambiance background
+  (image or solid), Page Mode applies, and the background's focus metadata
+  is exposed. `enableAmbiance` implies `enableFluidInterface`; declaring
+  both is redundant but harmless.
 
 |                          | Background = None | Background = image/solid |
 |--------------------------|-------------------|--------------------------|
-| **Route not flagged**    | normal page       | normal page — opaque canvas suppresses the ambiance |
-| **Route flagged**        | normal page       | ambiance visible; Page Mode + Card Surface active |
+| **No flags**             | normal page       | normal page — opaque canvas suppresses the ambiance |
+| **`enableFluidInterface`** | Card Surface active; page paints its own backdrop | same — global ambiance still suppressed |
+| **`enableAmbiance`**     | normal page       | ambiance visible; Page Mode + Card Surface + focus active |
 
 This *tightens* current behavior: unflagged routes stop leaking the photo
 through canvas gaps. The user/org choice of background (Theme & Palette
@@ -72,7 +91,28 @@ dialog / `settings.public.theme.backgroundImagePath` seed) remains the actual
 on-switch and stays global.
 
 Initial flag list: Provider Directory (`/provider-directory`), Vertical
-Timeline. Package-specific ambiance pages opt in via their own workflow.json.
+Timeline — both `enableAmbiance`. Package-specific pages opt in via their
+own workflow.json.
+
+### Focus — curated imagery declares its neutral space
+
+Every ambiance image has a subject and a neutral zone; content must render
+in the neutral zone or legibility dies (the yoga shot's neutral space is
+left of the figure; the zen stones' is right of the stones). Focus is
+therefore **a property of the curated image, not a user preference**:
+
+- Background library entries (`themeBackgrounds.js` /
+  `settings.public.theme.backgroundLibrary`) gain a `focus` field:
+  `'left' | 'center' | 'right'` (v1). Solid colors and None have no focus
+  (treated as `center`). Future values reserved for multi-panel layouts
+  (`'split-2'`, `'split-3'`) — the library shape allows them; v1 pages may
+  treat unknown values as `center`.
+- `AmbianceZone` exposes the active focus to the page (React context hook +
+  a `--ambiance-focus` CSS var) so both bespoke pages and shared components
+  can align their content column into the neutral space.
+- DirectoryConsole maps focus to its column alignment (the `?align`
+  prototype, generalized). The `?align` URL param survives as a dev/demo
+  override that wins over library metadata.
 
 ### Three persisted theme axes (new + extended)
 
@@ -118,11 +158,14 @@ A new wrapper composing exactly like the existing guards:
 AuthGuard > PatientGuard > AmbianceZone > ErrorBoundary > page
 ```
 
-When the route is flagged AND a background is active, `AmbianceZone`:
+On an `enableFluidInterface` route (directly declared, or implied by
+`enableAmbiance`), `AmbianceZone`:
 
 1. Wraps the page in a **Page-Mode-derived `ThemeProvider`** (the shared
    helper promoted from DirectoryConsole: rebuild with the app's accent
-   palette + typography, flip only mode-dependent tokens).
+   palette + typography, flip only mode-dependent tokens). Page Mode applies
+   only on `enableAmbiance` routes with an active background; on plain
+   `enableFluidInterface` routes the app mode stands.
 2. Carries **MuiCard/MuiPaper component overrides** implementing the active
    `cardSurface` — so even a raw MUI `<Card>` in the zone renders legible
    glass/flat treatment with correct ink. Enforcement that depends on
@@ -130,18 +173,20 @@ When the route is flagged AND a background is active, `AmbianceZone`:
    be forgotten.
 3. Maintains the shared CSS vars (`--panel`, `--panel-hard`, `--ink`,
    `--hairline`, scrim gradients) that bespoke pages consume directly.
+4. On `enableAmbiance` routes with an active image background, exposes the
+   background's `focus` via context hook + `--ambiance-focus` CSS var.
 
-When the route is unflagged or background is None, AmbianceZone renders
-children unchanged (zero cost, zero behavior change).
+When the route declares neither flag, AmbianceZone renders children
+unchanged (zero cost, zero behavior change).
 
 ### StyledMainRouter changes
 
 - Match the active route (`useLocation` + `matchPath` against `allRoutes`)
   and include the ambiance `backgroundImage`/solid `backgroundColor` in
-  `mainAppStyle` **only when the active route is flagged**. One decision
-  point, in the file that already owns both the background and the route
-  table.
-- Compose `AmbianceZone` into the guard chain per route flag.
+  `mainAppStyle` **only when the active route declares `enableAmbiance`**.
+  One decision point, in the file that already owns both the background and
+  the route table.
+- Compose `AmbianceZone` into the guard chain when either flag is present.
 
 ### `Meteor.StyledCard` — the premium surface component
 
@@ -203,10 +248,13 @@ New section order (both dialog and `/theming`, via shared `ThemeControls`):
 2. **DirectoryConsole polish** — `xl` padding, scrim/legibility pass,
    `pageMode` consumption (replacing its inline override with the shared
    helper when Phase 3 lands, inline until then).
-3. **Zone plumbing** — `allowAmbiance` flag through the route pipeline,
-   StyledMainRouter conditional painting, `AmbianceZone` wrapper with theme
-   override net, shared glass/flat tokens extracted from DirectoryConsole,
-   `Meteor.StyledCard`, Ctrl+Shift+L graduation, flag the two initial routes.
+3. **Zone plumbing** — `enableAmbiance` + `enableFluidInterface` flags
+   through the route pipeline, StyledMainRouter conditional painting,
+   `AmbianceZone` wrapper with theme-override net, `focus` metadata on the
+   background library + context/CSS-var exposure, shared glass/flat tokens
+   extracted from DirectoryConsole, `Meteor.StyledCard`, Ctrl+Shift+L
+   graduation, flag the two initial routes. **Acceptance: Glass and Flat
+   toggles visibly work on cards on the `enableAmbiance` routes.**
 4. **Theme packs (future — seams only)** — a pack is a named macro over the
    axes above: `{ preset palette, font, ambiance background, cardSurface
    default, pageMode default }`, delivered via `settings.public.theme.packs`

--- a/imports/accounts/client/components/LoginForm.jsx
+++ b/imports/accounts/client/components/LoginForm.jsx
@@ -19,12 +19,7 @@ import {
 import { logger } from '../../lib/AccountsLogger';
 import { useDevAutoLogin } from '../hooks/useDevAutoLogin';
 
-export function LoginForm({ onSuccess, onSignupClick, onForgotPasswordClick, isDark = false }) {
-  // Theme-aware colors
-  const cardBgColor = isDark ? '#2a2a2a' : '#ffffff';
-  const cardTextColor = isDark ? 'rgba(255, 255, 255, 0.87)' : 'rgba(0, 0, 0, 0.87)';
-  const inputBorderColor = isDark ? 'rgba(255, 255, 255, 0.23)' : 'rgba(0, 0, 0, 0.23)';
-
+export function LoginForm({ onSuccess, onSignupClick, onForgotPasswordClick }) {
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
@@ -330,23 +325,27 @@ export function LoginForm({ onSuccess, onSignupClick, onForgotPasswordClick, isD
   return (
     <Paper
       elevation={0}
-      sx={{
-        p: 5,
-        maxWidth: 440,
-        mx: 'auto',
-        backgroundColor: cardBgColor,
-        border: '1px solid',
-        borderColor: inputBorderColor,
-        borderRadius: 2,
-        '& .MuiTypography-root': { color: cardTextColor },
-        '& .MuiInputBase-root': { color: cardTextColor },
-        '& .MuiInputLabel-root': { color: cardTextColor },
-        '& .MuiOutlinedInput-notchedOutline': {
-          borderColor: inputBorderColor
-        },
-        '& .MuiFormHelperText-root': {
-          color: isDark ? 'rgba(255, 255, 255, 0.6)' : 'rgba(0, 0, 0, 0.6)'
-        }
+      sx={function(theme) {
+        return {
+          p: 5,
+          maxWidth: 440,
+          mx: 'auto',
+          bgcolor: 'background.paper',
+          border: '1px solid',
+          borderColor: 'divider',
+          borderRadius: 2,
+          // Chrome autofill paints its own opaque blue over inputs; re-skin it
+          // from the LIVE theme so the filled tint tracks light/dark and the
+          // ThemeDialog presets. background.default keeps the fill subtly
+          // distinct from the paper card (the box-shadow inset trick needs an
+          // opaque color, so tokens are read from the theme object here).
+          '& input:-webkit-autofill, & input:-webkit-autofill:hover, & input:-webkit-autofill:focus': {
+            WebkitBoxShadow: '0 0 0 1000px ' + theme.palette.background.default + ' inset',
+            WebkitTextFillColor: theme.palette.text.primary,
+            caretColor: theme.palette.text.primary,
+            borderRadius: 'inherit'
+          }
+        };
       }}
     >
       <Box sx={{ mb: 4 }}>
@@ -378,10 +377,10 @@ export function LoginForm({ onSuccess, onSignupClick, onForgotPasswordClick, isD
               fontSize: '0.875rem',
               letterSpacing: '0.5px',
               textTransform: 'none',
-              color: cardTextColor,
+              color: 'text.primary',
               '&.Mui-selected': {
                 backgroundColor: 'action.selected',
-                color: cardTextColor,
+                color: 'text.primary',
                 '&:hover': {
                   backgroundColor: 'action.hover',
                 }

--- a/imports/accounts/client/components/LoginForm.jsx
+++ b/imports/accounts/client/components/LoginForm.jsx
@@ -335,24 +335,20 @@ export function LoginForm({ onSuccess, onSignupClick, onForgotPasswordClick }) {
           border: '1px solid',
           borderColor: 'divider',
           borderRadius: 2,
-          // Chrome autofill paints its own opaque blue over inputs; re-skin it
-          // from the LIVE theme so the filled tint tracks light/dark and the
-          // ThemeDialog presets. background.default keeps the fill subtly
-          // distinct from the paper card (the box-shadow inset trick needs an
-          // opaque color, so tokens are read from the theme object here).
-          '& input:-webkit-autofill, & input:-webkit-autofill:hover, & input:-webkit-autofill:focus': {
-            WebkitBoxShadow: '0 0 0 1000px ' + theme.palette.background.default + ' inset',
-            WebkitTextFillColor: theme.palette.text.primary,
-            caretColor: theme.palette.text.primary,
-            borderRadius: 'inherit'
-          },
-          // Assertiveness that TRACKS the accent: resting input outlines carry a
-          // faint wash of primary.main, brightening on hover/focus. In Limestone
+          // Assertiveness that TRACKS the accent: input FILL + outline carry a
+          // wash of primary.main, brightening on hover/focus. In Limestone
           // primary is desaturated stone (reads calm/neutral); in Tron it's the
           // dialed hue (reads cyan/assertive) — same code, the palette does the
-          // work. :not(.Mui-error) so validation red still wins.
+          // work. Fill is stronger than the disabled button's wash (0.14).
+          // :not(.Mui-error) so validation red still wins.
+          '& .MuiOutlinedInput-root:not(.Mui-error)': {
+            backgroundColor: alpha(theme.palette.primary.main, 0.18)
+          },
+          '& .MuiOutlinedInput-root:hover:not(.Mui-error), & .MuiOutlinedInput-root.Mui-focused:not(.Mui-error)': {
+            backgroundColor: alpha(theme.palette.primary.main, 0.26)
+          },
           '& .MuiOutlinedInput-root:not(.Mui-error) .MuiOutlinedInput-notchedOutline': {
-            borderColor: alpha(theme.palette.primary.main, 0.30)
+            borderColor: alpha(theme.palette.primary.main, 0.35)
           },
           '& .MuiOutlinedInput-root:hover:not(.Mui-error) .MuiOutlinedInput-notchedOutline': {
             borderColor: alpha(theme.palette.primary.main, 0.6)
@@ -360,6 +356,16 @@ export function LoginForm({ onSuccess, onSignupClick, onForgotPasswordClick }) {
           '& .MuiOutlinedInput-root.Mui-focused:not(.Mui-error) .MuiOutlinedInput-notchedOutline': {
             borderColor: theme.palette.primary.main,
             borderWidth: 2
+          },
+          // Chrome autofill paints its own opaque fill; re-skin it to an OPAQUE
+          // blend that matches the resting accent tint (box-shadow inset needs
+          // an opaque color, so mix the accent into the paper via color-mix —
+          // Chrome/Electron only, safe here).
+          '& input:-webkit-autofill, & input:-webkit-autofill:hover, & input:-webkit-autofill:focus': {
+            WebkitBoxShadow: '0 0 0 1000px color-mix(in srgb, ' + theme.palette.primary.main + ' 18%, ' + theme.palette.background.paper + ') inset',
+            WebkitTextFillColor: theme.palette.text.primary,
+            caretColor: theme.palette.text.primary,
+            borderRadius: 'inherit'
           },
           // The disabled SIGN IN button (empty form) gets a faint accent wash
           // instead of dead grey, so the form reads as "armed" in Tron.

--- a/imports/accounts/client/components/LoginForm.jsx
+++ b/imports/accounts/client/components/LoginForm.jsx
@@ -16,6 +16,7 @@ import {
   ToggleButtonGroup,
   ToggleButton
 } from '@mui/material';
+import { alpha } from '@mui/material/styles';
 import { logger } from '../../lib/AccountsLogger';
 import { useDevAutoLogin } from '../hooks/useDevAutoLogin';
 
@@ -344,6 +345,27 @@ export function LoginForm({ onSuccess, onSignupClick, onForgotPasswordClick }) {
             WebkitTextFillColor: theme.palette.text.primary,
             caretColor: theme.palette.text.primary,
             borderRadius: 'inherit'
+          },
+          // Assertiveness that TRACKS the accent: resting input outlines carry a
+          // faint wash of primary.main, brightening on hover/focus. In Limestone
+          // primary is desaturated stone (reads calm/neutral); in Tron it's the
+          // dialed hue (reads cyan/assertive) — same code, the palette does the
+          // work. :not(.Mui-error) so validation red still wins.
+          '& .MuiOutlinedInput-root:not(.Mui-error) .MuiOutlinedInput-notchedOutline': {
+            borderColor: alpha(theme.palette.primary.main, 0.30)
+          },
+          '& .MuiOutlinedInput-root:hover:not(.Mui-error) .MuiOutlinedInput-notchedOutline': {
+            borderColor: alpha(theme.palette.primary.main, 0.6)
+          },
+          '& .MuiOutlinedInput-root.Mui-focused:not(.Mui-error) .MuiOutlinedInput-notchedOutline': {
+            borderColor: theme.palette.primary.main,
+            borderWidth: 2
+          },
+          // The disabled SIGN IN button (empty form) gets a faint accent wash
+          // instead of dead grey, so the form reads as "armed" in Tron.
+          '& .MuiButton-contained.Mui-disabled': {
+            backgroundColor: alpha(theme.palette.primary.main, 0.14),
+            color: alpha(theme.palette.primary.main, 0.5)
           }
         };
       }}

--- a/imports/accounts/client/pages/LoginPage.jsx
+++ b/imports/accounts/client/pages/LoginPage.jsx
@@ -1,7 +1,6 @@
 // imports/accounts/client/pages/LoginPage.jsx
 
 import React from 'react';
-import { Meteor } from 'meteor/meteor';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { Container, Box } from '@mui/material';
 import { LoginForm } from '../components/LoginForm';
@@ -17,11 +16,6 @@ export function LoginPage() {
   // already decoded once — sanitize the decoded value (internal paths only;
   // invalid/absent falls back to the home route).
   const returnTo = sanitizeReturnPath(searchParams.get('returnTo'));
-
-  // Get Honeycomb theme for dark mode support
-  const useAppTheme = Meteor.useTheme;
-  const appTheme = useAppTheme ? useAppTheme() : { theme: 'light' };
-  const isDark = appTheme.theme === 'dark';
 
   const handleSuccess = function() {
     // Redirect to the originally requested page after successful login,
@@ -41,17 +35,17 @@ export function LoginPage() {
   };
 
   return (
-    <Box sx={{ minHeight: '100vh' }}>
-      <Container maxWidth="sm">
-        <Box sx={{ pt: 8, pb: 4 }}>
-          <LoginForm
-            onSuccess={handleSuccess}
-            onSignupClick={handleSignupClick}
-            onForgotPasswordClick={handleForgotPasswordClick}
-            isDark={isDark}
-          />
-        </Box>
-      </Container>
-    </Box>
+    // No page-level bgcolor and no 100vh here: StyledMainRouter paints
+    // background.default and the router area is already viewport-minus-chrome
+    // (rules/ui/layout-patterns.md) — a 100vh child just forces page scroll.
+    <Container maxWidth="sm">
+      <Box sx={{ pt: 8, pb: 4 }}>
+        <LoginForm
+          onSuccess={handleSuccess}
+          onSignupClick={handleSignupClick}
+          onForgotPasswordClick={handleForgotPasswordClick}
+        />
+      </Box>
+    </Container>
   );
 }

--- a/imports/accounts/client/pages/LoginPage.jsx
+++ b/imports/accounts/client/pages/LoginPage.jsx
@@ -2,10 +2,22 @@
 
 import React from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
-import { Container, Box } from '@mui/material';
+import { Box } from '@mui/material';
 import { LoginForm } from '../components/LoginForm';
 import WorkflowNavigation from '/imports/lib/WorkflowNavigation.js';
 const { sanitizeReturnPath, appendReturnTo } = WorkflowNavigation;
+
+// Card placement as a 3×3 grid over the router area. ?align=left|center|right
+// and ?valign=top|center|bottom drop the card into one of nine cells; because
+// each cell is a 1fr third and the card is centered WITHIN its cell, placement
+// is "center-of-the-third" oriented — never jammed against a viewport edge.
+const ALIGN_COLUMN = { left: 1, center: 2, right: 3 };
+const VALIGN_ROW = { top: 1, center: 2, bottom: 3 };
+
+function resolveCell(value, map) {
+  const key = String(value || '').toLowerCase();
+  return map[key] || map.center;
+}
 
 export function LoginPage() {
   const navigate = useNavigate();
@@ -16,6 +28,10 @@ export function LoginPage() {
   // already decoded once — sanitize the decoded value (internal paths only;
   // invalid/absent falls back to the home route).
   const returnTo = sanitizeReturnPath(searchParams.get('returnTo'));
+
+  // Placement (defaults to dead-center when absent/invalid).
+  const gridColumn = resolveCell(searchParams.get('align'), ALIGN_COLUMN);
+  const gridRow = resolveCell(searchParams.get('valign'), VALIGN_ROW);
 
   const handleSuccess = function() {
     // Redirect to the originally requested page after successful login,
@@ -35,17 +51,31 @@ export function LoginPage() {
   };
 
   return (
-    // No page-level bgcolor and no 100vh here: StyledMainRouter paints
-    // background.default and the router area is already viewport-minus-chrome
-    // (rules/ui/layout-patterns.md) — a 100vh child just forces page scroll.
-    <Container maxWidth="sm">
-      <Box sx={{ pt: 8, pb: 4 }}>
+    // No page-level bgcolor here: StyledMainRouter paints background.default and
+    // (with the ambiance axis) any background image. height:100% claims the
+    // router's bounded height (rules/ui/layout-patterns.md) so the 3×3 grid can
+    // vertically place the card; the card is centered within its 1fr cell, so
+    // e.g. align=left sits it in the middle of the left third, not at the edge.
+    <Box
+      sx={{
+        height: '100%',
+        display: 'grid',
+        gridTemplateColumns: 'repeat(3, 1fr)',
+        gridTemplateRows: 'repeat(3, 1fr)',
+        overflow: 'auto',
+        p: 2
+      }}
+    >
+      {/* Fixed card width (not 1fr of the cell) so justifySelf centers it on
+          the third's center and lets it overflow into neighbors on narrow
+          screens — center-oriented, never shrunk-to-third or edge-anchored. */}
+      <Box sx={{ gridColumn: gridColumn, gridRow: gridRow, justifySelf: 'center', alignSelf: 'center', width: 'min(440px, calc(100vw - 32px))' }}>
         <LoginForm
           onSuccess={handleSuccess}
           onSignupClick={handleSignupClick}
           onForgotPasswordClick={handleForgotPasswordClick}
         />
       </Box>
-    </Container>
+    </Box>
   );
 }

--- a/imports/accounts/client/pages/LoginPage.jsx
+++ b/imports/accounts/client/pages/LoginPage.jsx
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
-import { Box } from '@mui/material';
+import { Box, useMediaQuery } from '@mui/material';
 import { LoginForm } from '../components/LoginForm';
 import WorkflowNavigation from '/imports/lib/WorkflowNavigation.js';
 const { sanitizeReturnPath, appendReturnTo } = WorkflowNavigation;
@@ -61,32 +61,56 @@ export function LoginPage() {
     navigate('/forgot-password');
   };
 
+  const formEl = (
+    <LoginForm
+      onSuccess={handleSuccess}
+      onSignupClick={handleSignupClick}
+      onForgotPasswordClick={handleForgotPasswordClick}
+    />
+  );
+
+  // The absolute align/valign placement is a big-desktop affordance. On a short
+  // OR narrow viewport a bottom/right-anchored tall card runs off-screen (the
+  // error state especially) — so we gate on BOTH width and height (valign=bottom
+  // is fundamentally a height problem) and, below the threshold, fall back to a
+  // plain centered card. align/valign are intentionally ignored when compact.
+  const roomy = useMediaQuery('(min-width:1200px) and (min-height:900px)');
+
+  // Compact / mobile: centered and scroll-safe. The minHeight:100% flex wrapper
+  // (rather than height:100% + justifyContent) avoids the classic flex-centering
+  // clip — when the card is taller than the viewport the wrapper grows and the
+  // outer box scrolls, keeping the top of the card reachable.
+  if (!roomy) {
+    return (
+      <Box sx={{ height: '100%', overflow: 'auto' }}>
+        <Box sx={{
+          minHeight: '100%', display: 'flex', flexDirection: 'column',
+          alignItems: 'center', justifyContent: 'center', p: 2
+        }}>
+          <Box sx={{ width: 'min(440px, calc(100vw - 32px))' }}>
+            {formEl}
+          </Box>
+        </Box>
+      </Box>
+    );
+  }
+
+  // Roomy desktop: absolute placement on the (leftPct, topPct) anchor — top-
+  // anchored vertically (grows downward, no reflow), center-anchored
+  // horizontally (translateX -50%). No page-level bgcolor: StyledMainRouter
+  // paints background.default + the ambiance image (rules/ui/layout-patterns.md).
   return (
-    // No page-level bgcolor here: StyledMainRouter paints background.default and
-    // (with the ambiance axis) any background image. height:100% claims the
-    // router's bounded height (rules/ui/layout-patterns.md); the card is
-    // absolutely placed and centered on the (leftPct, topPct) anchor so its
-    // position is independent of its own height — no grid-row reflow, and
-    // symmetric growth when the form gets taller.
     <Box sx={{ position: 'relative', height: '100%', overflow: 'auto', p: 2 }}>
-      {/* Top-anchored vertically (top edge at topPct → grows downward),
-          center-anchored horizontally (translateX -50%). On narrow screens force
-          horizontal center so the card never runs off-edge; desktop uses the
-          requested third. Width caps at 440px (or the viewport minus padding). */}
       <Box
         sx={{
           position: 'absolute',
           top: topPct,
-          left: { xs: '50%', sm: leftPct },
+          left: leftPct,
           transform: 'translateX(-50%)',
           width: 'min(440px, calc(100vw - 32px))'
         }}
       >
-        <LoginForm
-          onSuccess={handleSuccess}
-          onSignupClick={handleSignupClick}
-          onForgotPasswordClick={handleForgotPasswordClick}
-        />
+        {formEl}
       </Box>
     </Box>
   );

--- a/imports/accounts/client/pages/LoginPage.jsx
+++ b/imports/accounts/client/pages/LoginPage.jsx
@@ -7,14 +7,25 @@ import { LoginForm } from '../components/LoginForm';
 import WorkflowNavigation from '/imports/lib/WorkflowNavigation.js';
 const { sanitizeReturnPath, appendReturnTo } = WorkflowNavigation;
 
-// Card placement as a 3×3 grid over the router area. ?align=left|center|right
-// and ?valign=top|center|bottom drop the card into one of nine cells; because
-// each cell is a 1fr third and the card is centered WITHIN its cell, placement
-// is "center-of-the-third" oriented — never jammed against a viewport edge.
-const ALIGN_COLUMN = { left: 1, center: 2, right: 3 };
-const VALIGN_ROW = { top: 1, center: 2, bottom: 3 };
+// Card placement over the router area. ?align=left|center|right centers the card
+// horizontally (⅙ / ½ / ⅚ of the width). ?valign=top|center|bottom sets the
+// card's TOP EDGE on a fixed line and lets it grow DOWNWARD, so the tabs and
+// inputs hold their position when the form gets taller (inline error, alert box,
+// changed button) — only the area below expands. That's what keeps the inputs
+// from jumping between steps.
+//
+// The line is a fixed % — never a height-dependent transform, which is what was
+// redrawing the inputs. `bottom` sits at 50%: the card floats in the lower half
+// with roughly the bottom ~20% of the window left open beneath a typical card,
+// then grows down into that space (raise the % to hug lower, lower it to float
+// higher). top/center sit near the top of their regions.
+//
+// Absolute, not grid: a 1fr grid row balloons to fit a tall card and reflows the
+// page. Vertical is a fixed top edge (no Y translate); horizontal is centered.
+const ALIGN_X = { left: '16.67%', center: '50%', right: '83.34%' };
+const VALIGN_Y = { top: '0%', center: '33.34%', bottom: '50%' };
 
-function resolveCell(value, map) {
+function resolvePlacement(value, map) {
   const key = String(value || '').toLowerCase();
   return map[key] || map.center;
 }
@@ -29,9 +40,9 @@ export function LoginPage() {
   // invalid/absent falls back to the home route).
   const returnTo = sanitizeReturnPath(searchParams.get('returnTo'));
 
-  // Placement (defaults to dead-center when absent/invalid).
-  const gridColumn = resolveCell(searchParams.get('align'), ALIGN_COLUMN);
-  const gridRow = resolveCell(searchParams.get('valign'), VALIGN_ROW);
+  // Placement anchor points (default to dead-center when absent/invalid).
+  const leftPct = resolvePlacement(searchParams.get('align'), ALIGN_X);
+  const topPct = resolvePlacement(searchParams.get('valign'), VALIGN_Y);
 
   const handleSuccess = function() {
     // Redirect to the originally requested page after successful login,
@@ -53,23 +64,24 @@ export function LoginPage() {
   return (
     // No page-level bgcolor here: StyledMainRouter paints background.default and
     // (with the ambiance axis) any background image. height:100% claims the
-    // router's bounded height (rules/ui/layout-patterns.md) so the 3×3 grid can
-    // vertically place the card; the card is centered within its 1fr cell, so
-    // e.g. align=left sits it in the middle of the left third, not at the edge.
-    <Box
-      sx={{
-        height: '100%',
-        display: 'grid',
-        gridTemplateColumns: 'repeat(3, 1fr)',
-        gridTemplateRows: 'repeat(3, 1fr)',
-        overflow: 'auto',
-        p: 2
-      }}
-    >
-      {/* Fixed card width (not 1fr of the cell) so justifySelf centers it on
-          the third's center and lets it overflow into neighbors on narrow
-          screens — center-oriented, never shrunk-to-third or edge-anchored. */}
-      <Box sx={{ gridColumn: gridColumn, gridRow: gridRow, justifySelf: 'center', alignSelf: 'center', width: 'min(440px, calc(100vw - 32px))' }}>
+    // router's bounded height (rules/ui/layout-patterns.md); the card is
+    // absolutely placed and centered on the (leftPct, topPct) anchor so its
+    // position is independent of its own height — no grid-row reflow, and
+    // symmetric growth when the form gets taller.
+    <Box sx={{ position: 'relative', height: '100%', overflow: 'auto', p: 2 }}>
+      {/* Top-anchored vertically (top edge at topPct → grows downward),
+          center-anchored horizontally (translateX -50%). On narrow screens force
+          horizontal center so the card never runs off-edge; desktop uses the
+          requested third. Width caps at 440px (or the viewport minus padding). */}
+      <Box
+        sx={{
+          position: 'absolute',
+          top: topPct,
+          left: { xs: '50%', sm: leftPct },
+          transform: 'translateX(-50%)',
+          width: 'min(440px, calc(100vw - 32px))'
+        }}
+      >
         <LoginForm
           onSuccess={handleSuccess}
           onSignupClick={handleSignupClick}

--- a/imports/lib/MedicalRecordImporter.js
+++ b/imports/lib/MedicalRecordImporter.js
@@ -164,9 +164,10 @@ const MedicalRecordImporter = {
               // console.log('Collections', JSON.stringify(Object.keys(Collections)));
               if(Collections[collectionName]){
                 console.log('Collections[collectionName]', Collections[collectionName])
-                if(!Collections[collectionName].findOne({_id: newRecord._id})){                  
+                if(!Collections[collectionName].findOne({_id: newRecord._id})){
                   //console.log('Couldnt find record; attempting to insert.')
-                  let newRecordId = Collections[collectionName]._collection.insert(newRecord, {validate: false, filter: false}, function(error){
+                  // Raw LocalCollection.insert only accepts (doc, callback) — no options object
+                  let newRecordId = Collections[collectionName]._collection.insert(newRecord, function(error){
                     if(error) {
                       log.error('insert error', { error: error.message });
                     }
@@ -209,9 +210,12 @@ const MedicalRecordImporter = {
                       // switched from Meteor.default_connection to Meteor.connection
                       // switched from matching on Task._id to matching on Task.id 
                       
-                      if(!window[collectionName]._collection.findOne({id: newRecord.id})){                  
+                      if(!window[collectionName]._collection.findOne({id: newRecord.id})){
                         //console.log('Couldnt find record; attempting to insert.')
-                        let newRecordId = window[collectionName]._collection.insert(newRecord, {validate: false, filter: false}, function(error){
+                        // Raw LocalCollection.insert only accepts (doc, callback) — passing an
+                        // options object here made Minimongo defer-call it as the callback,
+                        // flooding the console with "callback is not a function" per record.
+                        let newRecordId = window[collectionName]._collection.insert(newRecord, function(error){
                           if(error) {
                             log.error('insert error', { error: error.message });
                           }

--- a/imports/lib/ServerMethods.js
+++ b/imports/lib/ServerMethods.js
@@ -138,7 +138,18 @@ async function runPipeline(entry, params, context) {
   if (options._validator) {
     const paramsObject = isPlainObject(params) ? params : {};
     if (!options._validator(paramsObject)) {
-      throw new Meteor.Error('validation-failed', 'Invalid params for ' + entry.name, { errors: options._validator.errors });
+      // Name the failing fields in the reason — "Invalid params for X" alone
+      // gives the caller nothing to act on (the details object rarely surfaces
+      // in UI error handlers, which typically show error.reason)
+      const fieldSummary = (options._validator.errors || []).slice(0, 5).map(function(err) {
+        const path = String(get(err, 'instancePath', '') || '').replace(/^\//, '').replace(/\//g, '.');
+        const missing = get(err, 'params.missingProperty');
+        const field = path || missing || 'params';
+        return field + ' ' + get(err, 'message', 'is invalid');
+      }).join('; ');
+      throw new Meteor.Error('validation-failed',
+        'Invalid params for ' + entry.name + (fieldSummary ? ' — ' + fieldSummary : ''),
+        { errors: options._validator.errors });
     }
   }
 

--- a/imports/lib/SessionKeys.js
+++ b/imports/lib/SessionKeys.js
@@ -61,6 +61,8 @@ export const VIEWPORT         = 'viewport';
 export const SESSION_INSPECTOR_OPEN = 'sessionInspectorOpen'; // Cmd/Ctrl+Shift+D debug dashboard
 export const THEME_DIALOG_OPEN      = 'themeDialogOpen';      // Cmd/Ctrl+Shift+T theme palette dialog
 export const ABOUT_DIALOG_OPEN      = 'aboutDialogOpen';      // Cmd/Ctrl+Shift+A about + update status
+export const PAGE_MODE    = 'pageMode';    // ambiance content-ink override: 'light' | 'dark' | undefined
+export const CARD_SURFACE = 'cardSurface'; // card surface state: 'solid' | 'glass' | 'flat'
 
 // ── FHIR id / display toggles ────────────────────────────────────────────────
 export const SHOW_SYSTEM_IDS    = 'showSystemIds';
@@ -130,7 +132,7 @@ export default {
   CURRENT_USER, SESSION_ID, ACCOUNTS_ACCESS_TOKEN, ACCOUNTS_REFRESH_TOKEN,
   SELECTED_ENDPOINT, SELECTED_ENDPOINT_ID, SPIDER_SCANNING,
   THEME, DISPLAY_NAVBARS, APP_HEIGHT, APP_WIDTH, VIEWPORT, SESSION_INSPECTOR_OPEN, THEME_DIALOG_OPEN,
-  ABOUT_DIALOG_OPEN,
+  ABOUT_DIALOG_OPEN, PAGE_MODE, CARD_SURFACE,
   SHOW_SYSTEM_IDS, SHOW_FHIR_IDS, SHOW_EXPERIMENTAL,
   SIMULATOR_MISSION_ID, SIMULATOR_LAUNCH_DATE, SIMULATOR_VEHICLE,
   SIMULATOR_MISSION_MODE, SELECTED_CREWED_VEHICLE,

--- a/imports/lib/SessionKeys.js
+++ b/imports/lib/SessionKeys.js
@@ -63,6 +63,7 @@ export const THEME_DIALOG_OPEN      = 'themeDialogOpen';      // Cmd/Ctrl+Shift+
 export const ABOUT_DIALOG_OPEN      = 'aboutDialogOpen';      // Cmd/Ctrl+Shift+A about + update status
 export const PAGE_MODE    = 'pageMode';    // ambiance content-ink override: 'light' | 'dark' | undefined
 export const CARD_SURFACE = 'cardSurface'; // card surface state: 'solid' | 'glass' | 'flat'
+export const PAGE_SURFACE_OVERRIDES = 'pageSurfaceOverrides'; // { [pathname]: 'solid'|'flat' } — Ctrl+Shift+K per-route card↔full-height
 
 // ── FHIR id / display toggles ────────────────────────────────────────────────
 export const SHOW_SYSTEM_IDS    = 'showSystemIds';
@@ -132,7 +133,7 @@ export default {
   CURRENT_USER, SESSION_ID, ACCOUNTS_ACCESS_TOKEN, ACCOUNTS_REFRESH_TOKEN,
   SELECTED_ENDPOINT, SELECTED_ENDPOINT_ID, SPIDER_SCANNING,
   THEME, DISPLAY_NAVBARS, APP_HEIGHT, APP_WIDTH, VIEWPORT, SESSION_INSPECTOR_OPEN, THEME_DIALOG_OPEN,
-  ABOUT_DIALOG_OPEN, PAGE_MODE, CARD_SURFACE,
+  ABOUT_DIALOG_OPEN, PAGE_MODE, CARD_SURFACE, PAGE_SURFACE_OVERRIDES,
   SHOW_SYSTEM_IDS, SHOW_FHIR_IDS, SHOW_EXPERIMENTAL,
   SIMULATOR_MISSION_ID, SIMULATOR_LAUNCH_DATE, SIMULATOR_VEHICLE,
   SIMULATOR_MISSION_MODE, SELECTED_CREWED_VEHICLE,

--- a/imports/lib/SessionKeys.js
+++ b/imports/lib/SessionKeys.js
@@ -64,6 +64,7 @@ export const ABOUT_DIALOG_OPEN      = 'aboutDialogOpen';      // Cmd/Ctrl+Shift+
 export const PAGE_MODE    = 'pageMode';    // ambiance content-ink override: 'light' | 'dark' | undefined
 export const CARD_SURFACE = 'cardSurface'; // card surface state: 'solid' | 'glass' | 'flat'
 export const PAGE_SURFACE_OVERRIDES = 'pageSurfaceOverrides'; // { [pathname]: 'solid'|'flat' } — Ctrl+Shift+K per-route card↔full-height
+export const AMBIANCE_HUD_OPEN = 'ambianceHudOpen'; // Cmd/Ctrl+Shift+E ambiance curation HUD
 
 // ── FHIR id / display toggles ────────────────────────────────────────────────
 export const SHOW_SYSTEM_IDS    = 'showSystemIds';
@@ -133,7 +134,7 @@ export default {
   CURRENT_USER, SESSION_ID, ACCOUNTS_ACCESS_TOKEN, ACCOUNTS_REFRESH_TOKEN,
   SELECTED_ENDPOINT, SELECTED_ENDPOINT_ID, SPIDER_SCANNING,
   THEME, DISPLAY_NAVBARS, APP_HEIGHT, APP_WIDTH, VIEWPORT, SESSION_INSPECTOR_OPEN, THEME_DIALOG_OPEN,
-  ABOUT_DIALOG_OPEN, PAGE_MODE, CARD_SURFACE, PAGE_SURFACE_OVERRIDES,
+  ABOUT_DIALOG_OPEN, PAGE_MODE, CARD_SURFACE, PAGE_SURFACE_OVERRIDES, AMBIANCE_HUD_OPEN,
   SHOW_SYSTEM_IDS, SHOW_FHIR_IDS, SHOW_EXPERIMENTAL,
   SIMULATOR_MISSION_ID, SIMULATOR_LAUNCH_DATE, SIMULATOR_VEHICLE,
   SIMULATOR_MISSION_MODE, SELECTED_CREWED_VEHICLE,

--- a/imports/lib/SessionKeys.js
+++ b/imports/lib/SessionKeys.js
@@ -52,6 +52,16 @@ export const SELECTED_ENDPOINT_ID  = 'selectedEndpointId';   // Endpoint _id (se
 // tell. Cross-package, so it lives here per the session-keys contract.
 export const SPIDER_SCANNING       = 'spiderScanning';       // boolean
 
+// Seeded vendor sandbox endpoints (client-side session array, not persisted).
+// Written by @orbital/lantern's "Seed Epic Sandbox Endpoint" button
+// (/server-configuration?tab=lantern) with the seed RPC's return record
+// { endpointId, name, address, healthTag, vendor, patientLaunchable };
+// cleared by its "Clear sandboxes" button. Read by provider-directory's
+// DirectoryConsole, which shows the SANDBOXES band only while
+// (Session.get(SANDBOX_ENDPOINTS) || []).length > 0. Cross-package, so it
+// lives here per the session-keys contract.
+export const SANDBOX_ENDPOINTS     = 'sandboxEndpoints';     // [{ endpointId, name, address, healthTag, vendor, patientLaunchable }]
+
 // ── App chrome / theme ───────────────────────────────────────────────────────
 export const THEME           = 'theme';            // 'light' | 'dark'
 export const DISPLAY_NAVBARS  = 'displayNavbars';
@@ -132,7 +142,7 @@ export default {
   SELECTED_PATIENT, SELECTED_PATIENT_ID, SELECTED_PATIENT_MONGO_ID,
   SELECTED_PRACTITIONER_ID, SELECTED_PRACTITIONER_ROLE_ID,
   CURRENT_USER, SESSION_ID, ACCOUNTS_ACCESS_TOKEN, ACCOUNTS_REFRESH_TOKEN,
-  SELECTED_ENDPOINT, SELECTED_ENDPOINT_ID, SPIDER_SCANNING,
+  SELECTED_ENDPOINT, SELECTED_ENDPOINT_ID, SPIDER_SCANNING, SANDBOX_ENDPOINTS,
   THEME, DISPLAY_NAVBARS, APP_HEIGHT, APP_WIDTH, VIEWPORT, SESSION_INSPECTOR_OPEN, THEME_DIALOG_OPEN,
   ABOUT_DIALOG_OPEN, PAGE_MODE, CARD_SURFACE, PAGE_SURFACE_OVERRIDES, AMBIANCE_HUD_OPEN,
   SHOW_SYSTEM_IDS, SHOW_FHIR_IDS, SHOW_EXPERIMENTAL,

--- a/imports/lib/loggerRedact.js
+++ b/imports/lib/loggerRedact.js
@@ -1,32 +1,54 @@
 // imports/lib/loggerRedact.js
 // PHI redaction net for LogRecords. Plain CJS, no Meteor imports.
+//
+// Safety contract: log call sites pass ARBITRARY runtime values, including
+// accidental host objects (React SyntheticEvents whose .view is `window`,
+// DOM nodes, etc.). The walker must terminate in bounded time on ANY input:
+//  - `seen` is a visited-set for the whole walk (never deleted from), so a
+//    shared reference is materialized once and marked on later sightings.
+//    A path-based guard (delete-on-exit) re-walks shared subtrees once per
+//    path — exponential on dense graphs; it froze and OOM-crashed the tab
+//    when a click handler logged a SyntheticEvent (2026-08-01).
+//  - MAX_DEPTH caps nesting; host objects are stubbed out entirely.
 const PHI_FIELDS = ['name', 'given', 'family', 'birthDate', 'address', 'telecom', 'photo', 'contact', 'maritalStatus', 'communication', 'email', 'phone'];
 const PATIENT_COMPARTMENT = ['Patient', 'RelatedPerson', 'Person', 'Practitioner'];
+const MAX_DEPTH = 32;
 
-function redactPhiInner(value, seen) {
+function isHostObject(value) {
+  /* global window, Node, Event */
+  if (typeof window !== 'undefined' && value === window) { return '[window]'; }
+  if (typeof Node !== 'undefined' && value instanceof Node) { return '[dom-node]'; }
+  if (typeof Event !== 'undefined' && value instanceof Event) { return '[event]'; }
+  // React SyntheticEvent (not an Event instance): duck-type on its signature
+  if (value.nativeEvent !== undefined && typeof value.stopPropagation === 'function') { return '[synthetic-event]'; }
+  return null;
+}
+
+function redactPhiInner(value, seen, depth) {
   if (value === null || typeof value !== 'object') { return value; }
   // Preserve Error objects: extract message + stack so diagnostics survive
   if (value instanceof Error) {
     const errOut = { message: value.message, stack: value.stack };
     // Redact any enumerable properties on the error that might carry PHI
     Object.keys(value).forEach(function(key) {
-      errOut[key] = redactPhiInner(value[key], seen);
+      errOut[key] = redactPhiInner(value[key], seen, depth + 1);
     });
     return errOut;
   }
   // Preserve Date objects as ISO strings
   if (value instanceof Date) { return value.toISOString(); }
-  // Cycle guard: if we have seen this object already, mark it to avoid infinite loops
+  const hostStub = isHostObject(value);
+  if (hostStub) { return hostStub; }
+  if (depth >= MAX_DEPTH) { return '[max-depth]'; }
+  // Visited-set: cycles AND shared references collapse to a marker after
+  // their first materialization (safety over duplicate-subtree fidelity)
   if (seen.has(value)) { return { redacted: true, circular: true }; }
   seen.add(value);
   if (PATIENT_COMPARTMENT.includes(value.resourceType)) {
-    seen.delete(value);
     return { redacted: true, resourceType: value.resourceType, id: value.id };
   }
   if (Array.isArray(value)) {
-    const arr = value.map(function(item) { return redactPhiInner(item, seen); });
-    seen.delete(value);
-    return arr;
+    return value.map(function(item) { return redactPhiInner(item, seen, depth + 1); });
   }
   const out = {};
   Object.keys(value).forEach(function(key) {
@@ -35,15 +57,14 @@ function redactPhiInner(value, seen) {
     } else if (key === 'identifier') {
       out[key] = { redacted: true };
     } else {
-      out[key] = redactPhiInner(value[key], seen);
+      out[key] = redactPhiInner(value[key], seen, depth + 1);
     }
   });
-  seen.delete(value);
   return out;
 }
 
 function redactPhi(value) {
-  return redactPhiInner(value, new WeakSet());
+  return redactPhiInner(value, new WeakSet(), 0);
 }
 
 module.exports = { redactPhi };

--- a/imports/lib/sessionKeyGroups.js
+++ b/imports/lib/sessionKeyGroups.js
@@ -79,7 +79,7 @@ export const SESSION_KEY_GROUPS = [
     label: 'App Chrome & Theme',
     exact: [THEME, DISPLAY_NAVBARS, APP_HEIGHT, APP_WIDTH, VIEWPORT,
             'sessionInspectorOpen', 'quickSearchOpen', 'luxMode', 'pageMode', 'cardSurface',
-            'pageSurfaceOverrides'],
+            'pageSurfaceOverrides', 'ambianceHudOpen'],
     prefixes: ['display']
   },
   {

--- a/imports/lib/sessionKeyGroups.js
+++ b/imports/lib/sessionKeyGroups.js
@@ -78,7 +78,8 @@ export const SESSION_KEY_GROUPS = [
     id: 'chrome',
     label: 'App Chrome & Theme',
     exact: [THEME, DISPLAY_NAVBARS, APP_HEIGHT, APP_WIDTH, VIEWPORT,
-            'sessionInspectorOpen', 'quickSearchOpen', 'luxMode', 'pageMode', 'cardSurface'],
+            'sessionInspectorOpen', 'quickSearchOpen', 'luxMode', 'pageMode', 'cardSurface',
+            'pageSurfaceOverrides'],
     prefixes: ['display']
   },
   {

--- a/imports/lib/sessionKeyGroups.js
+++ b/imports/lib/sessionKeyGroups.js
@@ -78,7 +78,7 @@ export const SESSION_KEY_GROUPS = [
     id: 'chrome',
     label: 'App Chrome & Theme',
     exact: [THEME, DISPLAY_NAVBARS, APP_HEIGHT, APP_WIDTH, VIEWPORT,
-            'sessionInspectorOpen', 'quickSearchOpen', 'luxMode'],
+            'sessionInspectorOpen', 'quickSearchOpen', 'luxMode', 'pageMode', 'cardSurface'],
     prefixes: ['display']
   },
   {

--- a/imports/lib/sessionKeyGroups.js
+++ b/imports/lib/sessionKeyGroups.js
@@ -65,7 +65,7 @@ export const SESSION_KEY_GROUPS = [
   {
     id: 'endpoints',
     label: 'Endpoints & Sharing',
-    exact: [SELECTED_ENDPOINT, SELECTED_ENDPOINT_ID],
+    exact: [SELECTED_ENDPOINT, SELECTED_ENDPOINT_ID, 'spiderScanning', 'sandboxEndpoints'],
     prefixes: []
   },
   {

--- a/imports/lib/themePersistence.js
+++ b/imports/lib/themePersistence.js
@@ -1,8 +1,14 @@
 // imports/lib/themePersistence.js
 //
-// Persist the user's theme choice (preset, accent hue, font, mode, background)
-// so it survives a reload. v1 = localStorage, per-browser, applied at client
-// boot before the theme paints.
+// Persist the user's theme choice so it survives a reload. v1 = localStorage,
+// per-browser, applied at client boot before the theme paints.
+//
+// Shape (all optional, merge-written):
+//   { presetId, accentHue, fontFamily, mode, backgroundImagePath,
+//     paletteOverrides: { <paletteKey>: <hex> } }
+// paletteOverrides are per-field colors set in the PaletteFieldEditor; they
+// re-apply at boot AFTER the preset (so they win) and are cleared when a new
+// preset is chosen. Passing paletteOverrides: null in a patch clears them.
 //
 // Follow-up (documented, not built): a per-user MongoDB sink so the choice
 // follows the account across devices — saveThemeChoice() gains a second write

--- a/imports/lib/themePersistence.js
+++ b/imports/lib/themePersistence.js
@@ -5,10 +5,14 @@
 //
 // Shape (all optional, merge-written):
 //   { presetId, accentHue, fontFamily, mode, backgroundImagePath,
+//     pageMode, cardSurface,
 //     paletteOverrides: { <paletteKey>: <hex> } }
 // paletteOverrides are per-field colors set in the PaletteFieldEditor; they
 // re-apply at boot AFTER the preset (so they win) and are cleared when a new
 // preset is chosen. Passing paletteOverrides: null in a patch clears them.
+// pageMode ('light'|'dark') is the ambiance content-ink override; cardSurface
+// ('solid'|'glass'|'flat') is the card surface state. Both consumed only by
+// ambiance/fluid routes (see the 2026-08-03 ambiance spec).
 //
 // Follow-up (documented, not built): a per-user MongoDB sink so the choice
 // follows the account across devices — saveThemeChoice() gains a second write

--- a/imports/lib/themePersistence.js
+++ b/imports/lib/themePersistence.js
@@ -6,6 +6,7 @@
 // Shape (all optional, merge-written):
 //   { presetId, accentHue, fontFamily, mode, backgroundImagePath,
 //     pageMode, cardSurface,
+//     pageSurfaceOverrides: { <pathname>: 'solid'|'flat' },
 //     paletteOverrides: { <paletteKey>: <hex> } }
 // paletteOverrides are per-field colors set in the PaletteFieldEditor; they
 // re-apply at boot AFTER the preset (so they win) and are cleared when a new
@@ -13,6 +14,8 @@
 // pageMode ('light'|'dark') is the ambiance content-ink override; cardSurface
 // ('solid'|'glass'|'flat') is the card surface state. Both consumed only by
 // ambiance/fluid routes (see the 2026-08-03 ambiance spec).
+// pageSurfaceOverrides is the Ctrl+Shift+K per-route card↔full-height map;
+// malformed entries are dropped at boot (unknown values treated as unset).
 //
 // Follow-up (documented, not built): a per-user MongoDB sink so the choice
 // follows the account across devices — saveThemeChoice() gains a second write

--- a/imports/patient/AutoDashboard.jsx
+++ b/imports/patient/AutoDashboard.jsx
@@ -975,10 +975,13 @@ export function AutoDashboard(props){
     ) : <EmptyState message="No diagnostic reports found" />;
 
 
-    // Main dashboard layout
+    // Main dashboard layout — the chart column lands in the ambiance image's
+    // neutral space via Meteor.StyledContainer (degrades to vanilla Container
+    // when the host hasn't registered it).
+    const AmbientColumn = Meteor.StyledContainer || Container;
     let patientChartLayout = (
         <Fade in={true} timeout={800}>
-            <Container maxWidth="lg" sx={{ mt: 4, mb: 10, pb: '100px' }}>
+            <AmbientColumn maxWidth="lg" sx={{ mt: 4, mb: 10, pb: '100px' }}>
                 {/* Patient Header */}
                 <Box sx={{ mb: 4 }}>
                     <PatientCard 
@@ -1576,7 +1579,7 @@ export function AutoDashboard(props){
                         </>
                     )}
                 </Stack>
-            </Container>
+            </AmbientColumn>
         </Fade>
     );
 

--- a/imports/patient/AutoDashboard.jsx
+++ b/imports/patient/AutoDashboard.jsx
@@ -123,6 +123,7 @@ import { DiagnosticReports } from '../lib/schemas/SimpleSchemas/DiagnosticReport
 import { get } from 'lodash';
 
 import PatientCard from './PatientCard';
+import AmbianceInk from '../ui/theme/AmbianceInk.jsx';
 import FhirUtilities from '../FhirUtilities';
 
 const log = (Meteor.Logger ? Meteor.Logger.for('AutoDashboard') : console);
@@ -224,15 +225,6 @@ export function AutoDashboard(props){
     const theme = useTheme();
     const client = useContext(FhirClientContext);
     const navigate = useNavigate();
-
-    // Get Honeycomb theme for dark mode support
-    const useAppTheme = Meteor.useTheme;
-    const appTheme = useAppTheme ? useAppTheme() : { theme: 'light' };
-    const isDark = appTheme.theme === 'dark';
-
-    // Theme-aware colors for cards
-    const cardBgColor = isDark ? '#1e1e1e' : '#ffffff';
-    const cardTextColor = isDark ? 'rgba(255, 255, 255, 0.87)' : 'rgba(0, 0, 0, 0.87)';
 
     const autoSubscribeEnabled = get(Meteor, 'settings.public.defaults.autoSubscribe', false);
 
@@ -993,7 +985,9 @@ export function AutoDashboard(props){
                     />
                 </Box>
 
-                {/* Sticky Action Controls */}
+                {/* Sticky Action Controls — sit on the ambiance background,
+                    so AmbianceInk keeps them legible against it */}
+                <AmbianceInk>
                 <Box
                     sx={{
                         position: 'sticky',
@@ -1141,11 +1135,12 @@ export function AutoDashboard(props){
                         </Button>
                     </ButtonGroup>
                 </Box>
+                </AmbianceInk>
 
                 {/* Clinical Data Sections */}
                 <Stack spacing={0}>
                     {/* Primary Clinical Data */}
-                    <Box sx={{ mb: 2 }}>
+                    <AmbianceInk><Box sx={{ mb: 2 }}>
                         <Typography
                             variant="overline"
                             color="text.secondary"
@@ -1153,18 +1148,12 @@ export function AutoDashboard(props){
                         >
                             Clinical History
                         </Typography>
-                    </Box>
+                    </Box></AmbianceInk>
 
                     {autoSubscribeEnabled === false && (
                         <Alert
                             severity="warning"
-                            sx={{
-                                mb: 3,
-                                bgcolor: isDark ? 'rgba(237, 108, 2, 0.15)' : 'rgba(237, 108, 2, 0.1)',
-                                color: cardTextColor,
-                                '& .MuiAlert-icon': { color: isDark ? '#ff9800' : '#ed6c02' },
-                                '& .MuiAlertTitle-root': { color: cardTextColor }
-                            }}
+                            sx={{ mb: 3 }}
                         >
                             <AlertTitle>Clinical Subscriptions Disabled</AlertTitle>
                             Clinical data subscriptions are not active. Contact your administrator
@@ -1224,7 +1213,7 @@ export function AutoDashboard(props){
                     {/* Treatments & Interventions */}
                     {(data.immunizations.length > 0 || data.procedures.length > 0 || data.medicationAdministrations.length > 0 || data.medicationRequests.length > 0 || data.serviceRequests.length > 0) && (
                         <>
-                            <Box sx={{ mb: 2, mt: 4 }}>
+                            <AmbianceInk><Box sx={{ mb: 2, mt: 4 }}>
                                 <Typography 
                                     variant="overline" 
                                     color="text.secondary" 
@@ -1232,7 +1221,7 @@ export function AutoDashboard(props){
                                 >
                                     Treatments & Interventions
                                 </Typography>
-                            </Box>
+                            </Box></AmbianceInk>
 
                             {data.immunizations.length > 0 && (
                                 <StyledCard
@@ -1299,7 +1288,7 @@ export function AutoDashboard(props){
                     {/* Measurements & Assessments */}
                     {(data.observations.length > 0 || data.questionnaireResponses.length > 0 || data.nutritionIntakes.length > 0) && (
                         <>
-                            <Box sx={{ mb: 2, mt: 4 }}>
+                            <AmbianceInk><Box sx={{ mb: 2, mt: 4 }}>
                                 <Typography 
                                     variant="overline" 
                                     color="text.secondary" 
@@ -1307,7 +1296,7 @@ export function AutoDashboard(props){
                                 >
                                     Measurements & Assessments
                                 </Typography>
-                            </Box>
+                            </Box></AmbianceInk>
 
                             {data.observations.length > 0 && (
                                 <StyledCard
@@ -1350,7 +1339,7 @@ export function AutoDashboard(props){
                     {/* Diagnostics & Imaging */}
                     {(data.diagnosticReports.length > 0 || data.imagingStudies.length > 0) && (
                         <>
-                            <Box sx={{ mb: 2, mt: 4 }}>
+                            <AmbianceInk><Box sx={{ mb: 2, mt: 4 }}>
                                 <Typography
                                     variant="overline"
                                     color="text.secondary"
@@ -1358,7 +1347,7 @@ export function AutoDashboard(props){
                                 >
                                     Diagnostics & Imaging
                                 </Typography>
-                            </Box>
+                            </Box></AmbianceInk>
 
                             {data.diagnosticReports.length > 0 && (
                                 <StyledCard
@@ -1389,7 +1378,7 @@ export function AutoDashboard(props){
                     {/* Care Coordination */}
                     {(data.careTeams.length > 0 || data.carePlans.length > 0 || data.consents.length > 0) && (
                         <>
-                            <Box sx={{ mb: 2, mt: 4 }}>
+                            <AmbianceInk><Box sx={{ mb: 2, mt: 4 }}>
                                 <Typography 
                                     variant="overline" 
                                     color="text.secondary" 
@@ -1397,7 +1386,7 @@ export function AutoDashboard(props){
                                 >
                                     Care Coordination
                                 </Typography>
-                            </Box>
+                            </Box></AmbianceInk>
 
                             {data.careTeams.length > 0 && (
                                 <StyledCard
@@ -1441,7 +1430,7 @@ export function AutoDashboard(props){
                     {/* Care Planning */}
                     {data.goals.length > 0 && (
                         <>
-                            <Box sx={{ mb: 2, mt: 4 }}>
+                            <AmbianceInk><Box sx={{ mb: 2, mt: 4 }}>
                                 <Typography 
                                     variant="overline" 
                                     color="text.secondary" 
@@ -1449,7 +1438,7 @@ export function AutoDashboard(props){
                                 >
                                     Care Planning
                                 </Typography>
-                            </Box>
+                            </Box></AmbianceInk>
 
                             <StyledCard
                                 icon={<FlagIcon />}
@@ -1467,7 +1456,7 @@ export function AutoDashboard(props){
                     {/* Clinical Documentation */}
                     {(data.documentReferences.length > 0 || data.communications.length > 0 || data.compositions.length > 0) && (
                         <>
-                            <Box sx={{ mb: 2, mt: 4 }}>
+                            <AmbianceInk><Box sx={{ mb: 2, mt: 4 }}>
                                 <Typography 
                                     variant="overline" 
                                     color="text.secondary" 
@@ -1475,7 +1464,7 @@ export function AutoDashboard(props){
                                 >
                                     Clinical Documentation
                                 </Typography>
-                            </Box>
+                            </Box></AmbianceInk>
 
                             {data.documentReferences.length > 0 && (
                                 <StyledCard
@@ -1518,7 +1507,7 @@ export function AutoDashboard(props){
                     {/* Locations */}
                     {data.locations.length > 0 && (
                         <>
-                            <Box sx={{ mb: 2, mt: 4 }}>
+                            <AmbianceInk><Box sx={{ mb: 2, mt: 4 }}>
                                 <Typography 
                                     variant="overline" 
                                     color="text.secondary" 
@@ -1526,7 +1515,7 @@ export function AutoDashboard(props){
                                 >
                                     Locations
                                 </Typography>
-                            </Box>
+                            </Box></AmbianceInk>
 
                             <StyledCard
                                 icon={<PlaceIcon />}
@@ -1543,7 +1532,7 @@ export function AutoDashboard(props){
                     {/* Genomics & Specimens */}
                     {(data.molecularSequences.length > 0 || data.specimens.length > 0) && (
                         <>
-                            <Box sx={{ mb: 2, mt: 4 }}>
+                            <AmbianceInk><Box sx={{ mb: 2, mt: 4 }}>
                                 <Typography
                                     variant="overline"
                                     color="text.secondary"
@@ -1551,7 +1540,7 @@ export function AutoDashboard(props){
                                 >
                                     Genomics & Specimens
                                 </Typography>
-                            </Box>
+                            </Box></AmbianceInk>
 
                             {data.molecularSequences.length > 0 && (
                                 <StyledCard
@@ -1617,15 +1606,7 @@ export function AutoDashboard(props){
                             borderRadius: 3,
                             boxShadow: '0 2px 8px rgba(0,0,0,0.08)',
                             border: '1px solid',
-                            borderColor: 'divider',
-                            bgcolor: cardBgColor,
-                            color: cardTextColor,
-                            '& .MuiTypography-root': {
-                                color: cardTextColor
-                            },
-                            '& .MuiTypography-body1': {
-                                color: isDark ? 'rgba(255, 255, 255, 0.6)' : 'rgba(0, 0, 0, 0.6)'
-                            }
+                            borderColor: 'divider'
                         }}
                     >
                         <CardContent sx={{ p: 6 }}>

--- a/imports/startup/client/hotkeys.js
+++ b/imports/startup/client/hotkeys.js
@@ -1,7 +1,7 @@
 // imports/startup/client/hotkeys.js
 
 import { Session } from 'meteor/session';
-import { SESSION_INSPECTOR_OPEN, THEME_DIALOG_OPEN, ABOUT_DIALOG_OPEN } from '/imports/lib/SessionKeys.js';
+import { SESSION_INSPECTOR_OPEN, THEME_DIALOG_OPEN, ABOUT_DIALOG_OPEN, AMBIANCE_HUD_OPEN } from '/imports/lib/SessionKeys.js';
 
 export function initializeKeyboardShortcuts() {
   document.addEventListener('keydown', (event) => {
@@ -104,10 +104,17 @@ export function initializeKeyboardShortcuts() {
       Session.set(THEME_DIALOG_OPEN, !Session.get(THEME_DIALOG_OPEN));
     }
 
+    // Cmd/Ctrl + Shift + E — Toggle Ambiance Tuning HUD (curation dev tool)
+    if ((event.metaKey || event.ctrlKey) && event.shiftKey && (event.key === 'E' || event.key === 'e')) {
+      event.preventDefault();
+      Session.set(AMBIANCE_HUD_OPEN, !Session.get(AMBIANCE_HUD_OPEN));
+    }
+
     // Escape — Close dialogs
     if (event.key === 'Escape') {
       Session.set(SESSION_INSPECTOR_OPEN, false);
       Session.set(THEME_DIALOG_OPEN, false);
+      Session.set(AMBIANCE_HUD_OPEN, false);
       Session.set('quickSearchOpen', false);
     }
   });

--- a/imports/startup/client/hotkeys.js
+++ b/imports/startup/client/hotkeys.js
@@ -68,10 +68,16 @@ export function initializeKeyboardShortcuts() {
       window.dispatchEvent(new CustomEvent('toggleAdminLinks'));
     }
 
-    // Cmd/Ctrl + Shift + L — Toggle flat card mode (Life Support dashboard)
+    // Cmd/Ctrl + Shift + L — Cycle card surface (solid → glass → flat)
     if ((event.metaKey || event.ctrlKey) && event.shiftKey && (event.key === 'L' || event.key === 'l')) {
       event.preventDefault();
-      window.dispatchEvent(new CustomEvent('toggleFlatCards'));
+      import('/imports/ui/themePresets.js').then(function(tp) { tp.cycleCardSurface(); });
+    }
+
+    // Cmd/Ctrl + Shift + K — Toggle this route between card and full-height (flat) layout
+    if ((event.metaKey || event.ctrlKey) && event.shiftKey && (event.key === 'K' || event.key === 'k')) {
+      event.preventDefault();
+      import('/imports/ui/themePresets.js').then(function(tp) { tp.togglePageSurfaceOverride(window.location.pathname); });
     }
 
     // Cmd/Ctrl + Shift + B — Toggle lunar background image

--- a/imports/ui-tables/PatientsTable.jsx
+++ b/imports/ui-tables/PatientsTable.jsx
@@ -274,7 +274,8 @@ export function PatientsTable(props = {}){
     tableRowSize = 'medium',
     logger = null,
 
-    rowClickMode = 'index',
+    // '_id' (default, MongoDB primary key per the id-lookup rule) | 'id' | 'index'
+    rowClickMode = '_id',
     page: initialPage = 0,  // Rename to avoid conflict with state
     size,
     order = 'descending',
@@ -530,6 +531,9 @@ export function PatientsTable(props = {}){
       onCellClick(id);
     }
   }
+  // Bound as selectPatientRow(patient, rowIndex) — the DOM click event arrives
+  // as a third argument and must NEVER leak into patientId (logging an event
+  // object walks window via event.view and freezes the tab).
   function selectPatientRow(patient, index){
     if(logger){
       logger.debug('Selecting a new Patient...');
@@ -1016,7 +1020,7 @@ export function PatientsTable(props = {}){
       
       // Main row
       tableRows.push(
-        <TableRow key={i} className="patientRow" hover={true} style={rowStyle} selected={selected} onClick={ selectPatientRow.bind(this, patientsToRender[i] )} >
+        <TableRow key={i} className="patientRow" hover={true} style={rowStyle} selected={selected} onClick={ selectPatientRow.bind(this, patientsToRender[i], i )} >
           <TableCell>
             <IconButton
               aria-label="expand row"

--- a/imports/ui-tables/PersonsTable.jsx
+++ b/imports/ui-tables/PersonsTable.jsx
@@ -862,7 +862,7 @@ export function PersonsTable(props){
       }
 
       tableRows.push(
-        <TableRow key={i} className="personRow" hover={true} style={rowStyle} selected={selected} onClick={ selectPersonRow.bind(this, personsToRender[i] )} >
+        <TableRow key={i} className="personRow" hover={true} style={rowStyle} selected={selected} onClick={ selectPersonRow.bind(this, personsToRender[i], i )} >
           { renderActionIcons(personsToRender[i]) }
           { renderRowAvatar(personsToRender[i], styles.avatar) }
           { renderIdentifier(personsToRender[i].identifier)}
@@ -1024,7 +1024,8 @@ PersonsTable.defaultProps = {
   hideSystemBarcode: false,
   hideCounts: true,
   
-  rowClickMode: 'index',
+  // '_id' (default, MongoDB primary key per the id-lookup rule) | 'id' | 'index'
+  rowClickMode: '_id',
 
   font3of9: true,
   hideFhirBarcode: false,

--- a/imports/ui/App.jsx
+++ b/imports/ui/App.jsx
@@ -1878,8 +1878,23 @@ function StyledMainRouter(props){
     overflowY: 'auto',
     overflowX: 'hidden',
     transition: 'padding-top 0.3s ease-in-out',
-    background: backgroundStyle, // Set background here so it's part of the object
+    backgroundColor: backgroundStyle, // longhand so the ambiance backgroundImage below can layer without a shorthand/longhand clash
     ...style // Merge the passed style prop
+  }
+
+  // Ambiance background (the decade-old themeBackgrounds axis; the ThemeDialog
+  // carousel writes settings.public.theme.backgroundImagePath). AppCanvas — the
+  // old renderer — is retired; the scroll region is now the single canvas, so
+  // the image layers over background.default here. Reactive: StyledMainRouter
+  // consumes useMuiTheme(), which regenerates on themeRefreshRequest, so
+  // setThemeBackground() repaints without reload. Cover + fixed so the photo
+  // sits behind the (opaque background.paper) content as ambiance.
+  const ambianceBackground = get(Meteor, 'settings.public.theme.backgroundImagePath', '');
+  if (ambianceBackground) {
+    mainAppStyle.backgroundImage = 'url(' + ambianceBackground + ')';
+    mainAppStyle.backgroundSize = 'cover';
+    mainAppStyle.backgroundPosition = 'center';
+    mainAppStyle.backgroundAttachment = 'fixed';
   }
 
   // NOTE: No paddingTop offset for the prominent header here. The #header Box is

--- a/imports/ui/App.jsx
+++ b/imports/ui/App.jsx
@@ -53,6 +53,7 @@ import WelcomeDialog from './components/WelcomeDialog.jsx';
 import SessionInspectorDialog from './SessionInspectorDialog.jsx';
 import AboutDialog from './AboutDialog.jsx';
 import ThemeDialog from './ThemeDialog.jsx';
+import AmbianceTuningHud from './theme/AmbianceTuningHud.jsx';
 import AppSnackbar from './AppSnackbar.jsx';
 import ExtensiblePage from './extensible/ExtensiblePage.jsx';
 import ErrorPage from './extensible/ErrorPage.jsx';
@@ -1804,6 +1805,7 @@ export function App(props){
             <WelcomeDialog />
             <SessionInspectorDialog />
             <ThemeDialog />
+            <AmbianceTuningHud />
             <AboutDialog />
             <AppSnackbar />
             <Box sx={{ display: 'flex', flex: 1, overflow: 'hidden' }}>

--- a/imports/ui/App.jsx
+++ b/imports/ui/App.jsx
@@ -703,7 +703,8 @@ let dynamicRoutes = [
     element: <OAuthPatientPickerPage />
   }, {
     path: "/patient-chart",
-    element: <PatientChart />
+    element: <PatientChart />,
+    enableAmbiance: true
   }, {
     path: "/biomarkers-charting",
     element: <BiomarkerChartingPage />

--- a/imports/ui/App.jsx
+++ b/imports/ui/App.jsx
@@ -10,6 +10,8 @@ import { Helmet } from "react-helmet";
 
 import {
   useNavigate,
+  useLocation,
+  matchPath,
   BrowserRouter as Router,
   Routes,
   Route,
@@ -45,6 +47,7 @@ import NoPatientSelectedCard from './components/NoPatientSelectedCard.jsx';
 import AuthGuard from './guards/AuthGuard.jsx';
 import PatientGuard from './guards/PatientGuard.jsx';
 import DataGuard from './guards/DataGuard.jsx';
+import AmbianceZone from './guards/AmbianceZone.jsx';
 import ErrorBoundary from './ErrorBoundary.jsx';
 import WelcomeDialog from './components/WelcomeDialog.jsx';
 import SessionInspectorDialog from './SessionInspectorDialog.jsx';
@@ -1866,6 +1869,17 @@ function StyledMainRouter(props){
     return Session.get("displayNavbars");
   }, []);
 
+  // Active-route capability lookup: ambiance paints ONLY on routes that
+  // declare enableAmbiance (the constraint that makes ambiance safe — spec
+  // docs/superpowers/specs/2026-08-03-ambiance-experience-zone-design.md).
+  // This also ends the historical leak where every route showed the photo
+  // through canvas gaps.
+  const routerLocation = useLocation();
+  const activeRoute = allRoutes.find(function(r) {
+    return r.path && matchPath({ path: r.path, end: true }, routerLocation.pathname);
+  }) || null;
+  const activeAllowsAmbiance = !!get(activeRoute, 'enableAmbiance');
+
   // Single source of truth: consume the palette computed by CustomThemeProvider
   // (settings-sanitized via getThemeSetting) instead of re-deriving page
   // background from Meteor.settings here. This was the second palette
@@ -1892,7 +1906,7 @@ function StyledMainRouter(props){
   // sits behind the (opaque background.paper) content as ambiance.
   // Solid 'color:' entries (themeBackgrounds EARTH_TONES) paint backgroundColor instead.
   const ambianceBackground = get(Meteor, 'settings.public.theme.backgroundImagePath', '');
-  if (ambianceBackground) {
+  if (ambianceBackground && activeAllowsAmbiance) {
     if (isColorBackground(ambianceBackground)) {
       // Solid ambiance: override the canvas color, no image layer.
       mainAppStyle.backgroundColor = colorFromBackground(ambianceBackground);
@@ -1929,9 +1943,10 @@ function StyledMainRouter(props){
         // white-screening the whole app. Keyed per route so navigating away remounts
         // a fresh boundary (error boundaries don't self-reset on route change).
         // Guards compose from the inside out: ErrorBoundary hugs the page,
+        // AmbianceZone provides the zone composition/theme on flagged routes,
         // `requirePatient` swaps in the no-patient page when no patient is
         // selected, and `requireAuth` stays outermost so authentication is
-        // checked first.
+        // checked first: requireAuth > requirePatient > AmbianceZone > ErrorBoundary > page.
         let element = (
           <ErrorBoundary
             key={'eb-' + (route.path || index)}
@@ -1940,6 +1955,13 @@ function StyledMainRouter(props){
             {routeElement}
           </ErrorBoundary>
         );
+        if (route.enableAmbiance || route.enableFluidInterface) {
+          element = (
+            <AmbianceZone ambiance={!!route.enableAmbiance} fluid={!!route.enableFluidInterface}>
+              {element}
+            </AmbianceZone>
+          );
+        }
         if (route.requirePatient) {
           element = <PatientGuard>{element}</PatientGuard>;
         }

--- a/imports/ui/App.jsx
+++ b/imports/ui/App.jsx
@@ -688,7 +688,8 @@ let dynamicRoutes = [
     element: <CdsHooksDebugger />
   }, {
     path: "/patient-quickchart",
-    element: <PatientQuickChart />
+    element: <PatientQuickChart />,
+    requirePatient: true
   }, {
     path: "/server-configuration",
     element: <ServerConfigurationPage />
@@ -705,7 +706,9 @@ let dynamicRoutes = [
   }, {
     path: "/patient-chart",
     element: <PatientChart />,
-    enableAmbiance: true
+    requirePatient: true,
+    enableAmbiance: true,
+    defaultSurface: "flat"
   }, {
     path: "/biomarkers-charting",
     element: <BiomarkerChartingPage />
@@ -1960,7 +1963,7 @@ function StyledMainRouter(props){
         );
         if (route.enableAmbiance || route.enableFluidInterface) {
           element = (
-            <AmbianceZone ambiance={!!route.enableAmbiance} fluid={!!route.enableFluidInterface}>
+            <AmbianceZone ambiance={!!route.enableAmbiance} fluid={!!route.enableFluidInterface} defaultSurface={route.defaultSurface}>
               {element}
             </AmbianceZone>
           );

--- a/imports/ui/App.jsx
+++ b/imports/ui/App.jsx
@@ -1494,6 +1494,7 @@ export function SlideOutCards(props){
 
 import { CustomThemeProvider, useTheme, getThemeSetting } from './CustomThemeProvider.jsx';
 export { CustomThemeProvider, useTheme, getThemeSetting };
+import { isColorBackground, colorFromBackground } from './theme/backgroundValue.js';
 
 
 
@@ -1889,12 +1890,18 @@ function StyledMainRouter(props){
   // consumes useMuiTheme(), which regenerates on themeRefreshRequest, so
   // setThemeBackground() repaints without reload. Cover + fixed so the photo
   // sits behind the (opaque background.paper) content as ambiance.
+  // Solid 'color:' entries (themeBackgrounds EARTH_TONES) paint backgroundColor instead.
   const ambianceBackground = get(Meteor, 'settings.public.theme.backgroundImagePath', '');
   if (ambianceBackground) {
-    mainAppStyle.backgroundImage = 'url(' + ambianceBackground + ')';
-    mainAppStyle.backgroundSize = 'cover';
-    mainAppStyle.backgroundPosition = 'center';
-    mainAppStyle.backgroundAttachment = 'fixed';
+    if (isColorBackground(ambianceBackground)) {
+      // Solid ambiance: override the canvas color, no image layer.
+      mainAppStyle.backgroundColor = colorFromBackground(ambianceBackground);
+    } else {
+      mainAppStyle.backgroundImage = 'url(' + ambianceBackground + ')';
+      mainAppStyle.backgroundSize = 'cover';
+      mainAppStyle.backgroundPosition = 'center';
+      mainAppStyle.backgroundAttachment = 'fixed';
+    }
   }
 
   // NOTE: No paddingTop offset for the prominent header here. The #header Box is

--- a/imports/ui/CustomThemeProvider.jsx
+++ b/imports/ui/CustomThemeProvider.jsx
@@ -10,6 +10,9 @@ import CssBaseline from '@mui/material/CssBaseline';
 
 import StyledCard from './components/StyledCard.jsx';
 import StyledContainer from './components/StyledContainer.jsx';
+import AmbianceInk from './theme/AmbianceInk.jsx';
+import { inkForColor } from './theme/contrastInk.js';
+import { saveThemeChoice } from '/imports/lib/themePersistence.js';
 
 //===============================================================================================================
 // Theming
@@ -21,6 +24,7 @@ export const useTheme = () => useContext(ThemeContext);
 Meteor.useTheme = useTheme;
 Meteor.StyledCard = StyledCard;           // surface-aware Card (solid|glass|flat)
 Meteor.StyledContainer = StyledContainer; // focus-aware content column
+Meteor.AmbianceInk = AmbianceInk;         // page-text ink for on-background content
 
 // Export React Router hooks via Meteor object for use in packages
 Meteor.useLocation = ReactRouterDOM.useLocation;
@@ -64,7 +68,13 @@ export function buildTypography(){
 
 // this Provider components enables the useTheme() hook in child components
 export const CustomThemeProvider = ({ children }) => {
+  // Session('theme') is the CANONICAL mode. Boot seeds it from the persisted
+  // choice (applyThemeChoiceAtBoot) before this mounts; header toggle, the
+  // Theme & Palette MODE control, and presets all write it, and the autorun
+  // below mirrors it into React state. Fall back to settings when unset.
   const [theme, setTheme] = useState(function() {
+    const sessionMode = Session.get('theme');
+    if (sessionMode === 'light' || sessionMode === 'dark') { return sessionMode; }
     const settingsMode = get(Meteor, 'settings.public.theme.darkMode', false);
     const paletteMode = get(Meteor, 'settings.public.theme.palette.mode', '');
     return settingsMode || paletteMode === 'dark' ? 'dark' : 'light';
@@ -89,11 +99,20 @@ export const CustomThemeProvider = ({ children }) => {
     // Get AppBar colors with dark mode support
     // Light mode: defaults to primary color if not specified
     const appBarColorLight = getThemeSetting("settings.public.theme.palette.appBarColor", primaryColor);
-    const appBarTextColorLight = getThemeSetting("settings.public.theme.palette.appBarTextColor", "#ffffff");
-
-    // Dark mode: defaults to light mode values if not specified
     const appBarColorDark = getThemeSetting("settings.public.theme.palette.appBarColorDark", appBarColorLight);
-    const appBarTextColorDark = getThemeSetting("settings.public.theme.palette.appBarTextColorDark", appBarTextColorLight);
+
+    // App-bar TEXT: explicit settings win; otherwise auto-contrast from the
+    // bar's own brightness (the ambiance AUTO idea applied to one color) —
+    // a bright accent bar gets dark ink, a near-black bar gets light ink.
+    // Unparseable bars (low-alpha gradients etc.) keep the legacy defaults.
+    const autoInk = function(barColor, fallback) {
+      const ink = inkForColor(barColor);
+      return ink ? (ink === 'dark' ? 'rgba(0, 0, 0, 0.87)' : '#ffffff') : fallback;
+    };
+    const appBarTextColorLight = getThemeSetting("settings.public.theme.palette.appBarTextColor", '')
+      || autoInk(appBarColorLight, '#ffffff');
+    const appBarTextColorDark = getThemeSetting("settings.public.theme.palette.appBarTextColorDark", '')
+      || autoInk(appBarColorDark, appBarTextColorLight);
 
     // Select the appropriate colors based on current mode
     const appBarColor = isDark ? appBarColorDark : appBarColorLight;
@@ -243,7 +262,11 @@ export const CustomThemeProvider = ({ children }) => {
   }, [theme, themeRefreshCounter]);
 
   const toggleTheme = () => {
-    setTheme((prevTheme) => (prevTheme === 'light' ? 'dark' : 'light'));
+    // Write the canonical Session key (the autorun mirrors it into state)
+    // and persist the choice so the mode survives reloads.
+    const next = liveThemeRef.current === 'light' ? 'dark' : 'light';
+    Session.set('theme', next);
+    saveThemeChoice({ mode: next });
   };
 
   // Function to force theme refresh when settings change
@@ -264,6 +287,25 @@ export const CustomThemeProvider = ({ children }) => {
 
       return () => handle.stop();
     }
+  }, []);
+
+  // Mirror the canonical Session('theme') into React state, and make sure the
+  // key is populated on first mount (so every Session reader agrees with the
+  // provider). The print swap below deliberately bypasses Session — it's a
+  // temporary override restored on afterprint, not a mode change.
+  useEffect(() => {
+    if (!Meteor.isClient) { return; }
+    const current = Session.get('theme');
+    if (current !== liveThemeRef.current) {
+      Session.set('theme', liveThemeRef.current);
+    }
+    const handle = Tracker.autorun(() => {
+      const sessionMode = Session.get('theme');
+      if ((sessionMode === 'light' || sessionMode === 'dark') && sessionMode !== liveThemeRef.current) {
+        setTheme(sessionMode);
+      }
+    });
+    return () => handle.stop();
   }, []);
 
   // Always print in the light theme — screens may be dark, but paper is white.

--- a/imports/ui/CustomThemeProvider.jsx
+++ b/imports/ui/CustomThemeProvider.jsx
@@ -8,6 +8,9 @@ import * as ReactRouterDOM from 'react-router-dom';
 import { ThemeProvider, createTheme } from '@mui/material/styles';
 import CssBaseline from '@mui/material/CssBaseline';
 
+import StyledCard from './components/StyledCard.jsx';
+import StyledContainer from './components/StyledContainer.jsx';
+
 //===============================================================================================================
 // Theming
 
@@ -16,6 +19,8 @@ const ThemeContext = createContext();
 
 export const useTheme = () => useContext(ThemeContext);
 Meteor.useTheme = useTheme;
+Meteor.StyledCard = StyledCard;           // surface-aware Card (solid|glass|flat)
+Meteor.StyledContainer = StyledContainer; // focus-aware content column
 
 // Export React Router hooks via Meteor object for use in packages
 Meteor.useLocation = ReactRouterDOM.useLocation;

--- a/imports/ui/DICOM/DicomViewerPage.jsx
+++ b/imports/ui/DICOM/DicomViewerPage.jsx
@@ -423,7 +423,9 @@ function DicomViewerPage() {
     searchParamsRef = searchParamsResult[0];
     setSearchParamsRef = searchParamsResult[1];
     fileIdFromQuery = searchParamsRef.get('file');
-    previousRouteFromQuery = searchParamsRef.get('previous');
+    // Back target: prefer `back` (the param the Files table + UploadPage use),
+    // fall back to the legacy `previous` for any existing links.
+    previousRouteFromQuery = searchParamsRef.get('back') || searchParamsRef.get('previous');
   }
 
   // Current user and role check

--- a/imports/ui/DICOM/StudyListPage.jsx
+++ b/imports/ui/DICOM/StudyListPage.jsx
@@ -157,7 +157,18 @@ export default function StudyListPage() {
               <Button
                 variant="contained"
                 startIcon={<UploadIcon />}
-                onClick={function() { navigate('/dicom/upload' + forwardParams); }}
+                onClick={function() {
+                  var uploadUrl = '/dicom/upload' + forwardParams;
+                  // The DICOM Files tab is the low-level override: uploads
+                  // launched from it return there via ?next. Every other entry
+                  // point (studies/keys tabs, ServiceRequest, patient chart)
+                  // omits next and falls through to the default Imaging Studies
+                  // tab — the common case.
+                  if (activeTab === TAB_INDICES.files) {
+                    uploadUrl += (forwardParams ? '&' : '?') + 'next=' + encodeURIComponent('/dicom/studies?tab=files');
+                  }
+                  navigate(uploadUrl);
+                }}
               >
                 Upload Image(s)
               </Button>

--- a/imports/ui/DICOM/UploadPage.jsx
+++ b/imports/ui/DICOM/UploadPage.jsx
@@ -468,9 +468,11 @@ function UploadPage() {
       // Check if any conversions succeeded
       const successCount = results.filter(function(r) { return r.success; }).length;
       if (successCount > 0) {
-        // Navigate to studies page to see the new FHIR resources
+        // Return to the launch tab if one was requested (?next — e.g. the DICOM
+        // Files tab override); otherwise default to the Imaging Studies tab to
+        // show the new FHIR resources.
         if (navigate) {
-          navigate('/dicom/studies' + forwardParams, { state: { aggregationResult: aggregationResult } });
+          navigate(nextUrl || ('/dicom/studies' + forwardParams), { state: { aggregationResult: aggregationResult } });
         }
       }
     } catch (err) {
@@ -723,10 +725,10 @@ function UploadPage() {
                 <Button
                   variant="outlined"
                   startIcon={<BackIcon />}
-                  onClick={() => navigate('/dicom/studies' + forwardParams)}
+                  onClick={() => navigate(nextUrl || ('/dicom/studies' + forwardParams))}
                   sx={{ color: cardTextColor }}
                 >
-                  Back to Studies
+                  {nextUrl && nextUrl.indexOf('tab=files') !== -1 ? 'Back to Files' : 'Back to Studies'}
                 </Button>
               )
             }

--- a/imports/ui/DICOM/UploadPage.jsx
+++ b/imports/ui/DICOM/UploadPage.jsx
@@ -32,7 +32,7 @@ import SimpleDicomViewport from './components/SimpleDicomViewport';
 import moment from 'moment';
 
 // DICOM parsing imports (dcmjs with dicom-parser fallback)
-import { extractAllDicomMetadataFromArrayBuffer, flattenDicomMetadataForGridFS } from './utils/DcmjsMetadata';
+import { extractAllDicomMetadataFromArrayBufferStream, flattenDicomMetadataForGridFS } from './utils/DcmjsMetadata';
 
 // Video file detection
 function isVideoFile(file) {
@@ -353,7 +353,9 @@ function UploadPage() {
   const parseDicomFile = async function(file) {
     try {
       const arrayBuffer = await file.arrayBuffer();
-      const metadata = extractAllDicomMetadataFromArrayBuffer(arrayBuffer);
+      // Parse via the dcmjs event stream (async; falls back to eager dcmjs →
+      // dicom-parser internally). Stamps parser: 'dcmjs-stream' on the result.
+      const metadata = await extractAllDicomMetadataFromArrayBufferStream(arrayBuffer);
       if (!metadata) {
         console.warn('[UploadPage] No metadata extracted from DICOM file:', file.name);
         return null;

--- a/imports/ui/DICOM/components/DicomFilesTable.jsx
+++ b/imports/ui/DICOM/components/DicomFilesTable.jsx
@@ -53,6 +53,36 @@ Meteor.startup(function() {
   }
 });
 
+// DICOM modalities that carry no pixel data — Structured Reports, key-object
+// selections, presentation states, encapsulated documents, audio, and
+// waveforms. The Cornerstone stack viewer has nothing to render for these and
+// throws "Viewport is not a valid type" the moment an image tool (window/level,
+// zoom) fires, so Preview is disabled for them. Unknown/blank modality falls
+// through to previewable (most files are images; don't block on missing data).
+const NON_IMAGE_MODALITIES = new Set([
+  'SR',       // Structured Report
+  'KO',       // Key Object Selection
+  'PR',       // Presentation State (GSPS)
+  'DOC',      // Encapsulated Document (PDF/CDA)
+  'AU',       // Audio
+  'ECG',      // Electrocardiogram waveform
+  'HD',       // Hemodynamic waveform
+  'EPS',      // Cardiac electrophysiology waveform
+  'RESP',     // Respiratory waveform
+  'REG',      // Spatial Registration
+  'SEG',      // Segmentation (needs a base image; not standalone-viewable)
+  'FID',      // Fiducials
+  'RTSTRUCT', // RT Structure Set
+  'RTPLAN',   // RT Plan
+  'RTRECORD', // RT Treatment Record
+  'PLAN'      // Plan
+]);
+
+function isPreviewableModality(modality) {
+  if (!modality || modality === '-') { return true; }
+  return !NON_IMAGE_MODALITIES.has(String(modality).toUpperCase());
+}
+
 /**
  * DicomFilesTable - Displays GridFS DICOM file metadata
  * Shows raw files stored in dicom.files collection
@@ -144,7 +174,11 @@ export default function DicomFilesTable({ isDark, cardTextColor, subheaderColor,
   function handlePreview(fileId, event) {
     event.stopPropagation();
     if (navigate) {
-      navigate('/dicom/viewer?file=' + fileId);
+      // Carry a back target (URL-encoded, since it has its own ?tab query) so
+      // the viewer's Back button returns to the DICOM Files tab rather than the
+      // default studies tab.
+      var back = encodeURIComponent('/dicom/studies?tab=files');
+      navigate('/dicom/viewer?file=' + fileId + '&back=' + back);
     } else {
       window.open('/api/dicom/files/' + fileId, '_blank');
     }
@@ -507,6 +541,7 @@ export default function DicomFilesTable({ isDark, cardTextColor, subheaderColor,
               const studyUid = file.studyInstanceUid;
               const seriesUid = file.seriesInstanceUid;
               const isLinked = !!(file.imagingStudyId || file.documentReferenceId);
+              const previewable = isPreviewableModality(file.modality);
 
               return (
                 <TableRow
@@ -519,15 +554,19 @@ export default function DicomFilesTable({ isDark, cardTextColor, subheaderColor,
                   }}
                 >
                   <TableCell>
-                    <Tooltip title="Preview DICOM file">
-                      <IconButton
-                        size="small"
-                        onClick={function(event) { handlePreview(file._id, event); }}
-                        sx={{ color: isDark ? '#90caf9' : '#1976d2' }}
-                        aria-label="Preview DICOM file"
-                      >
-                        <PreviewIcon fontSize="small" />
-                      </IconButton>
+                    <Tooltip title={previewable ? 'Preview DICOM file' : (modality + ' has no image to preview')}>
+                      {/* span wrapper so the Tooltip still fires on the disabled button */}
+                      <span>
+                        <IconButton
+                          size="small"
+                          disabled={!previewable}
+                          onClick={function(event) { handlePreview(file._id, event); }}
+                          sx={{ color: previewable ? (isDark ? '#90caf9' : '#1976d2') : undefined }}
+                          aria-label={previewable ? 'Preview DICOM file' : 'Preview unavailable for ' + modality}
+                        >
+                          <PreviewIcon fontSize="small" />
+                        </IconButton>
+                      </span>
                     </Tooltip>
                   </TableCell>
                   <TableCell>

--- a/imports/ui/DICOM/components/SimpleDicomViewport.jsx
+++ b/imports/ui/DICOM/components/SimpleDicomViewport.jsx
@@ -4,7 +4,7 @@
 
 import React, { useEffect, useRef, useState } from 'react';
 import { Box, CircularProgress, Typography } from '@mui/material';
-import { parseDicomFromBase64, parseDicomFromArrayBuffer, extractDicomMetadata, cleanupBlobUrl } from '../utils/SimpleDicomLoader';
+import { parseDicomFromBase64, parseDicomFromArrayBuffer, extractDicomMetadata, cleanupBlobUrl, buildFrameImageIds } from '../utils/SimpleDicomLoader';
 import { Toolbar } from './Toolbar';
 import { useTools } from '../hooks/useTools';
 import { initializeCornerstone3D } from '/imports/startup/client/cornerstone-setup';
@@ -29,6 +29,12 @@ export const SimpleDicomViewport = React.memo(function SimpleDicomViewport({ dic
   const [activeTool, setActiveTool] = useState('Wwwc');
   const [currentImageIndex, setCurrentImageIndex] = useState(1);
   const [totalImages, setTotalImages] = useState(1);
+  // A parsed DICOM object with no PixelData (7FE0,0010) or 0×0 dimensions — SR,
+  // KO, header-only test files, or an image modality that simply carries no
+  // pixels. There is nothing to render, and arming Cornerstone's image tools on
+  // such a viewport throws "Viewport is not a valid type" on the first drag, so
+  // we short-circuit before creating the rendering engine.
+  const [noImage, setNoImage] = useState(false);
 
   // Initialize tools — uses state (not ref) so useTools re-runs when engine is created
   const { setActiveTool: changeActiveTool, resetViewport, takeScreenshot } = useTools(
@@ -67,6 +73,7 @@ export const SimpleDicomViewport = React.memo(function SimpleDicomViewport({ dic
     async function loadAndRenderDicom() {
       setLoading(true);
       setError(null);
+      setNoImage(false);
 
       try {
         const imageIds = [];
@@ -107,9 +114,13 @@ export const SimpleDicomViewport = React.memo(function SimpleDicomViewport({ dic
           // Legacy path: parse from base64 string
           console.log('Parsing DICOM from base64 data...');
           firstParsed = parseDicomFromBase64(dicomData);
-          imageIds.push(firstParsed.imageId);
           runBlobUrls.push(firstParsed.blobUrl);
-          setTotalImages(1);
+          // Expand a multi-frame (cine) file into one image ID per frame so the
+          // stack-scroll wheel + "Image N/M" indicator step through frames.
+          const frameIdsA = buildFrameImageIds(firstParsed.imageId, firstParsed.numberOfFrames);
+          frameIdsA.forEach(function(id) { imageIds.push(id); });
+          setTotalImages(frameIdsA.length);
+          if (frameIdsA.length > 1) { console.log('Multi-frame DICOM:', frameIdsA.length, 'frames'); }
         } else if (dicomUrl) {
           // Single image path: fetch URL and parse from ArrayBuffer
           console.log('Fetching DICOM from URL:', dicomUrl);
@@ -121,9 +132,12 @@ export const SimpleDicomViewport = React.memo(function SimpleDicomViewport({ dic
           if (cancelled) return;
           console.log('Fetched DICOM file:', arrayBuffer.byteLength, 'bytes');
           firstParsed = parseDicomFromArrayBuffer(arrayBuffer);
-          imageIds.push(firstParsed.imageId);
           runBlobUrls.push(firstParsed.blobUrl);
-          setTotalImages(1);
+          // Expand a multi-frame (cine) file into one image ID per frame.
+          const frameIdsB = buildFrameImageIds(firstParsed.imageId, firstParsed.numberOfFrames);
+          frameIdsB.forEach(function(id) { imageIds.push(id); });
+          setTotalImages(frameIdsB.length);
+          if (frameIdsB.length > 1) { console.log('Multi-frame DICOM:', frameIdsB.length, 'frames'); }
         }
 
         if (cancelled) return;
@@ -132,6 +146,25 @@ export const SimpleDicomViewport = React.memo(function SimpleDicomViewport({ dic
         const meta = extractDicomMetadata(firstParsed.dataSet);
         console.log('DICOM metadata:', meta);
         setMetadata(meta);
+
+        // Pixel-data guard: no PixelData element (7FE0,0010) or 0×0 dimensions
+        // means there is no image to render. Skip engine/stack/tool init so
+        // Cornerstone never arms the image tools on a pixel-less viewport (which
+        // throws "Viewport is not a valid type" on the first drag). Show the
+        // "no image" state instead. (The Files table already disables Preview
+        // for non-image modalities; this also covers image-modality files that
+        // carry no pixels, and direct deep-links to the viewer.)
+        const ds = firstParsed.dataSet;
+        const hasPixelDataElement = !!(ds && ds.elements && ds.elements.x7fe00010);
+        const hasDimensions = meta.rows > 0 && meta.columns > 0;
+        if (!hasPixelDataElement || !hasDimensions) {
+          console.warn('[SimpleDicomViewport] No renderable pixel data (rows=' + meta.rows + ', cols=' + meta.columns + ', pixelData=' + hasPixelDataElement + ') — skipping viewport init');
+          if (!cancelled) {
+            setNoImage(true);
+            setLoading(false);
+          }
+          return;
+        }
 
         // CRITICAL: Ensure Cornerstone is fully initialized (not just checking existence)
         // This awaits the initialization promise which registers image loaders
@@ -358,8 +391,8 @@ export const SimpleDicomViewport = React.memo(function SimpleDicomViewport({ dic
         flexDirection: 'column',
       }}
     >
-      {/* Toolbar */}
-      {metadata && !loading && !error && (
+      {/* Toolbar — hidden when there is no image (tools would have nothing to act on) */}
+      {metadata && !loading && !error && !noImage && (
         <Toolbar
           activeTool={activeTool}
           onToolChange={handleToolChange}
@@ -438,8 +471,31 @@ export const SimpleDicomViewport = React.memo(function SimpleDicomViewport({ dic
         </Box>
       )}
 
+      {/* No-image state — parsed OK but carries no renderable pixel data */}
+      {noImage && !loading && !error && (
+        <Box
+          sx={{
+            position: 'absolute',
+            top: '50%',
+            left: '50%',
+            transform: 'translate(-50%, -50%)',
+            textAlign: 'center',
+            color: 'text.secondary',
+            p: 3,
+            maxWidth: '80%',
+          }}
+        >
+          <Typography variant="h6" gutterBottom sx={{ color: 'white' }}>
+            No image to display
+          </Typography>
+          <Typography variant="body2" sx={{ color: 'rgba(255,255,255,0.7)' }}>
+            This DICOM file{metadata && metadata.modality && metadata.modality !== 'N/A' ? ' (' + metadata.modality + ')' : ''} contains no image pixel data.
+          </Typography>
+        </Box>
+      )}
+
       {/* Metadata overlay */}
-      {metadata && !loading && !error && (
+      {metadata && !loading && !error && !noImage && (
         <Box
           sx={{
             position: 'absolute',

--- a/imports/ui/DICOM/utils/DcmjsMetadata.js
+++ b/imports/ui/DICOM/utils/DcmjsMetadata.js
@@ -24,6 +24,7 @@ const log = (typeof Meteor !== 'undefined' && Meteor.Logger)
 
 const { DicomMessage, DicomMetaDictionary } = dcmjs.data;
 const fhir = dcmjs.fhir;
+const eventStream = dcmjs.eventStream;
 
 /**
  * Check for the DICOM Part 10 magic bytes ('DICM' at offset 128).
@@ -185,5 +186,44 @@ export function extractAllDicomMetadataFromArrayBuffer(arrayBuffer, options = {}
     // dicom-parser throws plain strings, not Error instances
     log.warn('[DcmjsMetadata] dicom-parser fallback also failed', { error: String(fallbackError && fallbackError.message || fallbackError) });
     return null;
+  }
+}
+
+/**
+ * Streaming variant of extractAllDicomMetadataFromArrayBuffer: parses via the
+ * dcmjs EVENT STREAM (the SAX-style push core — DicomEventStream.fromPart10 →
+ * NaturalizedListener) instead of the eager in-place reader. Proven at parity
+ * with the eager path across our fixtures (and strictly more robust on
+ * malformed files — it recovers metadata where eager throws), so it is the
+ * preferred path where an async call site allows it.
+ *
+ * ASYNC: the event stream is generator-driven with backpressure, so this
+ * returns a Promise (unlike the sync eager sibling). Falls back to the sync
+ * eager dcmjs → dicom-parser chain on any stream failure, so the fallback net
+ * is never weaker than before.
+ *
+ * Stamps metadata.parser = 'dcmjs-stream' so stored dicom.files records show
+ * exactly which parser produced them.
+ * @param {ArrayBuffer} arrayBuffer - File contents
+ * @param {Object} [options] - Passed to DicomEventStream.fromPart10
+ * @returns {Promise<Object|null>} - { patient, study, series, instance } or null
+ */
+export async function extractAllDicomMetadataFromArrayBufferStream(arrayBuffer, options = {}) {
+  try {
+    if (!eventStream || !eventStream.DicomEventStream) {
+      throw new Error('dcmjs.eventStream unavailable in this bundle');
+    }
+    const dataset = await eventStream.DicomEventStream
+      .fromPart10(arrayBuffer, options)
+      .toNaturalized();
+    const metadata = nestedMetadataFromNaturalized(dataset);
+    metadata.parser = 'dcmjs-stream';
+    Object.defineProperty(metadata, 'dataset', { value: dataset, enumerable: false });
+    log.info('[DcmjsMetadata] extracted metadata via dcmjs event stream', { studyInstanceUid: get(metadata, 'study.studyInstanceUid') });
+    return metadata;
+  } catch (streamError) {
+    log.warn('[DcmjsMetadata] event-stream parse failed, falling back to eager dcmjs / dicom-parser', { error: String(streamError && streamError.message || streamError) });
+    // eager dcmjs → dicom-parser (synchronous), never weaker than before.
+    return extractAllDicomMetadataFromArrayBuffer(arrayBuffer, options);
   }
 }

--- a/imports/ui/DICOM/utils/DcmjsMetadata.test.mjs
+++ b/imports/ui/DICOM/utils/DcmjsMetadata.test.mjs
@@ -20,6 +20,7 @@ import {
   parseDicomWithDcmjs,
   nestedMetadataFromNaturalized,
   extractAllDicomMetadataFromArrayBuffer,
+  extractAllDicomMetadataFromArrayBufferStream,
   flattenDicomMetadataForGridFS,
   isDicomPart10
 } from './DcmjsMetadata.js';
@@ -160,5 +161,38 @@ test('flattenDicomMetadataForGridFS produces the flat shape /api/dicom/upload pe
 test('garbage input falls back gracefully and returns null', function() {
   const garbage = new TextEncoder().encode('definitely not dicom content at all').buffer;
   const metadata = extractAllDicomMetadataFromArrayBuffer(garbage);
+  assert.equal(metadata, null);
+});
+
+test('event-stream extraction is at parity with the eager reader and stamps its own provenance', async function() {
+  const arrayBuffer = loadFixtureArrayBuffer();
+
+  const streamed = await extractAllDicomMetadataFromArrayBufferStream(arrayBuffer);
+  const eager = extractAllDicomMetadataFromArrayBuffer(arrayBuffer);
+
+  assert.ok(streamed, 'event-stream metadata should be extracted');
+  assert.equal(streamed.parser, 'dcmjs-stream', 'provenance marker records the event-stream path');
+
+  // Same nested { patient, study, series, instance } values as the eager
+  // reader — the SAX push core must produce identical naturalized metadata.
+  // (parser differs by design: 'dcmjs-stream' vs 'dcmjs'.)
+  assert.deepEqual(streamed.patient, eager.patient);
+  assert.deepEqual(streamed.study, eager.study);
+  assert.deepEqual(streamed.series, eager.series);
+  assert.deepEqual(streamed.instance, eager.instance);
+
+  // The naturalized dataset rides along non-enumerably here too.
+  assert.ok(streamed.dataset, 'hidden dataset property attached on the stream path');
+  assert.equal(streamed.dataset.Modality, 'MR');
+  assert.equal(Object.keys(streamed).includes('dataset'), false);
+
+  // Flattened GridFS metadata carries the stream provenance forward.
+  const flat = flattenDicomMetadataForGridFS(streamed);
+  assert.equal(flat.parser, 'dcmjs-stream');
+});
+
+test('event-stream extraction falls back cleanly on garbage input', async function() {
+  const garbage = new TextEncoder().encode('definitely not dicom content at all').buffer;
+  const metadata = await extractAllDicomMetadataFromArrayBufferStream(garbage);
   assert.equal(metadata, null);
 });

--- a/imports/ui/DICOM/utils/SimpleDicomLoader.js
+++ b/imports/ui/DICOM/utils/SimpleDicomLoader.js
@@ -5,6 +5,40 @@
 import dicomParser from 'dicom-parser';
 
 /**
+ * Read NumberOfFrames (0028,0008) as an integer. Returns 1 for single-frame or
+ * when the tag is absent/unparseable.
+ * @param {Object} dataSet - Parsed DICOM dataset
+ * @returns {number}
+ */
+export function readNumberOfFrames(dataSet) {
+  try {
+    const nf = dataSet.intString('x00280008');
+    return (nf && nf > 1) ? nf : 1;
+  } catch (e) {
+    return 1;
+  }
+}
+
+/**
+ * Expand a base wadouri image ID into one image ID per frame for a multi-frame
+ * DICOM. The Cornerstone dicom-image-loader (v1.86) wadouri scheme uses a
+ * 1-based `&frame=N` suffix (verified against its own multiframe generator), so
+ * frames run 1..numberOfFrames. Single-frame files return the base ID unchanged.
+ * @param {string} imageId - Base image ID (e.g. 'wadouri:blob:...')
+ * @param {number} numberOfFrames
+ * @returns {string[]}
+ */
+export function buildFrameImageIds(imageId, numberOfFrames) {
+  const n = numberOfFrames || 1;
+  if (n <= 1) { return [imageId]; }
+  const ids = [];
+  for (let f = 1; f <= n; f++) {
+    ids.push(imageId + '&frame=' + f);
+  }
+  return ids;
+}
+
+/**
  * Parse DICOM file from base64 data and create Cornerstone image ID
  * @param {string} base64Data - Base64 encoded DICOM file
  * @returns {Object} - Parsed DICOM info with imageId for Cornerstone
@@ -42,7 +76,8 @@ export function parseDicomFromBase64(base64Data) {
       byteArray: bytes,
       transferSyntax: transferSyntax,
       imageId: imageId,
-      blobUrl: blobUrl
+      blobUrl: blobUrl,
+      numberOfFrames: readNumberOfFrames(dataSet)
     };
   } catch (error) {
     console.error('Error parsing DICOM:', error);
@@ -123,7 +158,8 @@ export function parseDicomFromArrayBuffer(arrayBuffer) {
       byteArray: bytes,
       transferSyntax: transferSyntax,
       imageId: imageId,
-      blobUrl: blobUrl
+      blobUrl: blobUrl,
+      numberOfFrames: readNumberOfFrames(dataSet)
     };
   } catch (error) {
     console.error('Error parsing DICOM from ArrayBuffer:', error);

--- a/imports/ui/ThemeDialog.jsx
+++ b/imports/ui/ThemeDialog.jsx
@@ -2,9 +2,10 @@
 //
 // The theme palette dialog — a modal overlay (open via the Header palette icon
 // or Ctrl/Cmd+Shift+T) that restyles the app live over whatever page is
-// underneath. The controls (preset tiles, font, mode, accent hue, ambiance)
-// are the shared <ThemeControls>; an "Advanced — per-field palette" collapsible
-// holds the shared <PaletteFieldEditor> (live adapter → per-field overrides
+// underneath. The controls (preset tiles, ambiance, font, mode, page text,
+// card surface) are the shared <ThemeControls>; an "Advanced — palette &
+// accent" collapsible holds the shared <PaletteFieldEditor> (accordion field
+// groups + the field-bound color wheel; live adapter → per-field overrides
 // that persist via setPaletteOverride). "Open full editor" hands off to
 // /theming, which mounts the SAME two components in its left column.
 //
@@ -75,7 +76,7 @@ export function ThemeDialog() {
           startIcon={advancedOpen ? <ExpandLessIcon /> : <ExpandMoreIcon />}
           sx={{ textTransform: 'none' }}
         >
-          Advanced — per-field palette
+          Advanced — palette &amp; accent
         </Button>
         <Collapse in={advancedOpen} unmountOnExit>
           <Box sx={{ mt: 2 }}>

--- a/imports/ui/ThemeDialog.jsx
+++ b/imports/ui/ThemeDialog.jsx
@@ -1,142 +1,50 @@
 // imports/ui/ThemeDialog.jsx
 //
 // The theme palette dialog — a modal overlay (open via the Header palette icon
-// or Ctrl/Cmd+Shift+T) that lets you restyle the app live over whatever page is
-// underneath. Four independent axes: a primary preset (Limestone / Tron /
-// Vaporwave), a font, an accent hue (the mono→single-hue slider), and an
-// ambiance background carousel. Each applies immediately (via the themePresets
-// helpers → themeRefreshRequest) and persists (localStorage). "Open full editor"
-// hands off to /theming for granular per-field color control.
+// or Ctrl/Cmd+Shift+T) that restyles the app live over whatever page is
+// underneath. The controls (preset tiles, font, mode, accent hue, ambiance)
+// are the shared <ThemeControls>; an "Advanced — per-field palette" collapsible
+// holds the shared <PaletteFieldEditor> (live adapter → per-field overrides
+// that persist via setPaletteOverride). "Open full editor" hands off to
+// /theming, which mounts the SAME two components in its left column.
 //
 // Mounted once at App root (App.jsx) beside SessionInspectorDialog; open state
-// rides the THEME_DIALOG_OPEN Session key — the same precedent.
+// rides the THEME_DIALOG_OPEN Session key.
 
 import React from 'react';
 import {
   Dialog, DialogTitle, DialogContent, DialogActions, Box, Typography, Button,
-  IconButton, ButtonBase, Chip, Divider, Select, MenuItem, FormControl,
-  InputLabel, Stack, Tooltip
+  IconButton, Divider, Collapse
 } from '@mui/material';
 import CloseIcon from '@mui/icons-material/Close';
-import LightModeIcon from '@mui/icons-material/LightMode';
-import DarkModeIcon from '@mui/icons-material/DarkMode';
 import OpenInFullIcon from '@mui/icons-material/OpenInFull';
-import { darken } from '@mui/material/styles';
-import Wheel from '@uiw/react-color-wheel';
-import { hsvaToHex, hexToHsva } from '@uiw/color-convert';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import ExpandLessIcon from '@mui/icons-material/ExpandLess';
 import { useNavigate } from 'react-router-dom';
-import { Meteor } from 'meteor/meteor';
 import { Session } from 'meteor/session';
 import { useTracker } from 'meteor/react-meteor-data';
-import { get } from 'lodash';
-import { useTheme } from './CustomThemeProvider.jsx';
+import { getThemeSetting } from './CustomThemeProvider.jsx';
 import { THEME_DIALOG_OPEN } from '/imports/lib/SessionKeys.js';
-import {
-  THEME_PRESETS, DEFAULT_FONT, CHAKRA_FONT, MARTIAN_FONT,
-  applyThemePreset, setAccentHue, setThemeFont, setThemeBackground
-} from './themePresets.js';
-import { getBackgroundLibrary } from './themeBackgrounds.js';
-import { loadThemeChoice } from '/imports/lib/themePersistence.js';
+import { setPaletteOverride } from './themePresets.js';
+import { ThemeControls } from './theme/ThemeControls.jsx';
+import { PaletteFieldEditor } from './theme/PaletteFieldEditor.jsx';
 
-const FONT_OPTIONS = [
-  { label: 'Default (Helvetica)', value: '' },
-  { label: 'Chakra Petch', value: CHAKRA_FONT },
-  { label: 'Martian Mono', value: MARTIAN_FONT }
-];
-
-// The palette keys a tile previews, in swatch/hex order.
-const SWATCH_KEYS = ['primaryColor', 'secondaryColor', 'successColor', 'infoColor', 'errorColor'];
-
-// Resolve a preset's preview palette. For the ACTIVE accent-driven preset
-// (Tron/Limestone), the lead + secondary swatches reflect the LIVE dialed hue
-// so the tile tracks the wheel; fixed multi-hue presets (Vaporwave) and
-// inactive tiles show their declared palette.
-function previewPalette(preset, liveAccent) {
-  const base = Object.assign({}, preset.palette);
-  if (liveAccent && !preset.advanced) {
-    base.primaryColor = liveAccent;
-    base.secondaryColor = darken(liveAccent, 0.3);
-  }
-  return base;
+// Live adapter: read the sanitized live setting, write a persisted per-field
+// override (setPaletteOverride writes settings + saveThemeChoice + refresh).
+function liveGetValue(key) {
+  return getThemeSetting('settings.public.theme.palette.' + key, '');
 }
-
-// Swatch strip preview for a preset tile.
-function PresetSwatches({ palette }) {
-  return (
-    <Box sx={{ display: 'flex', gap: 0.5, mt: 1 }}>
-      {SWATCH_KEYS.map(function(k) {
-        const c = get(palette, k);
-        if (!c) { return null; }
-        return <Box key={k} sx={{ width: 20, height: 20, borderRadius: '3px', bgcolor: c, border: '1px solid rgba(255,255,255,0.15)' }} />;
-      })}
-    </Box>
-  );
-}
-
-// Vertical hex readout — replaces the opaque "Aa Bb Cc 0123" font sample with
-// the tile's actual palette values, so each preset is legible as color data.
-function PresetHexList({ palette }) {
-  const rows = [
-    ['accent', get(palette, 'primaryColor')],
-    ['second', get(palette, 'secondaryColor')],
-    ['canvas', get(palette, 'backgroundCanvasDark') || get(palette, 'canvasColor')],
-    ['paper', get(palette, 'paperColorDark') || get(palette, 'paperColor')]
-  ].filter(function(r) { return !!r[1]; });
-  return (
-    <Box sx={{ mt: 1.5, display: 'grid', gridTemplateColumns: 'auto 1fr', rowGap: 0.25, columnGap: 1 }}>
-      {rows.map(function(row) {
-        return (
-          <React.Fragment key={row[0]}>
-            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75 }}>
-              <Box sx={{ width: 11, height: 11, borderRadius: '2px', bgcolor: row[1], border: '1px solid rgba(255,255,255,0.15)' }} />
-              <Typography variant="caption" color="text.secondary" sx={{ fontSize: 10, letterSpacing: '0.06em' }}>{row[0]}</Typography>
-            </Box>
-            <Typography variant="caption" sx={{ fontFamily: 'monospace', fontSize: 11, color: 'text.primary' }}>
-              {String(row[1]).toLowerCase()}
-            </Typography>
-          </React.Fragment>
-        );
-      })}
-    </Box>
-  );
+function liveSetValue(key, value) {
+  setPaletteOverride(key, value);
 }
 
 export function ThemeDialog() {
   const open = useTracker(function() { return !!Session.get(THEME_DIALOG_OPEN); }, []);
-  const mode = useTracker(function() { return Session.get('theme') || 'light'; }, []);
   const navigate = useNavigate();
-  const themeCtx = useTheme() || {};
-
-  // Current selections (from the persisted choice, so the dialog reflects state).
-  const choice = loadThemeChoice() || {};
-  const activePreset = choice.presetId || get(Meteor, 'settings.public.theme.defaultPreset', 'limestone');
-  const activeFont = get(Meteor, 'settings.public.theme.typography.fontFamily', '') || '';
-  const activeBg = get(Meteor, 'settings.public.theme.backgroundImagePath', '') || '';
-
-  // Hue wheel local state, initialized from the current accent when the dialog
-  // opens (so the wheel + the active tile's live swatches start truthful, not
-  // at an arbitrary amber default).
-  const currentAccent = get(Meteor, 'settings.public.theme.palette.primaryColor', '#53e6ff');
-  const [hsva, setHsva] = React.useState(function() {
-    try { return Object.assign({ a: 1 }, hexToHsva(currentAccent)); }
-    catch (e) { return { h: 40, s: 70, v: 100, a: 1 }; }
-  });
-  React.useEffect(function() {
-    if (open) {
-      try { setHsva(Object.assign({ a: 1 }, hexToHsva(currentAccent))); } catch (e) { /* keep prior */ }
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [open]);
-
-  const liveAccent = hsvaToHex(hsva);
+  const [advancedOpen, setAdvancedOpen] = React.useState(false);
 
   function handleClose() {
     Session.set(THEME_DIALOG_OPEN, false);
-  }
-
-  function handleMode() {
-    if (themeCtx.toggleTheme) { themeCtx.toggleTheme(); }
-    else { Session.set('theme', mode === 'light' ? 'dark' : 'light'); }
   }
 
   if (!open) { return null; }
@@ -156,134 +64,24 @@ export function ThemeDialog() {
       </DialogTitle>
 
       <DialogContent dividers>
-        {/* Primary preset tiles */}
-        <Typography variant="overline" color="text.secondary">Preset</Typography>
-        <Box sx={{ display: 'grid', gridTemplateColumns: { xs: '1fr', sm: 'repeat(3, 1fr)' }, gap: 2, mt: 1, mb: 3 }}>
-          {THEME_PRESETS.map(function(preset) {
-            const selected = preset.id === activePreset;
-            return (
-              <ButtonBase
-                key={preset.id}
-                id={'themePreset-' + preset.id}
-                onClick={function() { applyThemePreset(preset.id); }}
-                sx={{
-                  display: 'block', textAlign: 'left', p: 2, borderRadius: '8px',
-                  border: '2px solid', borderColor: selected ? 'primary.main' : 'divider',
-                  bgcolor: 'background.default',
-                  transition: 'border-color 0.15s ease, transform 0.15s ease',
-                  '&:hover': { transform: 'translateY(-2px)', borderColor: 'primary.light' }
-                }}
-              >
-                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                  <Typography variant="subtitle1" sx={{ fontWeight: 700 }}>{preset.name}</Typography>
-                  {preset.advanced ? <Chip label="Advanced · 3-hue" size="small" color="warning" variant="outlined" /> : null}
-                </Box>
-                <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 0.5, minHeight: 32 }}>
-                  {preset.description}
-                </Typography>
-                <PresetSwatches palette={previewPalette(preset, selected ? liveAccent : null)} />
-                <PresetHexList palette={previewPalette(preset, selected ? liveAccent : null)} />
-              </ButtonBase>
-            );
-          })}
-        </Box>
+        <ThemeControls compact />
 
-        <Divider sx={{ mb: 3 }} />
+        <Divider sx={{ my: 2 }} />
 
-        {/* Font + mode + hue row */}
-        <Box sx={{ display: 'grid', gridTemplateColumns: { xs: '1fr', md: '1fr 1fr' }, gap: 3, mb: 3 }}>
-          <Stack spacing={2}>
-            <FormControl fullWidth size="small">
-              <InputLabel id="themeFontLabel">Font</InputLabel>
-              <Select
-                labelId="themeFontLabel"
-                id="themeFontSelect"
-                label="Font"
-                value={activeFont}
-                onChange={function(e) { setThemeFont(e.target.value); }}
-              >
-                {FONT_OPTIONS.map(function(opt) {
-                  return (
-                    <MenuItem key={opt.value} value={opt.value} sx={{ fontFamily: opt.value || 'inherit' }}>
-                      {opt.label}
-                    </MenuItem>
-                  );
-                })}
-              </Select>
-            </FormControl>
-
-            <Box>
-              <Typography variant="overline" color="text.secondary">Mode</Typography>
-              <Box>
-                <Tooltip title={mode === 'light' ? 'Switch to dark' : 'Switch to light'}>
-                  <Button
-                    id="themeModeToggle"
-                    variant="outlined" size="small"
-                    startIcon={mode === 'light' ? <LightModeIcon /> : <DarkModeIcon />}
-                    onClick={handleMode}
-                  >
-                    {mode === 'light' ? 'Light' : 'Dark'}
-                  </Button>
-                </Tooltip>
-              </Box>
-            </Box>
-          </Stack>
-
-          <Box>
-            <Typography variant="overline" color="text.secondary">Accent hue</Typography>
-            <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, mt: 1 }}>
-              <Wheel
-                color={hsva}
-                onChange={function(color) {
-                  setHsva(color.hsva);
-                  setAccentHue(hsvaToHex(color.hsva));
-                }}
-                width={120}
-                height={120}
-              />
-              <Box>
-                <Box sx={{ width: 40, height: 40, borderRadius: '4px', bgcolor: liveAccent, border: '1px solid var(--divider, rgba(0,0,0,0.2))' }} />
-                <Typography variant="caption" sx={{ fontFamily: 'monospace' }}>{liveAccent}</Typography>
-                <Typography variant="caption" color="text.secondary" sx={{ display: 'block' }}>
-                  Desaturate → Limestone · saturate → Tron
-                </Typography>
-              </Box>
-            </Box>
+        <Button
+          id="themeAdvancedToggle"
+          size="small"
+          onClick={function() { setAdvancedOpen(function(v) { return !v; }); }}
+          startIcon={advancedOpen ? <ExpandLessIcon /> : <ExpandMoreIcon />}
+          sx={{ textTransform: 'none' }}
+        >
+          Advanced — per-field palette
+        </Button>
+        <Collapse in={advancedOpen} unmountOnExit>
+          <Box sx={{ mt: 2 }}>
+            <PaletteFieldEditor getValue={liveGetValue} setValue={liveSetValue} />
           </Box>
-        </Box>
-
-        <Divider sx={{ mb: 2 }} />
-
-        {/* Ambiance background carousel */}
-        <Typography variant="overline" color="text.secondary">Ambiance background</Typography>
-        <Box sx={{ display: 'flex', gap: 1.5, overflowX: 'auto', pb: 1, mt: 1 }}>
-          <ButtonBase
-            onClick={function() { setThemeBackground(''); }}
-            sx={{
-              flex: '0 0 auto', width: 96, height: 60, borderRadius: '6px',
-              border: '2px solid', borderColor: !activeBg ? 'primary.main' : 'divider',
-              bgcolor: 'background.default', fontSize: 11, color: 'text.secondary'
-            }}
-          >
-            None
-          </ButtonBase>
-          {getBackgroundLibrary().map(function(bg) {
-            const selected = activeBg === bg.src;
-            return (
-              <Tooltip key={bg.src} title={bg.name}>
-                <ButtonBase
-                  onClick={function() { setThemeBackground(bg.src); }}
-                  sx={{
-                    flex: '0 0 auto', width: 96, height: 60, borderRadius: '6px', overflow: 'hidden',
-                    border: '2px solid', borderColor: selected ? 'primary.main' : 'divider',
-                    backgroundImage: 'url(' + bg.src + ')', backgroundSize: 'cover', backgroundPosition: 'center',
-                    transition: 'transform 0.15s ease', '&:hover': { transform: 'scale(1.04)' }
-                  }}
-                />
-              </Tooltip>
-            );
-          })}
-        </Box>
+        </Collapse>
       </DialogContent>
 
       <DialogActions sx={{ justifyContent: 'space-between', px: 3 }}>

--- a/imports/ui/ThemeDialog.jsx
+++ b/imports/ui/ThemeDialog.jsx
@@ -21,8 +21,9 @@ import CloseIcon from '@mui/icons-material/Close';
 import LightModeIcon from '@mui/icons-material/LightMode';
 import DarkModeIcon from '@mui/icons-material/DarkMode';
 import OpenInFullIcon from '@mui/icons-material/OpenInFull';
+import { darken } from '@mui/material/styles';
 import Wheel from '@uiw/react-color-wheel';
-import { hsvaToHex } from '@uiw/color-convert';
+import { hsvaToHex, hexToHsva } from '@uiw/color-convert';
 import { useNavigate } from 'react-router-dom';
 import { Meteor } from 'meteor/meteor';
 import { Session } from 'meteor/session';
@@ -43,15 +44,58 @@ const FONT_OPTIONS = [
   { label: 'Martian Mono', value: MARTIAN_FONT }
 ];
 
+// The palette keys a tile previews, in swatch/hex order.
+const SWATCH_KEYS = ['primaryColor', 'secondaryColor', 'successColor', 'infoColor', 'errorColor'];
+
+// Resolve a preset's preview palette. For the ACTIVE accent-driven preset
+// (Tron/Limestone), the lead + secondary swatches reflect the LIVE dialed hue
+// so the tile tracks the wheel; fixed multi-hue presets (Vaporwave) and
+// inactive tiles show their declared palette.
+function previewPalette(preset, liveAccent) {
+  const base = Object.assign({}, preset.palette);
+  if (liveAccent && !preset.advanced) {
+    base.primaryColor = liveAccent;
+    base.secondaryColor = darken(liveAccent, 0.3);
+  }
+  return base;
+}
+
 // Swatch strip preview for a preset tile.
 function PresetSwatches({ palette }) {
-  const keys = ['primaryColor', 'secondaryColor', 'successColor', 'infoColor', 'errorColor'];
   return (
     <Box sx={{ display: 'flex', gap: 0.5, mt: 1 }}>
-      {keys.map(function(k) {
+      {SWATCH_KEYS.map(function(k) {
         const c = get(palette, k);
         if (!c) { return null; }
         return <Box key={k} sx={{ width: 20, height: 20, borderRadius: '3px', bgcolor: c, border: '1px solid rgba(255,255,255,0.15)' }} />;
+      })}
+    </Box>
+  );
+}
+
+// Vertical hex readout — replaces the opaque "Aa Bb Cc 0123" font sample with
+// the tile's actual palette values, so each preset is legible as color data.
+function PresetHexList({ palette }) {
+  const rows = [
+    ['accent', get(palette, 'primaryColor')],
+    ['second', get(palette, 'secondaryColor')],
+    ['canvas', get(palette, 'backgroundCanvasDark') || get(palette, 'canvasColor')],
+    ['paper', get(palette, 'paperColorDark') || get(palette, 'paperColor')]
+  ].filter(function(r) { return !!r[1]; });
+  return (
+    <Box sx={{ mt: 1.5, display: 'grid', gridTemplateColumns: 'auto 1fr', rowGap: 0.25, columnGap: 1 }}>
+      {rows.map(function(row) {
+        return (
+          <React.Fragment key={row[0]}>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75 }}>
+              <Box sx={{ width: 11, height: 11, borderRadius: '2px', bgcolor: row[1], border: '1px solid rgba(255,255,255,0.15)' }} />
+              <Typography variant="caption" color="text.secondary" sx={{ fontSize: 10, letterSpacing: '0.06em' }}>{row[0]}</Typography>
+            </Box>
+            <Typography variant="caption" sx={{ fontFamily: 'monospace', fontSize: 11, color: 'text.primary' }}>
+              {String(row[1]).toLowerCase()}
+            </Typography>
+          </React.Fragment>
+        );
       })}
     </Box>
   );
@@ -69,8 +113,22 @@ export function ThemeDialog() {
   const activeFont = get(Meteor, 'settings.public.theme.typography.fontFamily', '') || '';
   const activeBg = get(Meteor, 'settings.public.theme.backgroundImagePath', '') || '';
 
-  // Hue wheel local state.
-  const [hsva, setHsva] = React.useState({ h: 40, s: 70, v: 100, a: 1 });
+  // Hue wheel local state, initialized from the current accent when the dialog
+  // opens (so the wheel + the active tile's live swatches start truthful, not
+  // at an arbitrary amber default).
+  const currentAccent = get(Meteor, 'settings.public.theme.palette.primaryColor', '#53e6ff');
+  const [hsva, setHsva] = React.useState(function() {
+    try { return Object.assign({ a: 1 }, hexToHsva(currentAccent)); }
+    catch (e) { return { h: 40, s: 70, v: 100, a: 1 }; }
+  });
+  React.useEffect(function() {
+    if (open) {
+      try { setHsva(Object.assign({ a: 1 }, hexToHsva(currentAccent))); } catch (e) { /* keep prior */ }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
+
+  const liveAccent = hsvaToHex(hsva);
 
   function handleClose() {
     Session.set(THEME_DIALOG_OPEN, false);
@@ -123,10 +181,8 @@ export function ThemeDialog() {
                 <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 0.5, minHeight: 32 }}>
                   {preset.description}
                 </Typography>
-                <PresetSwatches palette={preset.palette} />
-                <Typography sx={{ mt: 1, fontFamily: preset.fontFamily || 'inherit', fontSize: 15 }}>
-                  Aa Bb Cc 0123
-                </Typography>
+                <PresetSwatches palette={previewPalette(preset, selected ? liveAccent : null)} />
+                <PresetHexList palette={previewPalette(preset, selected ? liveAccent : null)} />
               </ButtonBase>
             );
           })}
@@ -186,8 +242,8 @@ export function ThemeDialog() {
                 height={120}
               />
               <Box>
-                <Box sx={{ width: 40, height: 40, borderRadius: '4px', bgcolor: hsvaToHex(hsva), border: '1px solid var(--divider, rgba(0,0,0,0.2))' }} />
-                <Typography variant="caption" sx={{ fontFamily: 'monospace' }}>{hsvaToHex(hsva)}</Typography>
+                <Box sx={{ width: 40, height: 40, borderRadius: '4px', bgcolor: liveAccent, border: '1px solid var(--divider, rgba(0,0,0,0.2))' }} />
+                <Typography variant="caption" sx={{ fontFamily: 'monospace' }}>{liveAccent}</Typography>
                 <Typography variant="caption" color="text.secondary" sx={{ display: 'block' }}>
                   Desaturate → Limestone · saturate → Tron
                 </Typography>

--- a/imports/ui/ThemingPage.jsx
+++ b/imports/ui/ThemingPage.jsx
@@ -1,4 +1,14 @@
-import React, { useState, Fragment, useMemo } from 'react';
+// imports/ui/ThemingPage.jsx
+//
+// The /theming full editor. LEFT column = the SAME shared controls the Theme &
+// Palette dialog uses (<ThemeControls> + <PaletteFieldEditor>), so the two
+// surfaces are harmonized. RIGHT column = the live preview (independent
+// ThemeProvider built from the page's draft state). Field edits stage in local
+// state and drive the preview; "Load Theme Into Settings" writes them into
+// Meteor.settings AND persists the canonical per-field values as
+// paletteOverrides (survive reload, re-applied after the preset at boot).
+
+import React, { useState, useMemo } from 'react';
 
 import "ace-builds";
 import AceEditor from "react-ace";
@@ -6,17 +16,12 @@ import "ace-builds/src-noconflict/mode-json";
 import "ace-builds/src-noconflict/theme-github";
 import "ace-builds/src-noconflict/theme-monokai";
 
-import { Info } from './Index'
 import { useNavigate } from "react-router-dom";
 
-import Switch from '@mui/material/Switch';
-import FormGroup from '@mui/material/FormGroup';
-import FormControlLabel from '@mui/material/FormControlLabel';
 import { useTheme as useMuiTheme } from '@mui/material/styles';
 import Paper from '@mui/material/Paper';
 import Typography from '@mui/material/Typography';
 import Box from '@mui/material/Box';
-import TextField from '@mui/material/TextField';
 import Grid from '@mui/material/Grid';
 import Divider from '@mui/material/Divider';
 import FormControl from '@mui/material/FormControl';
@@ -26,553 +31,168 @@ import MenuItem from '@mui/material/MenuItem';
 import Button from '@mui/material/Button';
 import Snackbar from '@mui/material/Snackbar';
 import Alert from '@mui/material/Alert';
-import Dialog from '@mui/material/Dialog';
-import DialogTitle from '@mui/material/DialogTitle';
-import DialogContent from '@mui/material/DialogContent';
-import DialogActions from '@mui/material/DialogActions';
-import IconButton from '@mui/material/IconButton';
-import InputAdornment from '@mui/material/InputAdornment';
-import PaletteIcon from '@mui/icons-material/Palette';
+import Card from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
+import { createTheme, ThemeProvider } from '@mui/material/styles';
 import { get } from 'lodash';
 import { Meteor } from 'meteor/meteor';
 import { Session } from 'meteor/session';
 
-import { history, useTheme } from './App';
-import { alpha } from '@mui/material/styles';
-import Card from '@mui/material/Card';
-import CardContent from '@mui/material/CardContent';
-import { createTheme, ThemeProvider } from '@mui/material/styles';
-
-import Wheel from '@uiw/react-color-wheel';
-import ShadeSlider from '@uiw/react-color-shade-slider';
-import { hsvaToHex } from '@uiw/color-convert';
-
+import { useTheme } from './App';
+import { ThemeControls } from './theme/ThemeControls.jsx';
+import { PaletteFieldEditor, PALETTE_FIELD_GROUPS } from './theme/PaletteFieldEditor.jsx';
+import { saveThemeChoice } from '/imports/lib/themePersistence.js';
 
 export function ThemingPage(){
   const navigate = useNavigate();
   const { theme: themeMode, toggleTheme } = useTheme();
   const muiTheme = useMuiTheme();
-  
+
   const [showSuccessMessage, setShowSuccessMessage] = useState(false);
-  const [isPreviewingTheme, setIsPreviewingTheme] = useState(false);
-  const [colorPickerOpen, setColorPickerOpen] = useState(false);
-  const [colorPickerField, setColorPickerField] = useState('');
-  const [tempColor, setTempColor] = useState({ h: 214, s: 43, v: 90, a: 1 });
   const [previewThemeMode, setPreviewThemeMode] = useState('light');
-  
-  // State for settings - ensure we have theme structure
+
+  // Draft settings — edits stage here and feed the preview; nothing hits the
+  // live app until "Load Theme Into Settings".
   const [settings, setSettings] = useState(() => {
     const meteorSettings = JSON.parse(JSON.stringify(get(Meteor, 'settings', {})));
-    
-    // Ensure the theme structure exists
-    if (!meteorSettings.public) {
-      meteorSettings.public = {};
-    }
-    if (!meteorSettings.public.theme) {
-      meteorSettings.public.theme = {};
-    }
-    if (!meteorSettings.public.theme.palette) {
-      meteorSettings.public.theme.palette = {};
-    }
-    
+    if (!meteorSettings.public) { meteorSettings.public = {}; }
+    if (!meteorSettings.public.theme) { meteorSettings.public.theme = {}; }
+    if (!meteorSettings.public.theme.palette) { meteorSettings.public.theme.palette = {}; }
     return meteorSettings;
   });
-  
-  // Get preview mode from state
+
   const isDark = previewThemeMode === 'dark';
-  
-  // Helper function to validate and provide fallback for color values
+
   const validateColor = (color, fallback) => {
     if (!color || color.trim() === '') return fallback;
-    
-    // Check if it's a valid hex color (3 or 6 digits)
     const hexRegex = /^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$/;
-    if (color.startsWith('#') && !hexRegex.test(color)) {
-      // If it starts with # but isn't valid yet, use fallback
-      return fallback;
-    }
-    
-    // Check if it's a valid rgb/rgba color
+    if (color.startsWith('#') && !hexRegex.test(color)) { return fallback; }
     const rgbRegex = /^rgba?\(\s*\d+\s*,\s*\d+\s*,\s*\d+\s*(,\s*[\d.]+\s*)?\)$/;
-    if (color.startsWith('rgb') && !rgbRegex.test(color)) {
-      // If it starts with rgb but isn't valid yet, use fallback
-      return fallback;
-    }
-    
+    if (color.startsWith('rgb') && !rgbRegex.test(color)) { return fallback; }
     return color;
   };
 
-  // Create preview theme with pending changes - completely independent from main theme
+  // Live preview theme from draft state. Reads the CANONICAL surface keys the
+  // provider prefers (backgroundCanvas* / paperColor*Light|Dark), matching what
+  // PaletteFieldEditor writes — no shadowing.
   const previewTheme = useMemo(() => {
-    // Get all colors from local settings with proper defaults for empty values
-    const primaryColor = validateColor(get(settings, 'public.theme.palette.primaryColor'), 'rgb(108, 183, 110)');
-    const secondaryColor = validateColor(get(settings, 'public.theme.palette.secondaryColor'), '#fdb813');
-    const errorColor = validateColor(get(settings, 'public.theme.palette.errorColor'), 'rgb(128,20,60)');
-    const successColor = validateColor(get(settings, 'public.theme.palette.successColor'), '#4caf50');
-    const warningColor = validateColor(get(settings, 'public.theme.palette.warningColor'), '#ff9800');
-    const infoColor = validateColor(get(settings, 'public.theme.palette.infoColor'), '#2196f3');
-    
-    // Get AppBar colors with proper defaults
-    // Light mode: defaults to primary color if not specified
-    const appBarColorLight = validateColor(get(settings, 'public.theme.palette.appBarColor'), primaryColor);
-    const appBarTextColorLight = validateColor(get(settings, 'public.theme.palette.appBarTextColor'), '#ffffff');
-    
-    // Dark mode: defaults to light mode values if not specified
-    const appBarColorDark = validateColor(get(settings, 'public.theme.palette.appBarColorDark'), appBarColorLight);
-    const appBarTextColorDark = validateColor(get(settings, 'public.theme.palette.appBarTextColorDark'), appBarTextColorLight);
-    
-    // Select the appropriate colors based on preview mode
+    const p = (k) => get(settings, 'public.theme.palette.' + k);
+    const primaryColor = validateColor(p('primaryColor'), 'rgb(108, 183, 110)');
+    const secondaryColor = validateColor(p('secondaryColor'), '#fdb813');
+    const errorColor = validateColor(p('errorColor'), 'rgb(128,20,60)');
+    const successColor = validateColor(p('successColor'), '#4caf50');
+    const warningColor = validateColor(p('warningColor'), '#ff9800');
+    const infoColor = validateColor(p('infoColor'), '#2196f3');
+
+    const appBarColorLight = validateColor(p('appBarColor'), primaryColor);
+    const appBarTextColorLight = validateColor(p('appBarTextColor'), '#ffffff');
+    const appBarColorDark = validateColor(p('appBarColorDark'), appBarColorLight);
+    const appBarTextColorDark = validateColor(p('appBarTextColorDark'), appBarTextColorLight);
     const appBarColor = isDark ? appBarColorDark : appBarColorLight;
     const appBarTextColor = isDark ? appBarTextColorDark : appBarTextColorLight;
-    
-    // Get background colors with proper defaults
-    const backgroundPageColorLight = get(settings, 'public.theme.palette.backgroundPageColor') || '';
-    const backgroundPageColorDark = get(settings, 'public.theme.palette.backgroundPageColorDark') || backgroundPageColorLight;
-    const backgroundPageColor = backgroundPageColorDark && isDark ? 
-      validateColor(backgroundPageColorDark, '#121212') : 
-      validateColor(backgroundPageColorLight, '#fafafa');
-    
-    // Get paper colors with proper defaults
-    const paperColorLight = validateColor(get(settings, 'public.theme.palette.paperColor'), '#ffffff');
-    const paperColorDark = validateColor(get(settings, 'public.theme.palette.paperColorDark'), '#424242');
-    const paperColor = isDark ? paperColorDark : paperColorLight;
-    
-    const themeConfig = {
+
+    const canvas = isDark
+      ? validateColor(p('backgroundCanvasDark'), '#121212')
+      : validateColor(p('backgroundCanvas'), '#fafafa');
+    const paper = isDark
+      ? validateColor(p('paperColorDark'), '#424242')
+      : validateColor(p('paperColorLight'), '#ffffff');
+
+    return createTheme({
       palette: {
         mode: previewThemeMode,
-        primary: {
-          main: primaryColor
-        },
-        secondary: {
-          main: secondaryColor
-        },
-        error: {
-          main: errorColor
-        },
-        success: {
-          main: successColor
-        },
-        warning: {
-          main: warningColor
-        },
-        info: {
-          main: infoColor
-        },
-        appbar: {
-          main: appBarColor,
-          contrastText: appBarTextColor
-        }
+        primary: { main: primaryColor },
+        secondary: { main: secondaryColor },
+        error: { main: errorColor },
+        success: { main: successColor },
+        warning: { main: warningColor },
+        info: { main: infoColor },
+        appbar: { main: appBarColor, contrastText: appBarTextColor },
+        background: { default: canvas, paper: paper }
       }
-    };
-    
-    // Add background configuration
-    themeConfig.palette.background = {
-      default: backgroundPageColor || (previewThemeMode === 'dark' ? '#121212' : '#fafafa'),
-      paper: paperColor
-    };
-    
-    return createTheme(themeConfig);
+    });
   }, [previewThemeMode, isDark, settings]);
-  
-  // Helper function to update nested settings
-  const updateSetting = (path, value) => {
-    console.log('updateSetting called with:', path, value);
-    const newSettings = JSON.parse(JSON.stringify(settings));
-    const pathParts = path.split('.');
-    let current = newSettings;
-    
-    // Ensure all nested paths exist
-    for (let i = 0; i < pathParts.length - 1; i++) {
-      const part = pathParts[i];
-      if (part === "__proto__" || part === "constructor" || part === "prototype") {
-        console.error("Prototype pollution attempt blocked:", part);
-        return;
-      }
-      if (!current[part]) {
-        current[part] = {};
-      }
-      current = current[part];
-    }
-    
-    const lastPart = pathParts[pathParts.length - 1];
-    if (lastPart === "__proto__" || lastPart === "constructor" || lastPart === "prototype") {
-      console.error("Prototype pollution attempt blocked:", lastPart);
-      return;
-    }
-    current[lastPart] = value;
-    console.log('New settings:', newSettings);
-    setSettings(newSettings);
-    
-    // NOTE: We do NOT update Meteor.settings here anymore
-    // That only happens when user clicks "Preview Theme" or "Load Theme Into Settings"
-  };
 
-  // Open color picker for a specific field
-  const openColorPicker = (fieldPath, currentValue) => {
-    setColorPickerField(fieldPath);
-    // Try to parse the current color value
-    // For now, we'll just use the default color
-    setTempColor({ h: 214, s: 43, v: 90, a: 1 });
-    setColorPickerOpen(true);
-  };
-  
-  // Apply the selected color
-  const applySelectedColor = () => {
-    const hexColor = hsvaToHex(tempColor);
-    console.log('Applying color:', hexColor, 'to field:', colorPickerField);
-    updateSetting(colorPickerField, hexColor);
-    setColorPickerOpen(false);
-  };
-  
-  // Simple color field component
-  const ColorField = ({ label, fieldPath, helperText, placeholder }) => {
-    const value = get(settings, fieldPath, '');
-    return (
-      <TextField
-        fullWidth
-        label={label}
-        value={value}
-        onChange={(e) => updateSetting(fieldPath, e.target.value)}
-        variant="outlined"
-        size="small"
-        helperText={helperText}
-        placeholder={placeholder}
-        InputProps={{
-          endAdornment: (
-            <InputAdornment position="end">
-              <IconButton
-                edge="end"
-                onClick={() => openColorPicker(fieldPath, value)}
-                size="small"
-                aria-label="Palette"
-              >
-                <PaletteIcon />
-              </IconButton>
-            </InputAdornment>
-          ),
-        }}
-      />
-    );
-  };
-  
+  // Draft adapter for PaletteFieldEditor: bare key ↔ local settings state.
+  function updateSetting(path, value) {
+    const next = JSON.parse(JSON.stringify(settings));
+    const parts = path.split('.');
+    let cur = next;
+    for (let i = 0; i < parts.length - 1; i++) {
+      const part = parts[i];
+      if (part === '__proto__' || part === 'constructor' || part === 'prototype') { return; }
+      if (!cur[part]) { cur[part] = {}; }
+      cur = cur[part];
+    }
+    const last = parts[parts.length - 1];
+    if (last === '__proto__' || last === 'constructor' || last === 'prototype') { return; }
+    cur[last] = value;
+    setSettings(next);
+  }
+  const draftGet = (key) => get(settings, 'public.theme.palette.' + key, '') || '';
+  const draftSet = (key, value) => updateSetting('public.theme.palette.' + key, value);
+
+  function loadIntoSettings() {
+    if (Meteor.settings && Meteor.settings.public) {
+      if (!Meteor.settings.public.theme) { Meteor.settings.public.theme = {}; }
+      Object.assign(Meteor.settings.public.theme, get(settings, 'public.theme', {}));
+    }
+    // Persist the canonical per-field values the user set as paletteOverrides,
+    // so page edits survive reload like the dialog's do.
+    const paletteOverrides = {};
+    PALETTE_FIELD_GROUPS.forEach(function(group) {
+      group.fields.forEach(function(field) {
+        const v = get(settings, 'public.theme.palette.' + field.key);
+        if (v) { paletteOverrides[field.key] = v; }
+      });
+    });
+    saveThemeChoice({ paletteOverrides: paletteOverrides });
+
+    setShowSuccessMessage(true);
+    const settingsMode = get(settings, 'public.theme.mode', themeMode);
+    if (settingsMode !== themeMode) { toggleTheme(); }
+    Session.set('themeRefreshRequest', true);
+  }
 
   return (
     <Box
       id="ThemingPage"
-      sx={{
-        padding: '20px',
-        minHeight: '100vh',
-        backgroundColor: muiTheme.palette.background.default,
-        color: muiTheme.palette.text.primary
-      }}
+      sx={{ p: '20px', minHeight: '100vh', backgroundColor: muiTheme.palette.background.default, color: muiTheme.palette.text.primary }}
     >
       <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 3 }}>
         <Typography variant="h4">Theme Settings</Typography>
-        <Box sx={{ display: 'flex', gap: 2 }}>
-          <Button 
-            variant="contained" 
-            color="primary"
-            onClick={() => {
-              // Apply theme changes
-              console.log('Loading theme into settings...');
-              console.log('Current theme settings:', get(settings, 'public.theme'));
-              
-              // Update entire Meteor.settings.public.theme object
-              if (Meteor.settings && Meteor.settings.public) {
-                // Create or update the theme object
-                if (!Meteor.settings.public.theme) {
-                  Meteor.settings.public.theme = {};
-                }
-                
-                // Copy all theme settings from our state
-                const themeSettings = get(settings, 'public.theme', {});
-                Object.assign(Meteor.settings.public.theme, themeSettings);
-                
-                console.log('Updated Meteor.settings.public.theme:', Meteor.settings.public.theme);
-              }
-              
-              // Show success message
-              setShowSuccessMessage(true);
-              
-              // Check if theme mode is different and toggle if needed
-              const settingsMode = get(settings, 'public.theme.mode', themeMode);
-              if (settingsMode !== themeMode) {
-                toggleTheme();
-              }
-              
-              // Clear preview state since we're now loading the settings
-              Session.set('isPreviewingTheme', false);
-              Session.set('themeBackup', null);
-              setIsPreviewingTheme(false);
-              
-              // Trigger theme refresh in CustomThemeProvider
-              Session.set('themeRefreshRequest', true);
-              
-              // The theme changes should be visible immediately
-            }}
-          >
-            Load Theme Into Settings
-          </Button>
-        </Box>
+        <Button variant="contained" color="primary" onClick={loadIntoSettings}>
+          Load Theme Into Settings
+        </Button>
       </Box>
-      
+
       <Grid container spacing={3}>
-        {/* Left Column - Theme Configuration */}
+        {/* LEFT — shared controls (identical to the Theme & Palette dialog) */}
         <Grid item xs={12} md={6}>
           <Paper sx={{ p: 3, height: '100%' }}>
             <Typography variant="h6" gutterBottom>Theme Configuration</Typography>
-            <Grid container spacing={2}>
-              <Grid item xs={12}>
-                <Typography variant="subtitle2" gutterBottom>Default Theme Mode</Typography>
-                <FormControl fullWidth size="small">
-                  <InputLabel>Default Theme Mode</InputLabel>
-                  <Select
-                    value={get(settings, 'public.theme.mode', themeMode) || 'light'}
-                    onChange={(e) => {
-                      // Only update local settings, don't toggle the actual theme
-                      updateSetting('public.theme.mode', e.target.value);
-                    }}
-                    label="Default Theme Mode"
-                  >
-                    <MenuItem value="light">Light Mode</MenuItem>
-                    <MenuItem value="dark">Dark Mode</MenuItem>
-                  </Select>
-                </FormControl>
-              </Grid>
-              
-              <Grid item xs={12}>
-                <Divider sx={{ my: 1 }} />
-                <Typography variant="subtitle2" gutterBottom>Color Palette</Typography>
-              </Grid>
-              
-              {/* Left column - Primary and Secondary */}
-              <Grid item xs={6}>
-                <Grid container spacing={2}>
-                  <Grid item xs={12}>
-                    <ColorField
-                      label="Primary Color"
-                      fieldPath="public.theme.palette.primaryColor"
-                      helperText="Main brand color"
-                      placeholder="rgb(108, 183, 110)"
-                    />
-                  </Grid>
-                  <Grid item xs={12}>
-                    <ColorField
-                      label="Secondary Color"
-                      fieldPath="public.theme.palette.secondaryColor"
-                      helperText="Accent color"
-                      placeholder="#fdb813"
-                    />
-                  </Grid>
-                </Grid>
-              </Grid>
-              
-              {/* Right column - Status colors */}
-              <Grid item xs={6}>
-                <Grid container spacing={2}>
-                  <Grid item xs={12}>
-                    <ColorField
-                      label="Success Color"
-                      fieldPath="public.theme.palette.successColor"
-                      helperText="Success state color"
-                      placeholder="#4caf50"
-                    />
-                  </Grid>
-                  <Grid item xs={12}>
-                    <ColorField
-                      label="Info Color"
-                      fieldPath="public.theme.palette.infoColor"
-                      helperText="Info state color"
-                      placeholder="#2196f3"
-                    />
-                  </Grid>
-                  <Grid item xs={12}>
-                    <ColorField
-                      label="Warning Color"
-                      fieldPath="public.theme.palette.warningColor"
-                      helperText="Warning state color"
-                      placeholder="#ff9800"
-                    />
-                  </Grid>
-                  <Grid item xs={12}>
-                    <ColorField
-                      label="Error Color"
-                      fieldPath="public.theme.palette.errorColor"
-                      helperText="Error state color"
-                      placeholder="rgb(128,20,60)"
-                    />
-                  </Grid>
-                </Grid>
-              </Grid>
-              
-              <Grid item xs={12}>
-                <Divider sx={{ my: 1 }} />
-                <Typography variant="subtitle2" gutterBottom>Background Colors</Typography>
-              </Grid>
-              
-              <Grid item xs={6}>
-                <ColorField
-                  label="Background Page Color"
-                  fieldPath="public.theme.palette.backgroundPageColor"
-                  helperText="Light mode"
-                  placeholder="#fafafa"
-                />
-              </Grid>
-              
-              <Grid item xs={6}>
-                <ColorField
-                  label="Background Page Color (Dark)"
-                  fieldPath="public.theme.palette.backgroundPageColorDark"
-                  helperText="Dark mode"
-                  placeholder={get(settings, 'public.theme.palette.backgroundPageColor', '') || '#121212'}
-                />
-              </Grid>
-              
-              <Grid item xs={6}>
-                <ColorField
-                  label="Paper Color"
-                  fieldPath="public.theme.palette.paperColor"
-                  helperText="Light mode"
-                  placeholder="#ffffff"
-                />
-              </Grid>
-              
-              <Grid item xs={6}>
-                <ColorField
-                  label="Paper Color (Dark)"
-                  fieldPath="public.theme.palette.paperColorDark"
-                  helperText="Dark mode"
-                  placeholder={get(settings, 'public.theme.palette.paperColor', '') || '#424242'}
-                />
-              </Grid>
-              
-              <Grid item xs={12}>
-                <Divider sx={{ my: 1 }} />
-                <Typography variant="subtitle2" gutterBottom>App Bar Colors</Typography>
-              </Grid>
-              
-              <Grid item xs={6}>
-                <ColorField
-                  label="App Bar Color"
-                  fieldPath="public.theme.palette.appBarColor"
-                  helperText="Light mode (defaults to primary)"
-                  placeholder={get(settings, 'public.theme.palette.primaryColor', 'rgb(108, 183, 110)')}
-                />
-              </Grid>
-              
-              <Grid item xs={6}>
-                <ColorField
-                  label="App Bar Color (Dark)"
-                  fieldPath="public.theme.palette.appBarColorDark"
-                  helperText="Dark mode"
-                  placeholder={get(settings, 'public.theme.palette.appBarColor', get(settings, 'public.theme.palette.primaryColor', 'rgb(108, 183, 110)'))}
-                />
-              </Grid>
-              
-              <Grid item xs={6}>
-                <ColorField
-                  label="App Bar Text Color"
-                  fieldPath="public.theme.palette.appBarTextColor"
-                  helperText="Light mode text color"
-                  placeholder="#ffffff"
-                />
-              </Grid>
-              
-              <Grid item xs={6}>
-                <ColorField
-                  label="App Bar Text Color (Dark)"
-                  fieldPath="public.theme.palette.appBarTextColorDark"
-                  helperText="Dark mode text color"
-                  placeholder={get(settings, 'public.theme.palette.appBarTextColor', '#ffffff')}
-                />
-              </Grid>
-              
-              <Grid item xs={12}>
-                <Divider sx={{ my: 1 }} />
-                <Typography variant="subtitle2" gutterBottom>Additional Settings</Typography>
-              </Grid>
-              
-              <Grid item xs={12}>
-                <FormControl fullWidth size="small">
-                  <InputLabel>Nivo Theme</InputLabel>
-                  <Select
-                    value={get(settings, 'public.theme.palette.nivoTheme', 'red_grey')}
-                    onChange={(e) => updateSetting('public.theme.palette.nivoTheme', e.target.value)}
-                    label="Nivo Theme"
-                  >
-                    <MenuItem value="red_grey">Red Grey</MenuItem>
-                    <MenuItem value="blues">Blues</MenuItem>
-                    <MenuItem value="greens">Greens</MenuItem>
-                    <MenuItem value="purples">Purples</MenuItem>
-                    <MenuItem value="oranges">Oranges</MenuItem>
-                  </Select>
-                </FormControl>
-              </Grid>
-              
-              <Grid item xs={12}>
-                <TextField
-                  fullWidth
-                  label="Background Image Path"
-                  value={get(settings, 'public.theme.backgroundImagePath', '')}
-                  onChange={(e) => updateSetting('public.theme.backgroundImagePath', e.target.value)}
-                  variant="outlined"
-                  size="small"
-                />
-              </Grid>
-              
-              <Grid item xs={12}>
-                <FormControl fullWidth size="small">
-                  <InputLabel>Video Background</InputLabel>
-                  <Select
-                    value={get(settings, 'public.theme.showVideoBackground', false) ? 'enabled' : 'disabled'}
-                    onChange={(e) => updateSetting('public.theme.showVideoBackground', e.target.value === 'enabled')}
-                    label="Video Background"
-                  >
-                    <MenuItem value="disabled">Disabled</MenuItem>
-                    <MenuItem value="enabled">Enabled</MenuItem>
-                  </Select>
-                </FormControl>
-              </Grid>
-              
-              <Grid item xs={12}>
-                <TextField
-                  fullWidth
-                  label="Default Video"
-                  value={get(settings, 'public.theme.defaultVideo', '')}
-                  onChange={(e) => updateSetting('public.theme.defaultVideo', e.target.value)}
-                  variant="outlined"
-                  size="small"
-                  disabled={!get(settings, 'public.theme.showVideoBackground', false)}
-                />
-              </Grid>
-              
-            </Grid>
+            <ThemeControls />
+            <Divider sx={{ my: 2 }} />
+            <Typography variant="subtitle2" gutterBottom>Per-field palette</Typography>
+            <PaletteFieldEditor getValue={draftGet} setValue={draftSet} />
           </Paper>
         </Grid>
-        
-        {/* Right Column - Theme Preview */}
+
+        {/* RIGHT — live preview from draft state */}
         <Grid item xs={12} md={6}>
-          <Paper sx={{ 
-            p: 3, 
-            height: '100%',
-            backgroundColor: previewTheme.palette.background?.default || (previewThemeMode === 'dark' ? '#121212' : '#fafafa')
-          }}>
+          <Paper sx={{ p: 3, height: '100%', backgroundColor: previewTheme.palette.background?.default }}>
             <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
               <Typography variant="h6" sx={{ color: previewThemeMode === 'dark' ? '#ffffff' : 'inherit' }}>Theme Preview</Typography>
               <FormControl size="small" sx={{ minWidth: 120 }}>
-                <InputLabel sx={{ color: previewThemeMode === 'dark' ? '#ffffff' : 'inherit' }}>Theme Mode</InputLabel>
+                <InputLabel sx={{ color: previewThemeMode === 'dark' ? '#ffffff' : 'inherit' }}>Preview Mode</InputLabel>
                 <Select
                   value={previewThemeMode}
                   onChange={(e) => setPreviewThemeMode(e.target.value)}
-                  label="Theme Mode"
-                  sx={{ 
+                  label="Preview Mode"
+                  sx={{
                     color: previewThemeMode === 'dark' ? '#ffffff' : 'inherit',
-                    '& .MuiOutlinedInput-notchedOutline': {
-                      borderColor: previewThemeMode === 'dark' ? 'rgba(255, 255, 255, 0.23)' : 'rgba(0, 0, 0, 0.23)'
-                    },
-                    '& .MuiSvgIcon-root': {
-                      color: previewThemeMode === 'dark' ? '#ffffff' : 'inherit'
-                    }
+                    '& .MuiOutlinedInput-notchedOutline': { borderColor: previewThemeMode === 'dark' ? 'rgba(255,255,255,0.23)' : 'rgba(0,0,0,0.23)' },
+                    '& .MuiSvgIcon-root': { color: previewThemeMode === 'dark' ? '#ffffff' : 'inherit' }
                   }}
                 >
                   <MenuItem value="light">Light</MenuItem>
@@ -582,47 +202,35 @@ export function ThemingPage(){
             </Box>
             <ThemeProvider theme={previewTheme}>
               <Grid container spacing={3}>
-                {/* App Bar Preview */}
                 <Grid item xs={12}>
-                  <Box>
-                    <Typography variant="subtitle2" gutterBottom>App Bar Preview</Typography>
-                    <Box sx={{ 
-                      p: 2, 
-                      backgroundColor: previewTheme.palette.appbar?.main || previewTheme.palette.primary.main,
-                      color: previewTheme.palette.appbar?.contrastText || previewTheme.palette.primary.contrastText,
-                      borderRadius: 1,
-                      display: 'flex',
-                      alignItems: 'center',
-                      justifyContent: 'space-between'
-                    }}>
-                      <Typography variant="h6" sx={{ color: 'inherit' }}>Application Title</Typography>
-                      <Box>
-                        <Button size="small" sx={{ color: 'inherit' }}>Menu</Button>
-                        <Button size="small" sx={{ color: 'inherit' }}>Profile</Button>
-                      </Box>
+                  <Typography variant="subtitle2" gutterBottom>App Bar Preview</Typography>
+                  <Box sx={{
+                    p: 2, borderRadius: 1, display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+                    backgroundColor: previewTheme.palette.appbar?.main || previewTheme.palette.primary.main,
+                    color: previewTheme.palette.appbar?.contrastText || previewTheme.palette.primary.contrastText
+                  }}>
+                    <Typography variant="h6" sx={{ color: 'inherit' }}>Application Title</Typography>
+                    <Box>
+                      <Button size="small" sx={{ color: 'inherit' }}>Menu</Button>
+                      <Button size="small" sx={{ color: 'inherit' }}>Profile</Button>
                     </Box>
                   </Box>
                 </Grid>
-                
-                {/* Alert Examples */}
+
                 <Grid item xs={12}>
                   <Typography variant="subtitle2" gutterBottom>Status Colors</Typography>
                   <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
-                    <Alert severity="error">Error Alert - Uses the Error Color</Alert>
-                    <Alert severity="warning">Warning Alert - Uses the Warning Color</Alert>
-                    <Alert severity="info">Info Alert - Uses the Info Color</Alert>
-                    <Alert severity="success">Success Alert - Uses the Success Color</Alert>
+                    <Alert severity="error">Error Alert</Alert>
+                    <Alert severity="warning">Warning Alert</Alert>
+                    <Alert severity="info">Info Alert</Alert>
+                    <Alert severity="success">Success Alert</Alert>
                   </Box>
                 </Grid>
-              
-                {/* Component Examples */}
+
                 <Grid item xs={12}>
                   <Typography variant="subtitle2" gutterBottom>Component Examples</Typography>
                   <Paper sx={{ p: 2, mb: 2 }}>
                     <Typography variant="h6" gutterBottom>Paper Component</Typography>
-                    <Typography variant="body2" color="text.secondary" paragraph>
-                      Paper components automatically adjust to theme mode.
-                    </Typography>
                     <Box sx={{ display: 'flex', gap: 1 }}>
                       <Button variant="contained" color="primary" size="small">Action</Button>
                       <Button variant="outlined" size="small">Cancel</Button>
@@ -631,27 +239,17 @@ export function ThemingPage(){
                   <Card>
                     <CardContent>
                       <Typography variant="h6" gutterBottom>Card Component</Typography>
-                      <Typography variant="body2" color="text.secondary" paragraph>
-                        Cards also adapt to the current theme mode.
-                      </Typography>
                       <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap', mb: 2 }}>
                         <Button variant="contained" color="secondary" size="small">Secondary</Button>
                         <Button variant="outlined" color="secondary" size="small">Outlined</Button>
                         <Button variant="text" color="secondary" size="small">Text</Button>
                       </Box>
-                      <Alert severity="success" variant="outlined">
-                        Success message
-                      </Alert>
+                      <Alert severity="success" variant="outlined">Success message</Alert>
                     </CardContent>
                   </Card>
-                  
-                  {/* Settings Preview with AceEditor */}
                   <Card sx={{ mt: 2 }}>
                     <CardContent>
                       <Typography variant="h6" gutterBottom>Settings Preview</Typography>
-                      <Typography variant="body2" color="text.secondary" paragraph>
-                        Current theme configuration in JSON format:
-                      </Typography>
                       <Box sx={{ border: 1, borderColor: 'divider', borderRadius: 1 }}>
                         <AceEditor
                           mode="json"
@@ -664,15 +262,8 @@ export function ThemingPage(){
                           showPrintMargin={false}
                           showGutter={true}
                           highlightActiveLine={false}
-                          setOptions={{
-                            showLineNumbers: true,
-                            tabSize: 2,
-                            useWorker: false
-                          }}
-                          style={{
-                            fontFamily: 'monospace',
-                            fontSize: '12px'
-                          }}
+                          setOptions={{ showLineNumbers: true, tabSize: 2, useWorker: false }}
+                          style={{ fontFamily: 'monospace', fontSize: '12px' }}
                         />
                       </Box>
                     </CardContent>
@@ -683,71 +274,19 @@ export function ThemingPage(){
           </Paper>
         </Grid>
       </Grid>
-      
+
       <Snackbar
         open={showSuccessMessage}
         autoHideDuration={6000}
         onClose={() => setShowSuccessMessage(false)}
         anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
       >
-        <Alert 
-          onClose={() => setShowSuccessMessage(false)} 
-          severity="success" 
-          sx={{ width: '100%' }}
-        >
+        <Alert onClose={() => setShowSuccessMessage(false)} severity="success" sx={{ width: '100%' }}>
           Theme settings loaded successfully!
         </Alert>
       </Snackbar>
-      
-      {/* Color Picker Dialog */}
-      <Dialog 
-        open={colorPickerOpen} 
-        onClose={() => setColorPickerOpen(false)}
-        maxWidth="sm"
-        fullWidth
-      >
-        <DialogTitle>Choose Color</DialogTitle>
-        <DialogContent>
-          <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 2, pt: 2 }}>
-            <Wheel 
-              color={tempColor} 
-              onChange={(color) => setTempColor({ ...tempColor, ...color.hsva })} 
-              width={300}
-              height={300}
-            />
-            <ShadeSlider
-              hsva={tempColor}
-              style={{ width: '300px' }}
-              onChange={(newShade) => {
-                setTempColor({ ...tempColor, ...newShade });
-              }}
-            />
-            <Box sx={{ 
-              width: '100%', 
-              p: 2, 
-              backgroundColor: hsvaToHex(tempColor),
-              borderRadius: 1,
-              border: '1px solid',
-              borderColor: 'divider',
-              textAlign: 'center'
-            }}>
-              <Typography variant="body2" sx={{ 
-                color: tempColor.v > 50 ? '#000' : '#fff' 
-              }}>
-                {hsvaToHex(tempColor)}
-              </Typography>
-            </Box>
-          </Box>
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={() => setColorPickerOpen(false)}>Cancel</Button>
-          <Button onClick={applySelectedColor} variant="contained" color="primary">
-            Choose Color
-          </Button>
-        </DialogActions>
-      </Dialog>
     </Box>
   );
-};
+}
 
-export default ThemingPage 
+export default ThemingPage;

--- a/imports/ui/ThemingPage.jsx
+++ b/imports/ui/ThemingPage.jsx
@@ -1,22 +1,20 @@
 // imports/ui/ThemingPage.jsx
 //
 // The /theming full editor. LEFT column = the SAME shared controls the Theme &
-// Palette dialog uses (<ThemeControls> + <PaletteFieldEditor>), so the two
-// surfaces are harmonized. RIGHT column = the live preview (independent
-// ThemeProvider built from the page's draft state). Field edits stage in local
-// state and drive the preview; "Load Theme Into Settings" writes them into
-// Meteor.settings AND persists the canonical per-field values as
-// paletteOverrides (survive reload, re-applied after the preset at boot).
+// Palette dialog uses (<ThemeControls> + <PaletteFieldEditor>) — everything
+// applies to the LIVE app and persists (setPaletteOverride), so the two
+// surfaces are fully harmonized (no draft/Load duality). RIGHT column = a
+// component gallery rendered from the LIVE palette, defaulting to the INVERSE
+// of the current app mode so you can tune the dark appbar while viewing it in
+// light (and vice-versa) without flipping the whole app.
 
-import React, { useState, useMemo } from 'react';
+import React, { useState, useMemo, useEffect } from 'react';
 
 import "ace-builds";
 import AceEditor from "react-ace";
 import "ace-builds/src-noconflict/mode-json";
 import "ace-builds/src-noconflict/theme-github";
 import "ace-builds/src-noconflict/theme-monokai";
-
-import { useNavigate } from "react-router-dom";
 
 import { useTheme as useMuiTheme } from '@mui/material/styles';
 import Paper from '@mui/material/Paper';
@@ -29,54 +27,52 @@ import InputLabel from '@mui/material/InputLabel';
 import Select from '@mui/material/Select';
 import MenuItem from '@mui/material/MenuItem';
 import Button from '@mui/material/Button';
-import Snackbar from '@mui/material/Snackbar';
 import Alert from '@mui/material/Alert';
 import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
 import { createTheme, ThemeProvider } from '@mui/material/styles';
 import { get } from 'lodash';
 import { Meteor } from 'meteor/meteor';
-import { Session } from 'meteor/session';
 
-import { useTheme } from './App';
+import { getThemeSetting } from './CustomThemeProvider.jsx';
 import { ThemeControls } from './theme/ThemeControls.jsx';
-import { PaletteFieldEditor, PALETTE_FIELD_GROUPS } from './theme/PaletteFieldEditor.jsx';
-import { saveThemeChoice } from '/imports/lib/themePersistence.js';
+import { PaletteFieldEditor } from './theme/PaletteFieldEditor.jsx';
+import { setPaletteOverride } from './themePresets.js';
+
+// Live adapter (identical to the dialog): read the sanitized live value, write
+// a persisted per-field override.
+function liveGet(key) { return getThemeSetting('settings.public.theme.palette.' + key, ''); }
+function liveSet(key, value) { setPaletteOverride(key, value); }
+
+function validateColor(color, fallback) {
+  if (!color || String(color).trim() === '') return fallback;
+  const hexRegex = /^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$/;
+  if (color.startsWith('#') && !hexRegex.test(color)) { return fallback; }
+  const rgbRegex = /^rgba?\(\s*\d+\s*,\s*\d+\s*,\s*\d+\s*(,\s*[\d.]+\s*)?\)$/;
+  if (color.startsWith('rgb') && !rgbRegex.test(color)) { return fallback; }
+  return color;
+}
 
 export function ThemingPage(){
-  const navigate = useNavigate();
-  const { theme: themeMode, toggleTheme } = useTheme();
+  // The live app theme. Its object identity changes on every provider rebuild
+  // (the themeRefreshCounter bumps on each edit) — so it's the reliable
+  // reactivity tick for the gallery. Its palette.mode is the live app mode.
   const muiTheme = useMuiTheme();
+  const appMode = muiTheme.palette.mode || 'light';
 
-  const [showSuccessMessage, setShowSuccessMessage] = useState(false);
-  const [previewThemeMode, setPreviewThemeMode] = useState('light');
+  // Preview defaults to the INVERSE of the app mode; re-inverts whenever the
+  // app mode flips. The selector still lets you override in between.
+  const [previewMode, setPreviewMode] = useState(appMode === 'dark' ? 'light' : 'dark');
+  useEffect(function() {
+    setPreviewMode(appMode === 'dark' ? 'light' : 'dark');
+  }, [appMode]);
 
-  // Draft settings — edits stage here and feed the preview; nothing hits the
-  // live app until "Load Theme Into Settings".
-  const [settings, setSettings] = useState(() => {
-    const meteorSettings = JSON.parse(JSON.stringify(get(Meteor, 'settings', {})));
-    if (!meteorSettings.public) { meteorSettings.public = {}; }
-    if (!meteorSettings.public.theme) { meteorSettings.public.theme = {}; }
-    if (!meteorSettings.public.theme.palette) { meteorSettings.public.theme.palette = {}; }
-    return meteorSettings;
-  });
+  const isDark = previewMode === 'dark';
 
-  const isDark = previewThemeMode === 'dark';
-
-  const validateColor = (color, fallback) => {
-    if (!color || color.trim() === '') return fallback;
-    const hexRegex = /^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$/;
-    if (color.startsWith('#') && !hexRegex.test(color)) { return fallback; }
-    const rgbRegex = /^rgba?\(\s*\d+\s*,\s*\d+\s*,\s*\d+\s*(,\s*[\d.]+\s*)?\)$/;
-    if (color.startsWith('rgb') && !rgbRegex.test(color)) { return fallback; }
-    return color;
-  };
-
-  // Live preview theme from draft state. Reads the CANONICAL surface keys the
-  // provider prefers (backgroundCanvas* / paperColor*Light|Dark), matching what
-  // PaletteFieldEditor writes — no shadowing.
-  const previewTheme = useMemo(() => {
-    const p = (k) => get(settings, 'public.theme.palette.' + k);
+  // Gallery theme built from the LIVE palette settings for previewMode, reading
+  // the same canonical keys (and precedence) the provider uses.
+  const previewTheme = useMemo(function() {
+    const p = (k) => getThemeSetting('settings.public.theme.palette.' + k, '');
     const primaryColor = validateColor(p('primaryColor'), 'rgb(108, 183, 110)');
     const secondaryColor = validateColor(p('secondaryColor'), '#fdb813');
     const errorColor = validateColor(p('errorColor'), 'rgb(128,20,60)');
@@ -91,16 +87,21 @@ export function ThemingPage(){
     const appBarColor = isDark ? appBarColorDark : appBarColorLight;
     const appBarTextColor = isDark ? appBarTextColorDark : appBarTextColorLight;
 
+    // Light branch must NOT fall back to the unsuffixed generics (canvasColor /
+    // paperColor): those belong to whichever mode the settings file was
+    // authored for (here dark, e.g. paperColor '#1e1e1e !important') and would
+    // leak dark surfaces into the light preview. Generics feed the dark branch
+    // only. (rules/ui/theming.md — unsuffixed generics are mode-oriented.)
     const canvas = isDark
-      ? validateColor(p('backgroundCanvasDark'), '#121212')
+      ? validateColor(p('backgroundCanvasDark') || p('canvasColor'), '#121212')
       : validateColor(p('backgroundCanvas'), '#fafafa');
     const paper = isDark
-      ? validateColor(p('paperColorDark'), '#424242')
+      ? validateColor(p('paperColorDark') || p('paperColor'), '#1e1e1e')
       : validateColor(p('paperColorLight'), '#ffffff');
 
     return createTheme({
       palette: {
-        mode: previewThemeMode,
+        mode: previewMode,
         primary: { main: primaryColor },
         secondary: { main: secondaryColor },
         error: { main: errorColor },
@@ -111,48 +112,9 @@ export function ThemingPage(){
         background: { default: canvas, paper: paper }
       }
     });
-  }, [previewThemeMode, isDark, settings]);
-
-  // Draft adapter for PaletteFieldEditor: bare key ↔ local settings state.
-  function updateSetting(path, value) {
-    const next = JSON.parse(JSON.stringify(settings));
-    const parts = path.split('.');
-    let cur = next;
-    for (let i = 0; i < parts.length - 1; i++) {
-      const part = parts[i];
-      if (part === '__proto__' || part === 'constructor' || part === 'prototype') { return; }
-      if (!cur[part]) { cur[part] = {}; }
-      cur = cur[part];
-    }
-    const last = parts[parts.length - 1];
-    if (last === '__proto__' || last === 'constructor' || last === 'prototype') { return; }
-    cur[last] = value;
-    setSettings(next);
-  }
-  const draftGet = (key) => get(settings, 'public.theme.palette.' + key, '') || '';
-  const draftSet = (key, value) => updateSetting('public.theme.palette.' + key, value);
-
-  function loadIntoSettings() {
-    if (Meteor.settings && Meteor.settings.public) {
-      if (!Meteor.settings.public.theme) { Meteor.settings.public.theme = {}; }
-      Object.assign(Meteor.settings.public.theme, get(settings, 'public.theme', {}));
-    }
-    // Persist the canonical per-field values the user set as paletteOverrides,
-    // so page edits survive reload like the dialog's do.
-    const paletteOverrides = {};
-    PALETTE_FIELD_GROUPS.forEach(function(group) {
-      group.fields.forEach(function(field) {
-        const v = get(settings, 'public.theme.palette.' + field.key);
-        if (v) { paletteOverrides[field.key] = v; }
-      });
-    });
-    saveThemeChoice({ paletteOverrides: paletteOverrides });
-
-    setShowSuccessMessage(true);
-    const settingsMode = get(settings, 'public.theme.mode', themeMode);
-    if (settingsMode !== themeMode) { toggleTheme(); }
-    Session.set('themeRefreshRequest', true);
-  }
+    // muiTheme identity changes on every live edit → recompute from fresh settings.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [previewMode, isDark, muiTheme]);
 
   return (
     <Box
@@ -161,38 +123,42 @@ export function ThemingPage(){
     >
       <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 3 }}>
         <Typography variant="h4">Theme Settings</Typography>
-        <Button variant="contained" color="primary" onClick={loadIntoSettings}>
-          Load Theme Into Settings
-        </Button>
+        <Typography variant="caption" color="text.secondary">
+          Changes apply live &amp; persist — no save needed.
+        </Typography>
       </Box>
 
       <Grid container spacing={3}>
-        {/* LEFT — shared controls (identical to the Theme & Palette dialog) */}
+        {/* LEFT — shared controls (identical to the Theme & Palette dialog),
+            all live + persisted */}
         <Grid item xs={12} md={6}>
           <Paper sx={{ p: 3, height: '100%' }}>
             <Typography variant="h6" gutterBottom>Theme Configuration</Typography>
             <ThemeControls />
             <Divider sx={{ my: 2 }} />
             <Typography variant="subtitle2" gutterBottom>Per-field palette</Typography>
-            <PaletteFieldEditor getValue={draftGet} setValue={draftSet} />
+            <PaletteFieldEditor getValue={liveGet} setValue={liveSet} />
           </Paper>
         </Grid>
 
-        {/* RIGHT — live preview from draft state */}
+        {/* RIGHT — component gallery rendered from the LIVE palette, in the
+            INVERSE mode by default (tune dark while viewing light) */}
         <Grid item xs={12} md={6}>
           <Paper sx={{ p: 3, height: '100%', backgroundColor: previewTheme.palette.background?.default }}>
             <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
-              <Typography variant="h6" sx={{ color: previewThemeMode === 'dark' ? '#ffffff' : 'inherit' }}>Theme Preview</Typography>
-              <FormControl size="small" sx={{ minWidth: 120 }}>
-                <InputLabel sx={{ color: previewThemeMode === 'dark' ? '#ffffff' : 'inherit' }}>Preview Mode</InputLabel>
+              <Typography variant="h6" sx={{ color: isDark ? '#ffffff' : 'inherit' }}>
+                {previewMode === appMode ? 'Preview' : 'Preview — opposite mode'}
+              </Typography>
+              <FormControl size="small" sx={{ minWidth: 140 }}>
+                <InputLabel sx={{ color: isDark ? '#ffffff' : 'inherit' }}>Preview Mode</InputLabel>
                 <Select
-                  value={previewThemeMode}
-                  onChange={(e) => setPreviewThemeMode(e.target.value)}
+                  value={previewMode}
+                  onChange={(e) => setPreviewMode(e.target.value)}
                   label="Preview Mode"
                   sx={{
-                    color: previewThemeMode === 'dark' ? '#ffffff' : 'inherit',
-                    '& .MuiOutlinedInput-notchedOutline': { borderColor: previewThemeMode === 'dark' ? 'rgba(255,255,255,0.23)' : 'rgba(0,0,0,0.23)' },
-                    '& .MuiSvgIcon-root': { color: previewThemeMode === 'dark' ? '#ffffff' : 'inherit' }
+                    color: isDark ? '#ffffff' : 'inherit',
+                    '& .MuiOutlinedInput-notchedOutline': { borderColor: isDark ? 'rgba(255,255,255,0.23)' : 'rgba(0,0,0,0.23)' },
+                    '& .MuiSvgIcon-root': { color: isDark ? '#ffffff' : 'inherit' }
                   }}
                 >
                   <MenuItem value="light">Light</MenuItem>
@@ -253,9 +219,9 @@ export function ThemingPage(){
                       <Box sx={{ border: 1, borderColor: 'divider', borderRadius: 1 }}>
                         <AceEditor
                           mode="json"
-                          theme={previewThemeMode === 'dark' ? "monokai" : "github"}
+                          theme={isDark ? "monokai" : "github"}
                           name="settings-preview"
-                          value={JSON.stringify(get(settings, 'public.theme', {}), null, 2)}
+                          value={JSON.stringify(get(Meteor, 'settings.public.theme', {}), null, 2)}
                           width="100%"
                           height="200px"
                           readOnly={true}
@@ -274,17 +240,6 @@ export function ThemingPage(){
           </Paper>
         </Grid>
       </Grid>
-
-      <Snackbar
-        open={showSuccessMessage}
-        autoHideDuration={6000}
-        onClose={() => setShowSuccessMessage(false)}
-        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
-      >
-        <Alert onClose={() => setShowSuccessMessage(false)} severity="success" sx={{ width: '100%' }}>
-          Theme settings loaded successfully!
-        </Alert>
-      </Snackbar>
     </Box>
   );
 }

--- a/imports/ui/ThemingPage.jsx
+++ b/imports/ui/ThemingPage.jsx
@@ -136,7 +136,7 @@ export function ThemingPage(){
             <Typography variant="h6" gutterBottom>Theme Configuration</Typography>
             <ThemeControls />
             <Divider sx={{ my: 2 }} />
-            <Typography variant="subtitle2" gutterBottom>Per-field palette</Typography>
+            <Typography variant="subtitle2" gutterBottom>Palette &amp; accent</Typography>
             <PaletteFieldEditor getValue={liveGet} setValue={liveSet} />
           </Paper>
         </Grid>

--- a/imports/ui/components/StyledCard.jsx
+++ b/imports/ui/components/StyledCard.jsx
@@ -19,7 +19,9 @@ import { useAmbiance } from '../theme/AmbianceContext.js';
 import { buildSurfaceStyles } from '../theme/surfaceStyles.js';
 import { CARD_SURFACE } from '/imports/lib/SessionKeys.js';
 
-export function StyledCard(props) {
+// forwardRef so MUI transitions (Fade/Grow/Collapse around cards) can attach
+// their ref to the underlying Card.
+export const StyledCard = React.forwardRef(function StyledCard(props, ref) {
   const { surface, sx, children, ...rest } = props;
   const theme = useTheme();
   const composition = useAmbiance();
@@ -33,10 +35,10 @@ export function StyledCard(props) {
   });
 
   return (
-    <Card {...rest} sx={Object.assign({}, styles.root, sx)}>
+    <Card ref={ref} {...rest} sx={Object.assign({}, styles.root, sx)}>
       {children}
     </Card>
   );
-}
+});
 
 export default StyledCard;

--- a/imports/ui/components/StyledCard.jsx
+++ b/imports/ui/components/StyledCard.jsx
@@ -1,0 +1,42 @@
+// imports/ui/components/StyledCard.jsx
+//
+// Surface-aware Card, Meteor-object-distributed (Meteor.StyledCard) like
+// Meteor.useTheme — workflow packages consume it without import-path
+// coupling: `const Card = Meteor.StyledCard || MuiCard;`. Resolves its
+// surface from (in order) the `surface` prop, the ambiance zone
+// composition, the global Session axis, then 'solid'. Transitions between
+// states are animated (glass fades, flat melts into negative space). Spec:
+// docs/superpowers/specs/2026-08-03-ambiance-experience-zone-design.md
+
+import React from 'react';
+import Card from '@mui/material/Card';
+import { useTheme } from '@mui/material/styles';
+import { Session } from 'meteor/session';
+import { useTracker } from 'meteor/react-meteor-data';
+import { get } from 'lodash';
+
+import { useAmbiance } from '../theme/AmbianceContext.js';
+import { buildSurfaceStyles } from '../theme/surfaceStyles.js';
+import { CARD_SURFACE } from '/imports/lib/SessionKeys.js';
+
+export function StyledCard(props) {
+  const { surface, sx, children, ...rest } = props;
+  const theme = useTheme();
+  const composition = useAmbiance();
+  const sessionSurface = useTracker(function() { return Session.get(CARD_SURFACE); }, []);
+
+  const active = surface || get(composition, 'cardSurface') || sessionSurface || 'solid';
+  const styles = buildSurfaceStyles({
+    surface: active,
+    paperColor: get(theme, 'palette.background.paper', '#ffffff'),
+    dividerColor: get(theme, 'palette.divider', 'rgba(128,128,128,0.3)')
+  });
+
+  return (
+    <Card {...rest} sx={Object.assign({}, styles.root, sx)}>
+      {children}
+    </Card>
+  );
+}
+
+export default StyledCard;

--- a/imports/ui/components/StyledContainer.jsx
+++ b/imports/ui/components/StyledContainer.jsx
@@ -36,7 +36,8 @@ export const StyledContainer = React.forwardRef(function StyledContainer(props, 
   return (
     <Box ref={ref} {...rest} sx={Object.assign({
       width: '100%',
-      maxWidth: WIDTHS[maxWidth || 'lg'] || WIDTHS.lg,
+      // maxWidth={false} means full-bleed (MUI Container contract).
+      maxWidth: maxWidth === false ? 'none' : (WIDTHS[maxWidth || 'lg'] || WIDTHS.lg),
       px: { xs: 2, md: 3, xl: '200px' },
       boxSizing: 'content-box'
     }, align, showScrim ? {

--- a/imports/ui/components/StyledContainer.jsx
+++ b/imports/ui/components/StyledContainer.jsx
@@ -18,7 +18,9 @@ import { useAmbiance } from '../theme/AmbianceContext.js';
 
 const WIDTHS = { xs: '444px', sm: '600px', md: '900px', lg: '1200px', xl: '1536px' };
 
-export function StyledContainer(props) {
+// forwardRef so MUI transitions (Fade/Grow around page columns — e.g.
+// AutoDashboard) can attach their ref to the underlying Box.
+export const StyledContainer = React.forwardRef(function StyledContainer(props, ref) {
   const { focus, scrim, maxWidth, sx, children, ...rest } = props;
   const theme = useTheme();
   const composition = useAmbiance();
@@ -32,7 +34,7 @@ export function StyledContainer(props) {
   const showScrim = !!scrim && !!get(composition, 'background');
 
   return (
-    <Box {...rest} sx={Object.assign({
+    <Box ref={ref} {...rest} sx={Object.assign({
       width: '100%',
       maxWidth: WIDTHS[maxWidth || 'lg'] || WIDTHS.lg,
       px: { xs: 2, md: 3, xl: '200px' },
@@ -45,6 +47,6 @@ export function StyledContainer(props) {
       {children}
     </Box>
   );
-}
+});
 
 export default StyledContainer;

--- a/imports/ui/components/StyledContainer.jsx
+++ b/imports/ui/components/StyledContainer.jsx
@@ -1,0 +1,50 @@
+// imports/ui/components/StyledContainer.jsx
+//
+// Focus-aware content column, Meteor-object-distributed
+// (Meteor.StyledContainer). Places its column into the ambiance image's
+// neutral space (left | center | right — from the zone composition, or the
+// `focus` prop), with the wide-viewport 200px easement at the xl
+// breakpoint and an optional scrim backdrop. Pages using vanilla
+// <Container> swap one import and inherit placement:
+//   const Wrap = Meteor.StyledContainer || Container;
+// Spec: docs/superpowers/specs/2026-08-03-ambiance-experience-zone-design.md
+
+import React from 'react';
+import Box from '@mui/material/Box';
+import { useTheme, alpha } from '@mui/material/styles';
+import { get } from 'lodash';
+
+import { useAmbiance } from '../theme/AmbianceContext.js';
+
+const WIDTHS = { xs: '444px', sm: '600px', md: '900px', lg: '1200px', xl: '1536px' };
+
+export function StyledContainer(props) {
+  const { focus, scrim, maxWidth, sx, children, ...rest } = props;
+  const theme = useTheme();
+  const composition = useAmbiance();
+
+  const activeFocus = focus || get(composition, 'focus') || 'center';
+  const align = activeFocus === 'left' ? { ml: 0, mr: 'auto' }
+    : activeFocus === 'right' ? { ml: 'auto', mr: 0 }
+    : { mx: 'auto' };
+
+  const scrimStrength = get(composition, 'scrimStrength', 0.55);
+  const showScrim = !!scrim && !!get(composition, 'background');
+
+  return (
+    <Box {...rest} sx={Object.assign({
+      width: '100%',
+      maxWidth: WIDTHS[maxWidth || 'lg'] || WIDTHS.lg,
+      px: { xs: 2, md: 3, xl: '200px' },
+      boxSizing: 'content-box'
+    }, align, showScrim ? {
+      background: alpha(theme.palette.background.default, scrimStrength),
+      backdropFilter: 'blur(2px)',
+      borderRadius: '4px'
+    } : {}, sx)}>
+      {children}
+    </Box>
+  );
+}
+
+export default StyledContainer;

--- a/imports/ui/extensible/NoAuthorizationPage.jsx
+++ b/imports/ui/extensible/NoAuthorizationPage.jsx
@@ -133,9 +133,25 @@ export default function NoAuthorizationPage(props) {
     navigate(signUpPath);
   };
 
+  // The account tile routes to a settings-configurable sign-in path, so a
+  // deployment/brand can point it at a specific entry flow (e.g. Chronicle →
+  // /signin?align=right&valign=bottom&returnTo=%2Fprovider-directory via
+  // settings.public.accounts.signInPath). Defaults to the generic
+  // returnTo-preserving sign-in path when unset.
+  const accountTilePath = get(Meteor, 'settings.public.accounts.signInPath', signInPath);
+  const handleAccountTile = function() {
+    navigate(accountTilePath);
+  };
+
   // Safely get values from settings
   const appTitle = get(Meteor, 'settings.public.title', 'NodeOnFHIR');
-  const appDomain = get(Meteor, 'settings.public.domain', 'nodeonfhir.localhost');
+  // Show the host:port the app is actually served from — localhost:3000 in dev,
+  // the Electron dynamic port, or the deployed DNS host — instead of a static
+  // configured domain. Falls back to settings.public.domain when there's no
+  // window (non-browser render).
+  const appDomain = (typeof window !== 'undefined' && window.location && window.location.host)
+    ? window.location.host
+    : get(Meteor, 'settings.public.domain', 'nodeonfhir.localhost');
   const appVersion = get(Meteor, 'settings.public.version');
   
   // Handle version which might be an object with major/minor/patch
@@ -249,7 +265,7 @@ export default function NoAuthorizationPage(props) {
                   boxShadow: theme => `0 4px 20px ${alpha(theme.palette.primary.main, 0.1)}`,
                 },
               }}
-              onClick={handleSignIn}
+              onClick={handleAccountTile}
             >
               <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
                 <Box
@@ -456,7 +472,7 @@ export default function NoAuthorizationPage(props) {
                   boxShadow: theme => `0 4px 20px ${alpha(theme.palette.primary.main, 0.1)}`,
                 },
               }}
-              onClick={handleSignIn}
+              onClick={handleAccountTile}
             >
               <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
                 <Box
@@ -675,7 +691,7 @@ export default function NoAuthorizationPage(props) {
                 boxShadow: theme => `0 4px 20px ${alpha(theme.palette.primary.main, 0.1)}`,
               },
             }}
-            onClick={handleSignIn}
+            onClick={handleAccountTile}
           >
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
               <Box

--- a/imports/ui/extensible/NotFoundPage.jsx
+++ b/imports/ui/extensible/NotFoundPage.jsx
@@ -1,12 +1,16 @@
 // imports/ui/extensible/NotFoundPage.jsx
 
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import { get } from 'lodash';
 import { Meteor } from 'meteor/meteor';
+import { Session } from 'meteor/session';
+import { useTracker } from 'meteor/react-meteor-data';
 import { useLocation } from 'react-router-dom';
 
 import { Box, Typography, Button } from '@mui/material';
 import HomeIcon from '@mui/icons-material/Home';
+
+import { CARD_SURFACE } from '/imports/lib/SessionKeys.js';
 
 let useNavigate;
 let useAppTheme;
@@ -22,25 +26,9 @@ export function NotFoundPage() {
   const appTheme = useAppTheme ? useAppTheme() : { theme: 'light' };
   const isDark = appTheme.theme === 'dark';
 
-  const [flatCardMode, setFlatCardMode] = useState(false);
-
-  useEffect(function() {
-    function handleKeyDown(e) {
-      if (e.ctrlKey && e.shiftKey && (e.key === 'V' || e.key === 'v')) {
-        e.preventDefault();
-        setFlatCardMode(function(prev) { return !prev; });
-      }
-    }
-    function handleToggleFlatCards() {
-      setFlatCardMode(function(prev) { return !prev; });
-    }
-    window.addEventListener('keydown', handleKeyDown);
-    window.addEventListener('toggleFlatCards', handleToggleFlatCards);
-    return function() {
-      window.removeEventListener('keydown', handleKeyDown);
-      window.removeEventListener('toggleFlatCards', handleToggleFlatCards);
-    };
-  }, []);
+  // Flat mode rides the persisted cardSurface axis (Ctrl+Shift+L cycles it);
+  // the old toggleFlatCards CustomEvent + local Ctrl+Shift+V toggle retired.
+  const flatCardMode = useTracker(function() { return Session.get(CARD_SURFACE) === 'flat'; }, []);
 
   const title = get(Meteor, 'settings.public.404.title',
     get(Meteor, 'settings.public.defaults.notFoundPage.title', 'Page Not Found'));

--- a/imports/ui/guards/AmbianceZone.jsx
+++ b/imports/ui/guards/AmbianceZone.jsx
@@ -11,7 +11,7 @@
 // it renders children unchanged. Spec:
 // docs/superpowers/specs/2026-08-03-ambiance-experience-zone-design.md
 
-import React, { useMemo } from 'react';
+import React, { useMemo, useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
 import { ThemeProvider, useTheme, createTheme } from '@mui/material/styles';
 import { Meteor } from 'meteor/meteor';
@@ -24,13 +24,22 @@ import { buildSurfaceStyles } from '../theme/surfaceStyles.js';
 import { buildPageModeTheme } from '../theme/pageModeTheme.js';
 import { getBackgroundEntry } from '../themeBackgrounds.js';
 import { AmbianceContext } from '../theme/AmbianceContext.js';
+import { registerRouteSurfaceDefault } from '../themePresets.js';
+import { readableAccent } from '../theme/contrastInk.js';
 import { PAGE_MODE, CARD_SURFACE, PAGE_SURFACE_OVERRIDES } from '/imports/lib/SessionKeys.js';
 
 export function AmbianceZone(props) {
   const ambiance = !!props.ambiance;
   const fluid = !!props.fluid || ambiance;   // enableAmbiance implies fluid
+  const defaultSurface = props.defaultSurface;   // route-declared baseline ('flat' etc.)
   const appTheme = useTheme();
   const location = useLocation();
+
+  // Let the Ctrl+Shift+K toggle know this route's baseline, so it flips
+  // flat-by-default routes to solid cards (and back) instead of no-op'ing.
+  useEffect(function() {
+    registerRouteSurfaceDefault(location.pathname, defaultSurface);
+  }, [location.pathname, defaultSurface]);
 
   // Reactive axes (Session); background is a PLAIN read — the provider
   // rebuild re-renders us (never useTracker a bare settings read).
@@ -48,11 +57,39 @@ export function AmbianceZone(props) {
     entry: ambiance ? getBackgroundEntry(activeBg) : null,
     pageMode: pageMode,
     cardSurface: cardSurface,
-    surfaceOverride: surfaceOverride
+    surfaceOverride: surfaceOverride,
+    surfaceDefault: defaultSurface
   });
 
   const zoneTheme = useMemo(function() {
-    const base = buildPageModeTheme(appTheme, composition.pageMode) || appTheme;
+    // Cards follow the APP mode: the forced page-mode ink (the AUTO
+    // adjust-to-background behavior) applies only to the 'flat' surface,
+    // where content sits directly on the ambiance background. Solid and
+    // glass cards keep app-mode paper + ink — otherwise app-mode surfaces
+    // meet page-mode text and the card interiors read inverted/washed out.
+    let base = composition.cardSurface === 'flat'
+      ? (buildPageModeTheme(appTheme, composition.pageMode) || appTheme)
+      : appTheme;
+
+    // Accent legibility (ambiance pages only): invert an accent's brightness
+    // — hue preserved — when it matches the zone's surface polarity, so e.g.
+    // Tron cyan reads as deep teal on a light canvas but stays bright cyan on
+    // dark. Self-styled consoles that derive CSS vars from palette.primary
+    // (DirectoryConsole) pick this up automatically.
+    const zoneMode = base.palette.mode;
+    const primaryMain = get(base, 'palette.primary.main', '');
+    const secondaryMain = get(base, 'palette.secondary.main', '');
+    const readablePrimary = readableAccent(primaryMain, zoneMode);
+    const readableSecondary = readableAccent(secondaryMain, zoneMode);
+    if (readablePrimary !== primaryMain || readableSecondary !== secondaryMain) {
+      base = createTheme(base, {
+        palette: {
+          primary: base.palette.augmentColor({ color: { main: readablePrimary } }),
+          secondary: base.palette.augmentColor({ color: { main: readableSecondary } })
+        }
+      });
+    }
+
     if (composition.cardSurface === 'solid') { return base; }
     const surface = buildSurfaceStyles({
       surface: composition.cardSurface,

--- a/imports/ui/guards/AmbianceZone.jsx
+++ b/imports/ui/guards/AmbianceZone.jsx
@@ -1,0 +1,89 @@
+// imports/ui/guards/AmbianceZone.jsx
+//
+// Router-level zone wrapper (composes like AuthGuard/PatientGuard — see
+// App.jsx StyledMainRouter). On routes declaring enableAmbiance or
+// enableFluidInterface it: (1) assembles the composition object from the
+// active background's curation record + persisted axes, (2) provides it via
+// AmbianceContext + --ambiance-* CSS vars, and (3) wraps children in a
+// page-mode theme carrying MuiCard/MuiPaper overrides for the active card
+// surface — so even raw MUI cards render legibly over ambiance
+// (correctness by construction; discipline not required). With neither flag
+// it renders children unchanged. Spec:
+// docs/superpowers/specs/2026-08-03-ambiance-experience-zone-design.md
+
+import React, { useMemo } from 'react';
+import { useLocation } from 'react-router-dom';
+import { ThemeProvider, useTheme, createTheme } from '@mui/material/styles';
+import { Meteor } from 'meteor/meteor';
+import { Session } from 'meteor/session';
+import { useTracker } from 'meteor/react-meteor-data';
+import { get } from 'lodash';
+
+import { resolveComposition } from '../theme/ambianceComposition.js';
+import { buildSurfaceStyles } from '../theme/surfaceStyles.js';
+import { buildPageModeTheme } from '../theme/pageModeTheme.js';
+import { getBackgroundEntry } from '../themeBackgrounds.js';
+import { AmbianceContext } from '../theme/AmbianceContext.js';
+import { PAGE_MODE, CARD_SURFACE, PAGE_SURFACE_OVERRIDES } from '/imports/lib/SessionKeys.js';
+
+export function AmbianceZone(props) {
+  const ambiance = !!props.ambiance;
+  const fluid = !!props.fluid || ambiance;   // enableAmbiance implies fluid
+  const appTheme = useTheme();
+  const location = useLocation();
+
+  // Reactive axes (Session); background is a PLAIN read — the provider
+  // rebuild re-renders us (never useTracker a bare settings read).
+  const pageMode = useTracker(function() { return Session.get(PAGE_MODE); }, []);
+  const cardSurface = useTracker(function() { return Session.get(CARD_SURFACE); }, []);
+  const surfaceOverride = useTracker(function() {
+    const overrides = Session.get(PAGE_SURFACE_OVERRIDES) || {};
+    return overrides[location.pathname];
+  }, [location.pathname]);
+
+  const activeBg = get(Meteor, 'settings.public.theme.backgroundImagePath', '');
+
+  const composition = resolveComposition({
+    background: ambiance ? activeBg : '',   // fluid-only routes paint their own backdrop
+    entry: ambiance ? getBackgroundEntry(activeBg) : null,
+    pageMode: pageMode,
+    cardSurface: cardSurface,
+    surfaceOverride: surfaceOverride
+  });
+
+  const zoneTheme = useMemo(function() {
+    const base = buildPageModeTheme(appTheme, composition.pageMode) || appTheme;
+    if (composition.cardSurface === 'solid') { return base; }
+    const surface = buildSurfaceStyles({
+      surface: composition.cardSurface,
+      paperColor: get(base, 'palette.background.paper', '#ffffff'),
+      dividerColor: get(base, 'palette.divider', 'rgba(128,128,128,0.3)')
+    });
+    return createTheme(base, {
+      components: {
+        MuiCard: { styleOverrides: { root: surface.root } },
+        MuiPaper: { styleOverrides: { root: surface.root } }
+      }
+    });
+  }, [appTheme, composition.pageMode, composition.cardSurface]);
+
+  // Early return AFTER all hooks (React hooks-order rule); fluid is a
+  // static route capability, but keep the hook order unconditional anyway.
+  if (!fluid) { return props.children; }
+
+  return (
+    <AmbianceContext.Provider value={composition}>
+      <ThemeProvider theme={zoneTheme}>
+        <div style={{
+          height: '100%',
+          '--ambiance-focus': composition.focus,
+          '--ambiance-scrim': String(composition.scrimStrength)
+        }}>
+          {props.children}
+        </div>
+      </ThemeProvider>
+    </AmbianceContext.Provider>
+  );
+}
+
+export default AmbianceZone;

--- a/imports/ui/theme/AmbianceContext.js
+++ b/imports/ui/theme/AmbianceContext.js
@@ -1,0 +1,15 @@
+// imports/ui/theme/AmbianceContext.js
+//
+// React context carrying the zone composition object (see
+// ambianceComposition.js). Provided by AmbianceZone on enableAmbiance /
+// enableFluidInterface routes; useAmbiance() returns null everywhere else,
+// so shared components (StyledCard/StyledContainer) can fall back to
+// Session/global reads outside a zone.
+
+import React from 'react';
+
+export const AmbianceContext = React.createContext(null);
+
+export function useAmbiance() {
+  return React.useContext(AmbianceContext);
+}

--- a/imports/ui/theme/AmbianceInk.jsx
+++ b/imports/ui/theme/AmbianceInk.jsx
@@ -1,0 +1,41 @@
+// imports/ui/theme/AmbianceInk.jsx
+//
+// Ink wrapper for content that sits DIRECTLY on the ambiance background
+// (section headers, toolbars — anything outside a card). AmbianceZone gives
+// solid/glass pages the plain app theme so cards follow the app mode; this
+// wrapper re-applies the zone's resolved page-text mode (the PAGE TEXT
+// control / per-background AUTO curation) to just its children, so
+// on-background text stays legible against the backdrop regardless of the
+// card surface. No-op passthrough outside a zone, when no page mode is
+// resolved, or when it already matches the app mode.
+// Spec: docs/superpowers/specs/2026-08-03-ambiance-experience-zone-design.md
+
+import React, { useMemo } from 'react';
+import { ThemeProvider, useTheme } from '@mui/material/styles';
+import { Meteor } from 'meteor/meteor';
+
+import { useAmbiance } from './AmbianceContext.js';
+import { buildPageModeTheme } from './pageModeTheme.js';
+
+export function AmbianceInk(props) {
+  const appTheme = useTheme();
+  const composition = useAmbiance();
+  const pageMode = composition ? composition.pageMode : null;
+
+  const inkTheme = useMemo(function() {
+    return buildPageModeTheme(appTheme, pageMode) || appTheme;
+  }, [appTheme, pageMode]);
+
+  if (inkTheme === appTheme) { return props.children; }
+
+  return (
+    <ThemeProvider theme={inkTheme}>
+      {props.children}
+    </ThemeProvider>
+  );
+}
+
+// Packages can't import app paths — expose alongside Meteor.StyledCard etc.
+Meteor.AmbianceInk = AmbianceInk;
+
+export default AmbianceInk;

--- a/imports/ui/theme/AmbianceTuningHud.jsx
+++ b/imports/ui/theme/AmbianceTuningHud.jsx
@@ -59,6 +59,7 @@ export function AmbianceTuningHud() {
       await navigator.clipboard.writeText(JSON.stringify(curationRecord(), null, 2));
       setCopied(true);
     } catch (error) {
+      console.warn('[AmbianceTuningHud] Clipboard write failed:', error && error.message);
       setCopied(false);
     }
   }

--- a/imports/ui/theme/AmbianceTuningHud.jsx
+++ b/imports/ui/theme/AmbianceTuningHud.jsx
@@ -1,0 +1,121 @@
+// imports/ui/theme/AmbianceTuningHud.jsx
+//
+// Dev-tool overlay (Cmd/Ctrl+Shift+E) for authoring ambiance curation
+// records against the live page: tune focus / scrim / ink / surface /
+// accent, then Copy as JSON to paste into themeBackgrounds.js or
+// settings.public.theme.backgroundLibrary. Session Inspector posture: no
+// PHI, no persistence of its own (clipboard out only), hidden behind the
+// hotkey. Spec: docs/superpowers/specs/2026-08-03-ambiance-experience-zone-design.md
+
+import React from 'react';
+import {
+  Paper, Typography, Slider, Select, MenuItem, TextField, Button, Stack, IconButton
+} from '@mui/material';
+import CloseIcon from '@mui/icons-material/Close';
+import ContentCopyIcon from '@mui/icons-material/ContentCopy';
+import { Meteor } from 'meteor/meteor';
+import { Session } from 'meteor/session';
+import { useTracker } from 'meteor/react-meteor-data';
+import { get } from 'lodash';
+
+import { getBackgroundEntry } from '../themeBackgrounds.js';
+import { setPageMode, setCardSurface, setAccentHue } from '../themePresets.js';
+import { AMBIANCE_HUD_OPEN, PAGE_MODE, CARD_SURFACE } from '/imports/lib/SessionKeys.js';
+
+export function AmbianceTuningHud() {
+  const open = useTracker(function() { return !!Session.get(AMBIANCE_HUD_OPEN); }, []);
+  const pageMode = useTracker(function() { return Session.get(PAGE_MODE) || ''; }, []);
+  const cardSurface = useTracker(function() { return Session.get(CARD_SURFACE) || 'solid'; }, []);
+
+  const activeBg = get(Meteor, 'settings.public.theme.backgroundImagePath', '');
+  const entry = getBackgroundEntry(activeBg);
+
+  const [focus, setFocus] = React.useState(get(entry, 'focus', 'center'));
+  const [scrim, setScrim] = React.useState(get(entry, 'scrimStrength', 0.55));
+  const [accent, setAccent] = React.useState(get(Meteor, 'settings.public.theme.palette.primaryColor', ''));
+  const [copied, setCopied] = React.useState(false);
+
+  // Re-seed the draft when the background changes while open.
+  React.useEffect(function() {
+    setFocus(get(entry, 'focus', 'center'));
+    setScrim(get(entry, 'scrimStrength', 0.55));
+    setCopied(false);
+  }, [activeBg]);
+
+  if (!open) { return null; }
+
+  function curationRecord() {
+    return {
+      name: get(entry, 'name', '(unnamed)'),
+      src: activeBg,
+      focus: focus,
+      recommendedPageMode: pageMode || get(entry, 'recommendedPageMode', undefined),
+      scrimStrength: Math.round(scrim * 100) / 100
+    };
+  }
+
+  async function handleCopy() {
+    try {
+      await navigator.clipboard.writeText(JSON.stringify(curationRecord(), null, 2));
+      setCopied(true);
+    } catch (error) {
+      setCopied(false);
+    }
+  }
+
+  return (
+    <Paper elevation={8} sx={{
+      position: 'fixed', right: 16, bottom: 80, width: 300, p: 2, zIndex: 1400,
+      bgcolor: 'background.paper'
+    }}>
+      <Stack direction="row" sx={{ alignItems: 'center', justifyContent: 'space-between', mb: 1 }}>
+        <Typography variant="overline">Ambiance tuning</Typography>
+        <IconButton size="small" id="ambianceHudClose" onClick={function() { Session.set(AMBIANCE_HUD_OPEN, false); }}>
+          <CloseIcon fontSize="small" />
+        </IconButton>
+      </Stack>
+      <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 1 }}>
+        {activeBg ? (get(entry, 'name') || activeBg) : 'No ambiance background active'}
+      </Typography>
+
+      <Typography variant="caption">Scrim strength — {Math.round(scrim * 100)}%</Typography>
+      <Slider id="ambianceHudScrim" size="small" min={0} max={1} step={0.05} value={scrim}
+        onChange={function(e, v) { setScrim(v); }} sx={{ mb: 1 }} />
+
+      <Stack spacing={1} sx={{ mb: 1 }}>
+        <Select id="ambianceHudFocus" size="small" value={focus}
+          onChange={function(e) { setFocus(e.target.value); }}>
+          <MenuItem value="left">Focus: left</MenuItem>
+          <MenuItem value="center">Focus: center</MenuItem>
+          <MenuItem value="right">Focus: right</MenuItem>
+        </Select>
+        <Select id="ambianceHudPageMode" size="small" value={pageMode} displayEmpty
+          onChange={function(e) { setPageMode(e.target.value || null); }}>
+          <MenuItem value="">Ink: auto</MenuItem>
+          <MenuItem value="light">Ink: light</MenuItem>
+          <MenuItem value="dark">Ink: dark</MenuItem>
+        </Select>
+        <Select id="ambianceHudSurface" size="small" value={cardSurface}
+          onChange={function(e) { setCardSurface(e.target.value); }}>
+          <MenuItem value="solid">Surface: solid</MenuItem>
+          <MenuItem value="glass">Surface: glass</MenuItem>
+          <MenuItem value="flat">Surface: flat</MenuItem>
+        </Select>
+        <TextField id="ambianceHudAccent" size="small" label="Accent hex" value={accent}
+          onChange={function(e) { setAccent(e.target.value); }}
+          onBlur={function() { if (/^#[0-9a-fA-F]{6}$/.test(accent)) { setAccentHue(accent); } }} />
+      </Stack>
+
+      <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 1 }}>
+        Ink/surface/accent apply live. Focus + scrim land in the copied
+        record — paste into the background library to take effect.
+      </Typography>
+      <Button id="ambianceHudCopy" fullWidth size="small" variant="contained"
+        startIcon={<ContentCopyIcon />} onClick={handleCopy} disabled={!activeBg}>
+        {copied ? 'Copied' : 'Copy as JSON'}
+      </Button>
+    </Paper>
+  );
+}
+
+export default AmbianceTuningHud;

--- a/imports/ui/theme/PaletteFieldEditor.jsx
+++ b/imports/ui/theme/PaletteFieldEditor.jsx
@@ -1,16 +1,19 @@
 // imports/ui/theme/PaletteFieldEditor.jsx
 //
-// Shared per-field palette editor: grouped TextField color inputs + a
-// Wheel/ShadeSlider picker dialog. Extracted from ThemingPage's inline
-// ColorField so BOTH the Theme & Palette dialog (live adapter) and /theming
-// (draft adapter) drive the same fields.
+// Shared per-field palette editor: accordion-grouped TextField color inputs
+// (Main Theme / App Bar / Surfaces / Alerts) on the left, with ONE
+// field-bound Wheel + ShadeSlider on the right. Clicking a field's palette
+// icon binds the wheel to that field; the wheel defaults to the Accent
+// (primaryColor) — this is where the old Basic-controls ACCENT HUE wheel
+// lives now. Extracted from ThemingPage's inline ColorField so BOTH the
+// Theme & Palette dialog (live adapter) and /theming drive the same fields.
 //
 // Value-source-agnostic: the caller supplies getValue(fieldKey) / setValue(
 // fieldKey, value) where fieldKey is a BARE palette key ('appBarColorDark'),
 // not a dotted path — the dialog writes Meteor.settings.public.theme.palette,
-// the page writes local React state. Refresh/persist is the caller's job in
-// setValue; the editor only reads/writes values and defers heavy work to
-// blur/apply (never per-keystroke or per-wheel-drag).
+// /theming does the same (both adapters are live). One exception: edits to
+// primaryColor route through setAccentHue() so accent-tracking presets
+// (Tron/Vaporwave app-bar text) keep their behavior.
 //
 // PALETTE_FIELD_GROUPS is the ONE canonical key list. It targets the keys
 // CustomThemeProvider.createDynamicTheme reads FIRST — surfaces use
@@ -19,27 +22,25 @@
 
 import React from 'react';
 import {
-  Box, Grid, Typography, Divider, TextField, InputAdornment, IconButton,
-  Dialog, DialogTitle, DialogContent, DialogActions, Button
+  Box, Grid, Typography, TextField, InputAdornment, IconButton,
+  Accordion, AccordionSummary, AccordionDetails
 } from '@mui/material';
 import PaletteIcon from '@mui/icons-material/Palette';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import Wheel from '@uiw/react-color-wheel';
 import ShadeSlider from '@uiw/react-color-shade-slider';
-import { hsvaToHex } from '@uiw/color-convert';
+import { hsvaToHex, hexToHsva } from '@uiw/color-convert';
+import { setAccentHue } from '../themePresets.js';
 
 // Canonical, provider-aligned key set. Do NOT add backgroundPageColor* or the
 // unsuffixed canvasColor/paperColor/cardColor here — they lose to these keys
 // in createDynamicTheme, so edits would be shadowed by any active preset.
 export const PALETTE_FIELD_GROUPS = [
   {
-    title: 'Status',
+    title: 'Main Theme',
     fields: [
-      { key: 'primaryColor', label: 'Primary', help: 'Main brand color' },
-      { key: 'secondaryColor', label: 'Secondary', help: 'Accent color' },
-      { key: 'successColor', label: 'Success', help: '' },
-      { key: 'infoColor', label: 'Info', help: '' },
-      { key: 'warningColor', label: 'Warning', help: '' },
-      { key: 'errorColor', label: 'Error', help: '' }
+      { key: 'primaryColor', label: 'Accent (Primary)', help: 'Main brand color — desaturate → Limestone, saturate → Tron' },
+      { key: 'secondaryColor', label: 'Secondary', help: 'Supporting accent' }
     ]
   },
   {
@@ -61,103 +62,161 @@ export const PALETTE_FIELD_GROUPS = [
       { key: 'cardColorLight', label: 'Card', help: 'Light MuiCard override' },
       { key: 'cardColorDark', label: 'Card (Dark)', help: 'Dark MuiCard override' }
     ]
+  },
+  {
+    title: 'Alerts',
+    fields: [
+      { key: 'successColor', label: 'Success', help: '' },
+      { key: 'infoColor', label: 'Info', help: '' },
+      { key: 'warningColor', label: 'Warning', help: '' },
+      { key: 'errorColor', label: 'Error', help: '' }
+    ]
   }
 ];
 
+const FALLBACK_HSVA = { h: 214, s: 43, v: 90, a: 1 };
+
+function hsvaFromHex(hex) {
+  try {
+    if (hex) { return Object.assign({ a: 1 }, hexToHsva(hex)); }
+  } catch (e) { /* not a parseable hex — fall through */ }
+  return FALLBACK_HSVA;
+}
+
 export function PaletteFieldEditor({ getValue, setValue, fields = PALETTE_FIELD_GROUPS }) {
-  const [pickerOpen, setPickerOpen] = React.useState(false);
-  const [pickerKey, setPickerKey] = React.useState('');
-  const [tempColor, setTempColor] = React.useState({ h: 214, s: 43, v: 90, a: 1 });
+  // The wheel's bound field — Accent by default (the old ACCENT HUE wheel).
+  const [activeKey, setActiveKey] = React.useState('primaryColor');
+  const [hsva, setHsva] = React.useState(function() { return hsvaFromHex(getValue('primaryColor')); });
 
   // Local draft of text values so typing doesn't push a theme refresh per
   // keystroke; the caller's setValue (which may refresh/persist) fires on blur.
   const [drafts, setDrafts] = React.useState({});
+
+  const flatFields = fields.reduce(function(acc, group) { return acc.concat(group.fields); }, []);
+  const activeField = flatFields.find(function(f) { return f.key === activeKey; }) || flatFields[0] || {};
 
   function readValue(key) {
     if (key in drafts) { return drafts[key]; }
     return getValue(key) || '';
   }
 
+  function writeValue(key, value) {
+    // Accent edits ride setAccentHue so accent-tracking presets stay wired.
+    if (key === 'primaryColor') { setAccentHue(value); }
+    else { setValue(key, value); }
+  }
+
   function commit(key, value) {
-    setValue(key, value);
+    writeValue(key, value);
     setDrafts(function(prev) {
       const next = Object.assign({}, prev);
       delete next[key];
       return next;
     });
+    if (key === activeKey) { setHsva(hsvaFromHex(value)); }
   }
 
-  function openPicker(key) {
-    setPickerKey(key);
-    setTempColor({ h: 214, s: 43, v: 90, a: 1 });
-    setPickerOpen(true);
+  function bindWheel(key) {
+    setActiveKey(key);
+    setHsva(hsvaFromHex(getValue(key)));
   }
 
-  function applyPicked() {
-    commit(pickerKey, hsvaToHex(tempColor));
-    setPickerOpen(false);
+  function handleWheelChange(nextHsva) {
+    const merged = Object.assign({}, hsva, nextHsva);
+    setHsva(merged);
+    writeValue(activeKey, hsvaToHex(merged));
   }
+
+  const liveHex = hsvaToHex(hsva);
 
   return (
-    <Box>
-      {fields.map(function(group, gi) {
-        return (
-          <Box key={group.title} sx={{ mb: 2 }}>
-            {gi > 0 ? <Divider sx={{ mb: 2 }} /> : null}
-            <Typography variant="subtitle2" gutterBottom>{group.title}</Typography>
-            <Grid container spacing={2}>
-              {group.fields.map(function(field) {
-                return (
-                  <Grid item xs={6} key={field.key}>
-                    <TextField
-                      fullWidth
-                      size="small"
-                      variant="outlined"
-                      label={field.label}
-                      helperText={field.help}
-                      value={readValue(field.key)}
-                      onChange={function(e) {
-                        const v = e.target.value;
-                        setDrafts(function(prev) { return Object.assign({}, prev, { [field.key]: v }); });
-                      }}
-                      onBlur={function(e) { commit(field.key, e.target.value); }}
-                      InputProps={{
-                        endAdornment: (
-                          <InputAdornment position="end">
-                            <Box sx={{ width: 18, height: 18, mr: 0.5, borderRadius: '3px', border: '1px solid', borderColor: 'divider', bgcolor: readValue(field.key) || 'transparent' }} />
-                            <IconButton edge="end" size="small" aria-label={'Pick ' + field.label} onClick={function() { openPicker(field.key); }}>
-                              <PaletteIcon fontSize="small" />
-                            </IconButton>
-                          </InputAdornment>
-                        )
-                      }}
-                    />
-                  </Grid>
-                );
-              })}
-            </Grid>
-          </Box>
-        );
-      })}
+    <Box sx={{ display: 'grid', gridTemplateColumns: { xs: '1fr', md: 'minmax(0, 1fr) 220px' }, gap: 3, alignItems: 'start' }}>
+      {/* LEFT — accordion field groups */}
+      <Box>
+        {fields.map(function(group, gi) {
+          return (
+            <Accordion key={group.title} defaultExpanded={gi === 0} disableGutters elevation={0}
+              sx={{ border: '1px solid', borderColor: 'divider', '&:not(:last-of-type)': { borderBottom: 0 }, '&::before': { display: 'none' } }}>
+              <AccordionSummary expandIcon={<ExpandMoreIcon />} id={'palette-group-' + group.title.replace(/\W+/g, '-').toLowerCase()}>
+                <Typography variant="subtitle2">{group.title}</Typography>
+              </AccordionSummary>
+              <AccordionDetails>
+                <Grid container spacing={2}>
+                  {group.fields.map(function(field) {
+                    const active = field.key === activeKey;
+                    return (
+                      <Grid item xs={12} sm={6} key={field.key}>
+                        <TextField
+                          fullWidth
+                          size="small"
+                          variant="outlined"
+                          label={field.label}
+                          helperText={field.help}
+                          focused={active || undefined}
+                          value={readValue(field.key)}
+                          onChange={function(e) {
+                            const v = e.target.value;
+                            setDrafts(function(prev) { return Object.assign({}, prev, { [field.key]: v }); });
+                          }}
+                          onBlur={function(e) { commit(field.key, e.target.value); }}
+                          InputProps={{
+                            endAdornment: (
+                              <InputAdornment position="end">
+                                <Box sx={{ width: 18, height: 18, mr: 0.5, borderRadius: '3px', border: '1px solid', borderColor: 'divider', bgcolor: readValue(field.key) || 'transparent' }} />
+                                <IconButton
+                                  edge="end" size="small"
+                                  aria-label={'Edit ' + field.label + ' with the color wheel'}
+                                  color={active ? 'primary' : 'default'}
+                                  onClick={function() { bindWheel(field.key); }}
+                                >
+                                  <PaletteIcon fontSize="small" />
+                                </IconButton>
+                              </InputAdornment>
+                            )
+                          }}
+                        />
+                      </Grid>
+                    );
+                  })}
+                </Grid>
+              </AccordionDetails>
+            </Accordion>
+          );
+        })}
+      </Box>
 
-      <Dialog open={pickerOpen} onClose={function() { setPickerOpen(false); }} maxWidth="sm" fullWidth>
-        <DialogTitle>Choose Color</DialogTitle>
-        <DialogContent>
-          <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 2, pt: 2 }}>
-            <Wheel color={tempColor} onChange={function(color) { setTempColor(Object.assign({}, tempColor, color.hsva)); }} width={280} height={280} />
-            <ShadeSlider hsva={tempColor} style={{ width: '280px' }} onChange={function(shade) { setTempColor(Object.assign({}, tempColor, shade)); }} />
-            <Box sx={{ width: '100%', p: 2, borderRadius: 1, border: '1px solid', borderColor: 'divider', textAlign: 'center', backgroundColor: hsvaToHex(tempColor) }}>
-              <Typography variant="body2" sx={{ color: tempColor.v > 50 ? '#000' : '#fff', fontFamily: 'monospace' }}>
-                {hsvaToHex(tempColor)}
-              </Typography>
-            </Box>
+      {/* RIGHT — the ONE color wheel, bound to the selected field */}
+      <Box sx={{ position: { md: 'sticky' }, top: { md: 8 }, display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 1.5 }}>
+        <Typography variant="overline" color="text.secondary" sx={{ alignSelf: 'flex-start' }}>Color wheel</Typography>
+        <Wheel
+          color={hsva}
+          onChange={function(color) { handleWheelChange(color.hsva); }}
+          width={180}
+          height={180}
+        />
+        <ShadeSlider
+          hsva={hsva}
+          style={{ width: '180px' }}
+          onChange={function(shade) { handleWheelChange(shade); }}
+        />
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, alignSelf: 'stretch' }}>
+          <Box sx={{ width: 32, height: 32, borderRadius: '4px', bgcolor: liveHex, border: '1px solid', borderColor: 'divider' }} />
+          <Box sx={{ minWidth: 0 }}>
+            <Typography variant="caption" sx={{ display: 'block', fontWeight: 600 }} noWrap>
+              {activeField.label || activeKey}
+            </Typography>
+            <Typography variant="caption" sx={{ fontFamily: 'monospace' }}>{liveHex}</Typography>
           </Box>
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={function() { setPickerOpen(false); }}>Cancel</Button>
-          <Button onClick={applyPicked} variant="contained" color="primary">Choose Color</Button>
-        </DialogActions>
-      </Dialog>
+        </Box>
+        {activeKey === 'primaryColor' ? (
+          <Typography variant="caption" color="text.secondary" sx={{ alignSelf: 'flex-start' }}>
+            Desaturate → Limestone · saturate → Tron
+          </Typography>
+        ) : null}
+        <Typography variant="caption" color="text.secondary" sx={{ alignSelf: 'flex-start' }}>
+          Click a field's palette icon to edit it here.
+        </Typography>
+      </Box>
     </Box>
   );
 }

--- a/imports/ui/theme/PaletteFieldEditor.jsx
+++ b/imports/ui/theme/PaletteFieldEditor.jsx
@@ -1,0 +1,165 @@
+// imports/ui/theme/PaletteFieldEditor.jsx
+//
+// Shared per-field palette editor: grouped TextField color inputs + a
+// Wheel/ShadeSlider picker dialog. Extracted from ThemingPage's inline
+// ColorField so BOTH the Theme & Palette dialog (live adapter) and /theming
+// (draft adapter) drive the same fields.
+//
+// Value-source-agnostic: the caller supplies getValue(fieldKey) / setValue(
+// fieldKey, value) where fieldKey is a BARE palette key ('appBarColorDark'),
+// not a dotted path — the dialog writes Meteor.settings.public.theme.palette,
+// the page writes local React state. Refresh/persist is the caller's job in
+// setValue; the editor only reads/writes values and defers heavy work to
+// blur/apply (never per-keystroke or per-wheel-drag).
+//
+// PALETTE_FIELD_GROUPS is the ONE canonical key list. It targets the keys
+// CustomThemeProvider.createDynamicTheme reads FIRST — surfaces use
+// backgroundCanvas* / paperColor*Dark / cardColor*, NOT the legacy
+// backgroundPageColor* (lower precedence → silently shadowed by presets).
+
+import React from 'react';
+import {
+  Box, Grid, Typography, Divider, TextField, InputAdornment, IconButton,
+  Dialog, DialogTitle, DialogContent, DialogActions, Button
+} from '@mui/material';
+import PaletteIcon from '@mui/icons-material/Palette';
+import Wheel from '@uiw/react-color-wheel';
+import ShadeSlider from '@uiw/react-color-shade-slider';
+import { hsvaToHex } from '@uiw/color-convert';
+
+// Canonical, provider-aligned key set. Do NOT add backgroundPageColor* or the
+// unsuffixed canvasColor/paperColor/cardColor here — they lose to these keys
+// in createDynamicTheme, so edits would be shadowed by any active preset.
+export const PALETTE_FIELD_GROUPS = [
+  {
+    title: 'Status',
+    fields: [
+      { key: 'primaryColor', label: 'Primary', help: 'Main brand color' },
+      { key: 'secondaryColor', label: 'Secondary', help: 'Accent color' },
+      { key: 'successColor', label: 'Success', help: '' },
+      { key: 'infoColor', label: 'Info', help: '' },
+      { key: 'warningColor', label: 'Warning', help: '' },
+      { key: 'errorColor', label: 'Error', help: '' }
+    ]
+  },
+  {
+    title: 'App Bar (Header / Footer)',
+    fields: [
+      { key: 'appBarColor', label: 'App Bar', help: 'Light mode (defaults to primary)' },
+      { key: 'appBarColorDark', label: 'App Bar (Dark)', help: 'Dark mode' },
+      { key: 'appBarTextColor', label: 'App Bar Text', help: 'Light mode text' },
+      { key: 'appBarTextColorDark', label: 'App Bar Text (Dark)', help: 'Dark mode text' }
+    ]
+  },
+  {
+    title: 'Surfaces',
+    fields: [
+      { key: 'backgroundCanvas', label: 'Canvas', help: 'Light page background' },
+      { key: 'backgroundCanvasDark', label: 'Canvas (Dark)', help: 'Dark page background' },
+      { key: 'paperColorLight', label: 'Paper', help: 'Light cards / surfaces' },
+      { key: 'paperColorDark', label: 'Paper (Dark)', help: 'Dark cards / surfaces' },
+      { key: 'cardColorLight', label: 'Card', help: 'Light MuiCard override' },
+      { key: 'cardColorDark', label: 'Card (Dark)', help: 'Dark MuiCard override' }
+    ]
+  }
+];
+
+export function PaletteFieldEditor({ getValue, setValue, fields = PALETTE_FIELD_GROUPS }) {
+  const [pickerOpen, setPickerOpen] = React.useState(false);
+  const [pickerKey, setPickerKey] = React.useState('');
+  const [tempColor, setTempColor] = React.useState({ h: 214, s: 43, v: 90, a: 1 });
+
+  // Local draft of text values so typing doesn't push a theme refresh per
+  // keystroke; the caller's setValue (which may refresh/persist) fires on blur.
+  const [drafts, setDrafts] = React.useState({});
+
+  function readValue(key) {
+    if (key in drafts) { return drafts[key]; }
+    return getValue(key) || '';
+  }
+
+  function commit(key, value) {
+    setValue(key, value);
+    setDrafts(function(prev) {
+      const next = Object.assign({}, prev);
+      delete next[key];
+      return next;
+    });
+  }
+
+  function openPicker(key) {
+    setPickerKey(key);
+    setTempColor({ h: 214, s: 43, v: 90, a: 1 });
+    setPickerOpen(true);
+  }
+
+  function applyPicked() {
+    commit(pickerKey, hsvaToHex(tempColor));
+    setPickerOpen(false);
+  }
+
+  return (
+    <Box>
+      {fields.map(function(group, gi) {
+        return (
+          <Box key={group.title} sx={{ mb: 2 }}>
+            {gi > 0 ? <Divider sx={{ mb: 2 }} /> : null}
+            <Typography variant="subtitle2" gutterBottom>{group.title}</Typography>
+            <Grid container spacing={2}>
+              {group.fields.map(function(field) {
+                return (
+                  <Grid item xs={6} key={field.key}>
+                    <TextField
+                      fullWidth
+                      size="small"
+                      variant="outlined"
+                      label={field.label}
+                      helperText={field.help}
+                      value={readValue(field.key)}
+                      onChange={function(e) {
+                        const v = e.target.value;
+                        setDrafts(function(prev) { return Object.assign({}, prev, { [field.key]: v }); });
+                      }}
+                      onBlur={function(e) { commit(field.key, e.target.value); }}
+                      InputProps={{
+                        endAdornment: (
+                          <InputAdornment position="end">
+                            <Box sx={{ width: 18, height: 18, mr: 0.5, borderRadius: '3px', border: '1px solid', borderColor: 'divider', bgcolor: readValue(field.key) || 'transparent' }} />
+                            <IconButton edge="end" size="small" aria-label={'Pick ' + field.label} onClick={function() { openPicker(field.key); }}>
+                              <PaletteIcon fontSize="small" />
+                            </IconButton>
+                          </InputAdornment>
+                        )
+                      }}
+                    />
+                  </Grid>
+                );
+              })}
+            </Grid>
+          </Box>
+        );
+      })}
+
+      <Dialog open={pickerOpen} onClose={function() { setPickerOpen(false); }} maxWidth="sm" fullWidth>
+        <DialogTitle>Choose Color</DialogTitle>
+        <DialogContent>
+          <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 2, pt: 2 }}>
+            <Wheel color={tempColor} onChange={function(color) { setTempColor(Object.assign({}, tempColor, color.hsva)); }} width={280} height={280} />
+            <ShadeSlider hsva={tempColor} style={{ width: '280px' }} onChange={function(shade) { setTempColor(Object.assign({}, tempColor, shade)); }} />
+            <Box sx={{ width: '100%', p: 2, borderRadius: 1, border: '1px solid', borderColor: 'divider', textAlign: 'center', backgroundColor: hsvaToHex(tempColor) }}>
+              <Typography variant="body2" sx={{ color: tempColor.v > 50 ? '#000' : '#fff', fontFamily: 'monospace' }}>
+                {hsvaToHex(tempColor)}
+              </Typography>
+            </Box>
+          </Box>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={function() { setPickerOpen(false); }}>Cancel</Button>
+          <Button onClick={applyPicked} variant="contained" color="primary">Choose Color</Button>
+        </DialogActions>
+      </Dialog>
+    </Box>
+  );
+}
+
+export default PaletteFieldEditor;

--- a/imports/ui/theme/ThemeControls.jsx
+++ b/imports/ui/theme/ThemeControls.jsx
@@ -11,29 +11,26 @@
 
 import React from 'react';
 import {
-  Box, Typography, Button, ButtonBase, Chip, Divider, Select, MenuItem,
+  Box, Typography, ButtonBase, Chip, Divider, Select, MenuItem,
   FormControl, InputLabel, Stack, Tooltip
 } from '@mui/material';
 import ToggleButton from '@mui/material/ToggleButton';
 import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
 import LightModeIcon from '@mui/icons-material/LightMode';
 import DarkModeIcon from '@mui/icons-material/DarkMode';
-import { darken, useTheme as useMuiTheme } from '@mui/material/styles';
-import Wheel from '@uiw/react-color-wheel';
-import { hsvaToHex, hexToHsva } from '@uiw/color-convert';
+import AutoAwesomeIcon from '@mui/icons-material/AutoAwesome';
+import { useTheme as useMuiTheme } from '@mui/material/styles';
 import { Meteor } from 'meteor/meteor';
 import { Session } from 'meteor/session';
 import { useTracker } from 'meteor/react-meteor-data';
 import { get } from 'lodash';
-import { useTheme } from '../CustomThemeProvider.jsx';
 import {
   THEME_PRESETS, CHAKRA_FONT, MARTIAN_FONT,
-  applyThemePreset, setAccentHue, setThemeFont, setThemeBackground,
-  setPageMode, setCardSurface
+  applyThemePreset, setThemeFont, setThemeBackground,
+  setThemeMode, setPageMode, setCardSurface
 } from '../themePresets.js';
-import { getBackgroundLibrary, EARTH_TONES } from '../themeBackgrounds.js';
+import { getBackgroundLibrary, getBackgroundEntry, EARTH_TONES } from '../themeBackgrounds.js';
 import { colorFromBackground } from './backgroundValue.js';
-import { buildSurfaceStyles } from './surfaceStyles.js';
 import { PAGE_MODE, CARD_SURFACE } from '/imports/lib/SessionKeys.js';
 import { loadThemeChoice } from '/imports/lib/themePersistence.js';
 
@@ -46,15 +43,22 @@ const FONT_OPTIONS = [
 // The palette keys a tile previews, in swatch/hex order.
 const SWATCH_KEYS = ['primaryColor', 'secondaryColor', 'successColor', 'infoColor', 'errorColor'];
 
-// Resolve a preset's preview palette. For the ACTIVE accent-driven preset
-// (Tron/Limestone), the lead + secondary swatches reflect the LIVE dialed hue
-// so the tile tracks the wheel; fixed multi-hue presets (Vaporwave) and
-// inactive tiles show their declared palette.
-export function previewPalette(preset, liveAccent) {
+// The palette keys a tile previews (swatch row + hex list).
+const PREVIEW_KEYS = [
+  'primaryColor', 'secondaryColor', 'successColor', 'infoColor', 'errorColor',
+  'backgroundCanvasDark', 'canvasColor', 'paperColorDark', 'paperColor'
+];
+
+// Resolve a preset's preview palette. The ACTIVE tile overlays the LIVE
+// settings palette (accent dial, Advanced per-field edits — Vaporwave
+// included) so its swatches/hex track what's actually applied; inactive
+// tiles show their declared palette.
+export function previewPalette(preset, livePalette) {
   const base = Object.assign({}, preset.palette);
-  if (liveAccent && !preset.advanced) {
-    base.primaryColor = liveAccent;
-    base.secondaryColor = darken(liveAccent, 0.3);
+  if (livePalette) {
+    PREVIEW_KEYS.forEach(function(k) {
+      if (livePalette[k]) { base[k] = livePalette[k]; }
+    });
   }
   return base;
 }
@@ -99,30 +103,32 @@ function PresetHexList({ palette }) {
 }
 
 export function ThemeControls({ compact = false }) {
+  // Session('theme') is the canonical app mode — CustomThemeProvider mirrors
+  // it, so this control and the header Sun/Moon icon always agree.
   const mode = useTracker(function() { return Session.get('theme') || 'light'; }, []);
   const pageMode = useTracker(function() { return Session.get(PAGE_MODE); }, []);
   const cardSurface = useTracker(function() { return Session.get(CARD_SURFACE) || 'solid'; }, []);
-  const themeCtx = useTheme() || {};
-  const muiTheme = useMuiTheme();
+
+  // Subscribe to the live MUI theme: its identity changes on every
+  // pokeRefresh (preset apply, accent edit, background change), which is what
+  // re-renders this component so the non-reactive reads below — persisted
+  // choice, settings palette, tile highlight — stay current. Do not remove:
+  // without a theme subscription a preset click that doesn't change
+  // mode/pageMode/cardSurface leaves the tiles stale.
+  useMuiTheme();
 
   const choice = loadThemeChoice() || {};
   const activePreset = choice.presetId || get(Meteor, 'settings.public.theme.defaultPreset', 'limestone');
   const activeFont = get(Meteor, 'settings.public.theme.typography.fontFamily', '') || '';
   const activeBg = get(Meteor, 'settings.public.theme.backgroundImagePath', '') || '';
 
-  // Hue wheel initialized from the current accent on mount (the dialog remounts
-  // this each open; the page mounts it once — both start truthful).
-  const currentAccent = get(Meteor, 'settings.public.theme.palette.primaryColor', '#53e6ff');
-  const [hsva, setHsva] = React.useState(function() {
-    try { return Object.assign({ a: 1 }, hexToHsva(currentAccent)); }
-    catch (e) { return { h: 40, s: 70, v: 100, a: 1 }; }
-  });
-  const liveAccent = hsvaToHex(hsva);
+  // The active tile previews the LIVE palette (accent + Advanced edits);
+  // settings updates re-render this component via the theme subscription.
+  const livePalette = get(Meteor, 'settings.public.theme.palette', null);
 
-  function handleMode() {
-    if (themeCtx.toggleTheme) { themeCtx.toggleTheme(); }
-    else { Session.set('theme', mode === 'light' ? 'dark' : 'light'); }
-  }
+  // What PAGE TEXT "Auto" resolves to for the active background (curation).
+  const activeEntry = getBackgroundEntry(activeBg);
+  const autoResolvedInk = get(activeEntry, 'recommendedPageMode', '');
 
   return (
     <Box>
@@ -151,8 +157,8 @@ export function ThemeControls({ compact = false }) {
               <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 0.5, minHeight: 32 }}>
                 {preset.description}
               </Typography>
-              <PresetSwatches palette={previewPalette(preset, selected ? liveAccent : null)} />
-              <PresetHexList palette={previewPalette(preset, selected ? liveAccent : null)} />
+              <PresetSwatches palette={previewPalette(preset, selected ? livePalette : null)} />
+              <PresetHexList palette={previewPalette(preset, selected ? livePalette : null)} />
             </ButtonBase>
           );
         })}
@@ -209,127 +215,100 @@ export function ThemeControls({ compact = false }) {
 
       <Divider sx={{ mb: 3 }} />
 
-      {/* Basic theme controls: font, mode(s), accent hue, card surface */}
+      {/* Basic theme controls — two columns: MODE + PAGE TEXT left,
+          FONT + CARD SURFACE right. (Accent hue lives in Advanced.) */}
       <Typography variant="overline" color="text.secondary">Basic theme controls</Typography>
-      <Box sx={{ display: 'grid', gridTemplateColumns: { xs: '1fr', md: '1fr 1fr' }, gap: 3, mb: 3, mt: 1 }}>
+      <Box sx={{ display: 'grid', gridTemplateColumns: { xs: '1fr', sm: '1fr 1fr' }, gap: 3, mb: 3, mt: 1 }}>
         <Stack spacing={2}>
-          <FormControl fullWidth size="small">
-            <InputLabel id="themeFontLabel">Font</InputLabel>
-            <Select
-              labelId="themeFontLabel"
-              id="themeFontSelect"
-              label="Font"
-              value={activeFont}
-              onChange={function(e) { setThemeFont(e.target.value); }}
-            >
-              {FONT_OPTIONS.map(function(opt) {
-                return (
-                  <MenuItem key={opt.value} value={opt.value} sx={{ fontFamily: opt.value || 'inherit' }}>
-                    {opt.label}
-                  </MenuItem>
-                );
-              })}
-            </Select>
-          </FormControl>
-
           <Box>
             <Typography variant="overline" color="text.secondary">Mode</Typography>
-            <Box>
-              <Tooltip title={mode === 'light' ? 'Switch to dark' : 'Switch to light'}>
-                <Button
-                  id="themeModeToggle"
-                  variant="outlined" size="small"
-                  startIcon={mode === 'light' ? <LightModeIcon /> : <DarkModeIcon />}
-                  onClick={handleMode}
-                >
-                  {mode === 'light' ? 'Light' : 'Dark'}
-                </Button>
-              </Tooltip>
+            <Box sx={{ mt: 1 }}>
+              <ToggleButtonGroup
+                id="themeModeToggle"
+                exclusive size="small" value={mode}
+                onChange={function(event, next) { if (next) { setThemeMode(next); } }}
+              >
+                <ToggleButton id="themeMode-light" value="light">
+                  <LightModeIcon sx={{ fontSize: 16, mr: 0.75 }} /> Light
+                </ToggleButton>
+                <ToggleButton id="themeMode-dark" value="dark">
+                  <DarkModeIcon sx={{ fontSize: 16, mr: 0.75 }} /> Dark
+                </ToggleButton>
+              </ToggleButtonGroup>
             </Box>
           </Box>
 
           {activeBg ? (
             <Box>
-              <Typography variant="overline" color="text.secondary">Page mode</Typography>
-              <Box>
-                <Tooltip title="Content ink over the ambiance background (chrome keeps the app mode)">
-                  <Button
+              <Typography variant="overline" color="text.secondary">Page text</Typography>
+              <Box sx={{ mt: 1 }}>
+                <Tooltip title="Ink for text sitting on the ambiance background (cards and chrome keep the app mode)">
+                  <ToggleButtonGroup
                     id="themePageModeToggle"
-                    variant="outlined" size="small"
-                    startIcon={pageMode === 'dark' ? <DarkModeIcon /> : <LightModeIcon />}
-                    onClick={function() {
-                      const next = !pageMode ? 'light' : (pageMode === 'light' ? 'dark' : null);
-                      setPageMode(next);
+                    exclusive size="small" value={pageMode || 'auto'}
+                    onChange={function(event, next) {
+                      if (next) { setPageMode(next === 'auto' ? null : next); }
                     }}
                   >
-                    {pageMode ? (pageMode === 'dark' ? 'Dark' : 'Light') : 'Auto'}
-                  </Button>
+                    <ToggleButton id="themePageText-auto" value="auto">
+                      <AutoAwesomeIcon sx={{ fontSize: 16, mr: 0.75 }} /> Auto
+                    </ToggleButton>
+                    <ToggleButton id="themePageText-light" value="light">
+                      <LightModeIcon sx={{ fontSize: 16, mr: 0.75 }} /> Light
+                    </ToggleButton>
+                    <ToggleButton id="themePageText-dark" value="dark">
+                      <DarkModeIcon sx={{ fontSize: 16, mr: 0.75 }} /> Dark
+                    </ToggleButton>
+                  </ToggleButtonGroup>
                 </Tooltip>
+                {!pageMode && autoResolvedInk ? (
+                  <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 0.5 }}>
+                    Auto → {autoResolvedInk === 'light' ? 'dark text (bright background)' : 'light text (dark background)'}
+                  </Typography>
+                ) : null}
               </Box>
             </Box>
           ) : null}
         </Stack>
 
-        <Box>
-          <Typography variant="overline" color="text.secondary">Accent hue</Typography>
-          <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, mt: 1 }}>
-            <Wheel
-              color={hsva}
-              onChange={function(color) {
-                setHsva(color.hsva);
-                setAccentHue(hsvaToHex(color.hsva));
-              }}
-              width={compact ? 120 : 140}
-              height={compact ? 120 : 140}
-            />
-            <Box>
-              <Box sx={{ width: 40, height: 40, borderRadius: '4px', bgcolor: liveAccent, border: '1px solid var(--divider, rgba(0,0,0,0.2))' }} />
-              <Typography variant="caption" sx={{ fontFamily: 'monospace' }}>{liveAccent}</Typography>
-              <Typography variant="caption" color="text.secondary" sx={{ display: 'block' }}>
-                Desaturate → Limestone · saturate → Tron
-              </Typography>
-            </Box>
+        <Stack spacing={2}>
+          <Box>
+            <Typography variant="overline" color="text.secondary">Font</Typography>
+            <FormControl fullWidth size="small" sx={{ mt: 1 }}>
+              <InputLabel id="themeFontLabel">Font</InputLabel>
+              <Select
+                labelId="themeFontLabel"
+                id="themeFontSelect"
+                label="Font"
+                value={activeFont}
+                onChange={function(e) { setThemeFont(e.target.value); }}
+              >
+                {FONT_OPTIONS.map(function(opt) {
+                  return (
+                    <MenuItem key={opt.value} value={opt.value} sx={{ fontFamily: opt.value || 'inherit' }}>
+                      {opt.label}
+                    </MenuItem>
+                  );
+                })}
+              </Select>
+            </FormControl>
           </Box>
-        </Box>
 
-        <Box>
-          <Typography variant="overline" color="text.secondary">Card surface</Typography>
-          <Box sx={{ mt: 1 }}>
-            <ToggleButtonGroup
-              id="themeCardSurfaceGroup"
-              exclusive size="small" value={cardSurface}
-              onChange={function(event, next) { if (next) { setCardSurface(next); } }}
-            >
-              <ToggleButton id="themeCardSurface-solid" value="solid">Solid</ToggleButton>
-              <ToggleButton id="themeCardSurface-glass" value="glass">Glass</ToggleButton>
-              <ToggleButton id="themeCardSurface-flat" value="flat">Flat</ToggleButton>
-            </ToggleButtonGroup>
-            <Box id="themeCardSurfacePreview" sx={{ display: 'flex', gap: 1, mt: 1 }}>
-              {['solid', 'glass', 'flat'].map(function(s) {
-                const preview = buildSurfaceStyles({
-                  surface: s,
-                  paperColor: muiTheme.palette.background.paper,
-                  dividerColor: muiTheme.palette.divider
-                });
-                return (
-                  <Box key={s} sx={Object.assign({
-                    width: 72, height: 44, borderRadius: '6px', display: 'flex',
-                    alignItems: 'center', justifyContent: 'center', fontSize: 10,
-                    color: 'text.secondary', bgcolor: 'background.paper',
-                    border: '1px solid', borderColor: 'divider',
-                    outline: cardSurface === s ? '2px solid' : 'none',
-                    outlineColor: 'primary.main'
-                  }, preview.root)}>
-                    {s}
-                  </Box>
-                );
-              })}
+          <Box>
+            <Typography variant="overline" color="text.secondary">Card surface</Typography>
+            <Box sx={{ mt: 1 }}>
+              <ToggleButtonGroup
+                id="themeCardSurfaceGroup"
+                exclusive size="small" value={cardSurface}
+                onChange={function(event, next) { if (next) { setCardSurface(next); } }}
+              >
+                <ToggleButton id="themeCardSurface-solid" value="solid">Solid</ToggleButton>
+                <ToggleButton id="themeCardSurface-glass" value="glass">Glass</ToggleButton>
+                <ToggleButton id="themeCardSurface-flat" value="flat">Flat</ToggleButton>
+              </ToggleButtonGroup>
             </Box>
-            <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 0.5 }}>
-              Applies on ambiance/fluid pages (rolling out per page).
-            </Typography>
           </Box>
-        </Box>
+        </Stack>
       </Box>
     </Box>
   );

--- a/imports/ui/theme/ThemeControls.jsx
+++ b/imports/ui/theme/ThemeControls.jsx
@@ -1,11 +1,11 @@
 // imports/ui/theme/ThemeControls.jsx
 //
 // Shared theme-control surface: preset tiles (Limestone / Tron / Vaporwave),
-// font, mode toggle, accent-hue wheel, and the ambiance-background carousel.
-// Extracted from ThemeDialog so BOTH the Theme & Palette dialog and the
-// /theming page render the identical controls (harmonization). Drives the
-// themePresets helpers, which apply live + persist (localStorage) — so this
-// component owns no persistence itself.
+// ambiance backgrounds + earth tones, font, mode, page mode, accent hue, and
+// card surface. Extracted from ThemeDialog so BOTH the Theme & Palette
+// dialog and the /theming page render the identical controls
+// (harmonization). Drives the themePresets helpers, which apply live +
+// persist (localStorage) — so this component owns no persistence itself.
 //
 // Prop: compact — denser layout for the dialog; roomier for the page column.
 
@@ -255,7 +255,10 @@ export function ThemeControls({ compact = false }) {
                     id="themePageModeToggle"
                     variant="outlined" size="small"
                     startIcon={pageMode === 'dark' ? <DarkModeIcon /> : <LightModeIcon />}
-                    onClick={function() { setPageMode(pageMode === 'dark' ? 'light' : 'dark'); }}
+                    onClick={function() {
+                      const next = !pageMode ? 'light' : (pageMode === 'light' ? 'dark' : null);
+                      setPageMode(next);
+                    }}
                   >
                     {pageMode ? (pageMode === 'dark' ? 'Dark' : 'Light') : 'Auto'}
                   </Button>

--- a/imports/ui/theme/ThemeControls.jsx
+++ b/imports/ui/theme/ThemeControls.jsx
@@ -18,7 +18,7 @@ import ToggleButton from '@mui/material/ToggleButton';
 import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
 import LightModeIcon from '@mui/icons-material/LightMode';
 import DarkModeIcon from '@mui/icons-material/DarkMode';
-import { darken } from '@mui/material/styles';
+import { darken, useTheme as useMuiTheme } from '@mui/material/styles';
 import Wheel from '@uiw/react-color-wheel';
 import { hsvaToHex, hexToHsva } from '@uiw/color-convert';
 import { Meteor } from 'meteor/meteor';
@@ -33,6 +33,7 @@ import {
 } from '../themePresets.js';
 import { getBackgroundLibrary, EARTH_TONES } from '../themeBackgrounds.js';
 import { colorFromBackground } from './backgroundValue.js';
+import { buildSurfaceStyles } from './surfaceStyles.js';
 import { PAGE_MODE, CARD_SURFACE } from '/imports/lib/SessionKeys.js';
 import { loadThemeChoice } from '/imports/lib/themePersistence.js';
 
@@ -102,6 +103,7 @@ export function ThemeControls({ compact = false }) {
   const pageMode = useTracker(function() { return Session.get(PAGE_MODE); }, []);
   const cardSurface = useTracker(function() { return Session.get(CARD_SURFACE) || 'solid'; }, []);
   const themeCtx = useTheme() || {};
+  const muiTheme = useMuiTheme();
 
   const choice = loadThemeChoice() || {};
   const activePreset = choice.presetId || get(Meteor, 'settings.public.theme.defaultPreset', 'limestone');
@@ -302,6 +304,27 @@ export function ThemeControls({ compact = false }) {
               <ToggleButton id="themeCardSurface-glass" value="glass">Glass</ToggleButton>
               <ToggleButton id="themeCardSurface-flat" value="flat">Flat</ToggleButton>
             </ToggleButtonGroup>
+            <Box id="themeCardSurfacePreview" sx={{ display: 'flex', gap: 1, mt: 1 }}>
+              {['solid', 'glass', 'flat'].map(function(s) {
+                const preview = buildSurfaceStyles({
+                  surface: s,
+                  paperColor: muiTheme.palette.background.paper,
+                  dividerColor: muiTheme.palette.divider
+                });
+                return (
+                  <Box key={s} sx={Object.assign({
+                    width: 72, height: 44, borderRadius: '6px', display: 'flex',
+                    alignItems: 'center', justifyContent: 'center', fontSize: 10,
+                    color: 'text.secondary', bgcolor: 'background.paper',
+                    border: '1px solid', borderColor: 'divider',
+                    outline: cardSurface === s ? '2px solid' : 'none',
+                    outlineColor: 'primary.main'
+                  }, preview.root)}>
+                    {s}
+                  </Box>
+                );
+              })}
+            </Box>
             <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 0.5 }}>
               Applies on ambiance/fluid pages (rolling out per page).
             </Typography>

--- a/imports/ui/theme/ThemeControls.jsx
+++ b/imports/ui/theme/ThemeControls.jsx
@@ -1,0 +1,252 @@
+// imports/ui/theme/ThemeControls.jsx
+//
+// Shared theme-control surface: preset tiles (Limestone / Tron / Vaporwave),
+// font, mode toggle, accent-hue wheel, and the ambiance-background carousel.
+// Extracted from ThemeDialog so BOTH the Theme & Palette dialog and the
+// /theming page render the identical controls (harmonization). Drives the
+// themePresets helpers, which apply live + persist (localStorage) — so this
+// component owns no persistence itself.
+//
+// Prop: compact — denser layout for the dialog; roomier for the page column.
+
+import React from 'react';
+import {
+  Box, Typography, Button, ButtonBase, Chip, Divider, Select, MenuItem,
+  FormControl, InputLabel, Stack, Tooltip
+} from '@mui/material';
+import LightModeIcon from '@mui/icons-material/LightMode';
+import DarkModeIcon from '@mui/icons-material/DarkMode';
+import { darken } from '@mui/material/styles';
+import Wheel from '@uiw/react-color-wheel';
+import { hsvaToHex, hexToHsva } from '@uiw/color-convert';
+import { Meteor } from 'meteor/meteor';
+import { Session } from 'meteor/session';
+import { useTracker } from 'meteor/react-meteor-data';
+import { get } from 'lodash';
+import { useTheme } from '../CustomThemeProvider.jsx';
+import {
+  THEME_PRESETS, CHAKRA_FONT, MARTIAN_FONT,
+  applyThemePreset, setAccentHue, setThemeFont, setThemeBackground
+} from '../themePresets.js';
+import { getBackgroundLibrary } from '../themeBackgrounds.js';
+import { loadThemeChoice } from '/imports/lib/themePersistence.js';
+
+const FONT_OPTIONS = [
+  { label: 'Default (Helvetica)', value: '' },
+  { label: 'Chakra Petch', value: CHAKRA_FONT },
+  { label: 'Martian Mono', value: MARTIAN_FONT }
+];
+
+// The palette keys a tile previews, in swatch/hex order.
+const SWATCH_KEYS = ['primaryColor', 'secondaryColor', 'successColor', 'infoColor', 'errorColor'];
+
+// Resolve a preset's preview palette. For the ACTIVE accent-driven preset
+// (Tron/Limestone), the lead + secondary swatches reflect the LIVE dialed hue
+// so the tile tracks the wheel; fixed multi-hue presets (Vaporwave) and
+// inactive tiles show their declared palette.
+export function previewPalette(preset, liveAccent) {
+  const base = Object.assign({}, preset.palette);
+  if (liveAccent && !preset.advanced) {
+    base.primaryColor = liveAccent;
+    base.secondaryColor = darken(liveAccent, 0.3);
+  }
+  return base;
+}
+
+function PresetSwatches({ palette }) {
+  return (
+    <Box sx={{ display: 'flex', gap: 0.5, mt: 1 }}>
+      {SWATCH_KEYS.map(function(k) {
+        const c = get(palette, k);
+        if (!c) { return null; }
+        return <Box key={k} sx={{ width: 20, height: 20, borderRadius: '3px', bgcolor: c, border: '1px solid rgba(255,255,255,0.15)' }} />;
+      })}
+    </Box>
+  );
+}
+
+// Vertical hex readout — the tile's actual palette values, legible as color data.
+function PresetHexList({ palette }) {
+  const rows = [
+    ['accent', get(palette, 'primaryColor')],
+    ['second', get(palette, 'secondaryColor')],
+    ['canvas', get(palette, 'backgroundCanvasDark') || get(palette, 'canvasColor')],
+    ['paper', get(palette, 'paperColorDark') || get(palette, 'paperColor')]
+  ].filter(function(r) { return !!r[1]; });
+  return (
+    <Box sx={{ mt: 1.5, display: 'grid', gridTemplateColumns: 'auto 1fr', rowGap: 0.25, columnGap: 1 }}>
+      {rows.map(function(row) {
+        return (
+          <React.Fragment key={row[0]}>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75 }}>
+              <Box sx={{ width: 11, height: 11, borderRadius: '2px', bgcolor: row[1], border: '1px solid rgba(255,255,255,0.15)' }} />
+              <Typography variant="caption" color="text.secondary" sx={{ fontSize: 10, letterSpacing: '0.06em' }}>{row[0]}</Typography>
+            </Box>
+            <Typography variant="caption" sx={{ fontFamily: 'monospace', fontSize: 11, color: 'text.primary' }}>
+              {String(row[1]).toLowerCase()}
+            </Typography>
+          </React.Fragment>
+        );
+      })}
+    </Box>
+  );
+}
+
+export function ThemeControls({ compact = false }) {
+  const mode = useTracker(function() { return Session.get('theme') || 'light'; }, []);
+  const themeCtx = useTheme() || {};
+
+  const choice = loadThemeChoice() || {};
+  const activePreset = choice.presetId || get(Meteor, 'settings.public.theme.defaultPreset', 'limestone');
+  const activeFont = get(Meteor, 'settings.public.theme.typography.fontFamily', '') || '';
+  const activeBg = get(Meteor, 'settings.public.theme.backgroundImagePath', '') || '';
+
+  // Hue wheel initialized from the current accent on mount (the dialog remounts
+  // this each open; the page mounts it once — both start truthful).
+  const currentAccent = get(Meteor, 'settings.public.theme.palette.primaryColor', '#53e6ff');
+  const [hsva, setHsva] = React.useState(function() {
+    try { return Object.assign({ a: 1 }, hexToHsva(currentAccent)); }
+    catch (e) { return { h: 40, s: 70, v: 100, a: 1 }; }
+  });
+  const liveAccent = hsvaToHex(hsva);
+
+  function handleMode() {
+    if (themeCtx.toggleTheme) { themeCtx.toggleTheme(); }
+    else { Session.set('theme', mode === 'light' ? 'dark' : 'light'); }
+  }
+
+  return (
+    <Box>
+      {/* Primary preset tiles */}
+      <Typography variant="overline" color="text.secondary">Preset</Typography>
+      <Box sx={{ display: 'grid', gridTemplateColumns: { xs: '1fr', sm: 'repeat(3, 1fr)' }, gap: 2, mt: 1, mb: 3 }}>
+        {THEME_PRESETS.map(function(preset) {
+          const selected = preset.id === activePreset;
+          return (
+            <ButtonBase
+              key={preset.id}
+              id={'themePreset-' + preset.id}
+              onClick={function() { applyThemePreset(preset.id); }}
+              sx={{
+                display: 'block', textAlign: 'left', p: 2, borderRadius: '8px',
+                border: '2px solid', borderColor: selected ? 'primary.main' : 'divider',
+                bgcolor: 'background.default',
+                transition: 'border-color 0.15s ease, transform 0.15s ease',
+                '&:hover': { transform: 'translateY(-2px)', borderColor: 'primary.light' }
+              }}
+            >
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                <Typography variant="subtitle1" sx={{ fontWeight: 700 }}>{preset.name}</Typography>
+                {preset.advanced ? <Chip label="Advanced · 3-hue" size="small" color="warning" variant="outlined" /> : null}
+              </Box>
+              <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 0.5, minHeight: 32 }}>
+                {preset.description}
+              </Typography>
+              <PresetSwatches palette={previewPalette(preset, selected ? liveAccent : null)} />
+              <PresetHexList palette={previewPalette(preset, selected ? liveAccent : null)} />
+            </ButtonBase>
+          );
+        })}
+      </Box>
+
+      <Divider sx={{ mb: 3 }} />
+
+      {/* Font + mode + hue row */}
+      <Box sx={{ display: 'grid', gridTemplateColumns: { xs: '1fr', md: '1fr 1fr' }, gap: 3, mb: 3 }}>
+        <Stack spacing={2}>
+          <FormControl fullWidth size="small">
+            <InputLabel id="themeFontLabel">Font</InputLabel>
+            <Select
+              labelId="themeFontLabel"
+              id="themeFontSelect"
+              label="Font"
+              value={activeFont}
+              onChange={function(e) { setThemeFont(e.target.value); }}
+            >
+              {FONT_OPTIONS.map(function(opt) {
+                return (
+                  <MenuItem key={opt.value} value={opt.value} sx={{ fontFamily: opt.value || 'inherit' }}>
+                    {opt.label}
+                  </MenuItem>
+                );
+              })}
+            </Select>
+          </FormControl>
+
+          <Box>
+            <Typography variant="overline" color="text.secondary">Mode</Typography>
+            <Box>
+              <Tooltip title={mode === 'light' ? 'Switch to dark' : 'Switch to light'}>
+                <Button
+                  id="themeModeToggle"
+                  variant="outlined" size="small"
+                  startIcon={mode === 'light' ? <LightModeIcon /> : <DarkModeIcon />}
+                  onClick={handleMode}
+                >
+                  {mode === 'light' ? 'Light' : 'Dark'}
+                </Button>
+              </Tooltip>
+            </Box>
+          </Box>
+        </Stack>
+
+        <Box>
+          <Typography variant="overline" color="text.secondary">Accent hue</Typography>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, mt: 1 }}>
+            <Wheel
+              color={hsva}
+              onChange={function(color) {
+                setHsva(color.hsva);
+                setAccentHue(hsvaToHex(color.hsva));
+              }}
+              width={compact ? 120 : 140}
+              height={compact ? 120 : 140}
+            />
+            <Box>
+              <Box sx={{ width: 40, height: 40, borderRadius: '4px', bgcolor: liveAccent, border: '1px solid var(--divider, rgba(0,0,0,0.2))' }} />
+              <Typography variant="caption" sx={{ fontFamily: 'monospace' }}>{liveAccent}</Typography>
+              <Typography variant="caption" color="text.secondary" sx={{ display: 'block' }}>
+                Desaturate → Limestone · saturate → Tron
+              </Typography>
+            </Box>
+          </Box>
+        </Box>
+      </Box>
+
+      <Divider sx={{ mb: 2 }} />
+
+      {/* Ambiance background carousel */}
+      <Typography variant="overline" color="text.secondary">Ambiance background</Typography>
+      <Box sx={{ display: 'flex', gap: 1.5, overflowX: 'auto', pb: 1, mt: 1 }}>
+        <ButtonBase
+          onClick={function() { setThemeBackground(''); }}
+          sx={{
+            flex: '0 0 auto', width: 96, height: 60, borderRadius: '6px',
+            border: '2px solid', borderColor: !activeBg ? 'primary.main' : 'divider',
+            bgcolor: 'background.default', fontSize: 11, color: 'text.secondary'
+          }}
+        >
+          None
+        </ButtonBase>
+        {getBackgroundLibrary().map(function(bg) {
+          const selected = activeBg === bg.src;
+          return (
+            <Tooltip key={bg.src} title={bg.name}>
+              <ButtonBase
+                onClick={function() { setThemeBackground(bg.src); }}
+                sx={{
+                  flex: '0 0 auto', width: 96, height: 60, borderRadius: '6px', overflow: 'hidden',
+                  border: '2px solid', borderColor: selected ? 'primary.main' : 'divider',
+                  backgroundImage: 'url(' + bg.src + ')', backgroundSize: 'cover', backgroundPosition: 'center',
+                  transition: 'transform 0.15s ease', '&:hover': { transform: 'scale(1.04)' }
+                }}
+              />
+            </Tooltip>
+          );
+        })}
+      </Box>
+    </Box>
+  );
+}
+
+export default ThemeControls;

--- a/imports/ui/theme/ThemeControls.jsx
+++ b/imports/ui/theme/ThemeControls.jsx
@@ -14,6 +14,8 @@ import {
   Box, Typography, Button, ButtonBase, Chip, Divider, Select, MenuItem,
   FormControl, InputLabel, Stack, Tooltip
 } from '@mui/material';
+import ToggleButton from '@mui/material/ToggleButton';
+import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
 import LightModeIcon from '@mui/icons-material/LightMode';
 import DarkModeIcon from '@mui/icons-material/DarkMode';
 import { darken } from '@mui/material/styles';
@@ -26,9 +28,12 @@ import { get } from 'lodash';
 import { useTheme } from '../CustomThemeProvider.jsx';
 import {
   THEME_PRESETS, CHAKRA_FONT, MARTIAN_FONT,
-  applyThemePreset, setAccentHue, setThemeFont, setThemeBackground
+  applyThemePreset, setAccentHue, setThemeFont, setThemeBackground,
+  setPageMode, setCardSurface
 } from '../themePresets.js';
-import { getBackgroundLibrary } from '../themeBackgrounds.js';
+import { getBackgroundLibrary, EARTH_TONES } from '../themeBackgrounds.js';
+import { colorFromBackground } from './backgroundValue.js';
+import { PAGE_MODE, CARD_SURFACE } from '/imports/lib/SessionKeys.js';
 import { loadThemeChoice } from '/imports/lib/themePersistence.js';
 
 const FONT_OPTIONS = [
@@ -94,6 +99,8 @@ function PresetHexList({ palette }) {
 
 export function ThemeControls({ compact = false }) {
   const mode = useTracker(function() { return Session.get('theme') || 'light'; }, []);
+  const pageMode = useTracker(function() { return Session.get(PAGE_MODE); }, []);
+  const cardSurface = useTracker(function() { return Session.get(CARD_SURFACE) || 'solid'; }, []);
   const themeCtx = useTheme() || {};
 
   const choice = loadThemeChoice() || {};
@@ -149,10 +156,60 @@ export function ThemeControls({ compact = false }) {
         })}
       </Box>
 
+      {/* Ambiance background — images row + earth-tone solids row */}
+      <Typography variant="overline" color="text.secondary">Ambiance background</Typography>
+      <Box sx={{ display: 'flex', gap: 1.5, overflowX: 'auto', pb: 1, mt: 1 }}>
+        <ButtonBase
+          onClick={function() { setThemeBackground(''); }}
+          sx={{
+            flex: '0 0 auto', width: 96, height: 60, borderRadius: '6px',
+            border: '2px solid', borderColor: !activeBg ? 'primary.main' : 'divider',
+            bgcolor: 'background.default', fontSize: 11, color: 'text.secondary'
+          }}
+        >
+          None
+        </ButtonBase>
+        {getBackgroundLibrary().map(function(bg) {
+          const selected = activeBg === bg.src;
+          return (
+            <Tooltip key={bg.src} title={bg.name}>
+              <ButtonBase
+                onClick={function() { setThemeBackground(bg.src); }}
+                sx={{
+                  flex: '0 0 auto', width: 96, height: 60, borderRadius: '6px', overflow: 'hidden',
+                  border: '2px solid', borderColor: selected ? 'primary.main' : 'divider',
+                  backgroundImage: 'url(' + bg.src + ')', backgroundSize: 'cover', backgroundPosition: 'center',
+                  transition: 'transform 0.15s ease', '&:hover': { transform: 'scale(1.04)' }
+                }}
+              />
+            </Tooltip>
+          );
+        })}
+      </Box>
+      <Box sx={{ display: 'flex', gap: 1.5, overflowX: 'auto', pb: 1, mt: 1, mb: 3 }}>
+        {EARTH_TONES.map(function(tone) {
+          const selected = activeBg === tone.value;
+          return (
+            <Tooltip key={tone.value} title={tone.name}>
+              <ButtonBase
+                id={'themeEarthTone-' + tone.name.toLowerCase()}
+                onClick={function() { setThemeBackground(tone.value); }}
+                sx={{
+                  flex: '0 0 auto', width: 96, height: 36, borderRadius: '6px',
+                  border: '2px solid', borderColor: selected ? 'primary.main' : 'divider',
+                  bgcolor: colorFromBackground(tone.value)
+                }}
+              />
+            </Tooltip>
+          );
+        })}
+      </Box>
+
       <Divider sx={{ mb: 3 }} />
 
-      {/* Font + mode + hue row */}
-      <Box sx={{ display: 'grid', gridTemplateColumns: { xs: '1fr', md: '1fr 1fr' }, gap: 3, mb: 3 }}>
+      {/* Basic theme controls: font, mode(s), accent hue, card surface */}
+      <Typography variant="overline" color="text.secondary">Basic theme controls</Typography>
+      <Box sx={{ display: 'grid', gridTemplateColumns: { xs: '1fr', md: '1fr 1fr' }, gap: 3, mb: 3, mt: 1 }}>
         <Stack spacing={2}>
           <FormControl fullWidth size="small">
             <InputLabel id="themeFontLabel">Font</InputLabel>
@@ -188,6 +245,24 @@ export function ThemeControls({ compact = false }) {
               </Tooltip>
             </Box>
           </Box>
+
+          {activeBg ? (
+            <Box>
+              <Typography variant="overline" color="text.secondary">Page mode</Typography>
+              <Box>
+                <Tooltip title="Content ink over the ambiance background (chrome keeps the app mode)">
+                  <Button
+                    id="themePageModeToggle"
+                    variant="outlined" size="small"
+                    startIcon={pageMode === 'dark' ? <DarkModeIcon /> : <LightModeIcon />}
+                    onClick={function() { setPageMode(pageMode === 'dark' ? 'light' : 'dark'); }}
+                  >
+                    {pageMode ? (pageMode === 'dark' ? 'Dark' : 'Light') : 'Auto'}
+                  </Button>
+                </Tooltip>
+              </Box>
+            </Box>
+          ) : null}
         </Stack>
 
         <Box>
@@ -211,39 +286,24 @@ export function ThemeControls({ compact = false }) {
             </Box>
           </Box>
         </Box>
-      </Box>
 
-      <Divider sx={{ mb: 2 }} />
-
-      {/* Ambiance background carousel */}
-      <Typography variant="overline" color="text.secondary">Ambiance background</Typography>
-      <Box sx={{ display: 'flex', gap: 1.5, overflowX: 'auto', pb: 1, mt: 1 }}>
-        <ButtonBase
-          onClick={function() { setThemeBackground(''); }}
-          sx={{
-            flex: '0 0 auto', width: 96, height: 60, borderRadius: '6px',
-            border: '2px solid', borderColor: !activeBg ? 'primary.main' : 'divider',
-            bgcolor: 'background.default', fontSize: 11, color: 'text.secondary'
-          }}
-        >
-          None
-        </ButtonBase>
-        {getBackgroundLibrary().map(function(bg) {
-          const selected = activeBg === bg.src;
-          return (
-            <Tooltip key={bg.src} title={bg.name}>
-              <ButtonBase
-                onClick={function() { setThemeBackground(bg.src); }}
-                sx={{
-                  flex: '0 0 auto', width: 96, height: 60, borderRadius: '6px', overflow: 'hidden',
-                  border: '2px solid', borderColor: selected ? 'primary.main' : 'divider',
-                  backgroundImage: 'url(' + bg.src + ')', backgroundSize: 'cover', backgroundPosition: 'center',
-                  transition: 'transform 0.15s ease', '&:hover': { transform: 'scale(1.04)' }
-                }}
-              />
-            </Tooltip>
-          );
-        })}
+        <Box>
+          <Typography variant="overline" color="text.secondary">Card surface</Typography>
+          <Box sx={{ mt: 1 }}>
+            <ToggleButtonGroup
+              id="themeCardSurfaceGroup"
+              exclusive size="small" value={cardSurface}
+              onChange={function(event, next) { if (next) { setCardSurface(next); } }}
+            >
+              <ToggleButton id="themeCardSurface-solid" value="solid">Solid</ToggleButton>
+              <ToggleButton id="themeCardSurface-glass" value="glass">Glass</ToggleButton>
+              <ToggleButton id="themeCardSurface-flat" value="flat">Flat</ToggleButton>
+            </ToggleButtonGroup>
+            <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 0.5 }}>
+              Applies on ambiance/fluid pages (rolling out per page).
+            </Typography>
+          </Box>
+        </Box>
       </Box>
     </Box>
   );

--- a/imports/ui/theme/ambianceAnalysis.js
+++ b/imports/ui/theme/ambianceAnalysis.js
@@ -1,0 +1,113 @@
+// imports/ui/theme/ambianceAnalysis.js
+//
+// Palette extraction + neutral-space analysis for ambiance backgrounds.
+// analyzeImageData() is pure math over an RGBA byte array (unit-tested,
+// dependency-free); analyzeAmbianceImage() is the browser wrapper that
+// downsamples an <img> through a canvas and feeds it in. Outputs a draft
+// curation record for the background library. Curated values in the library
+// always win over these computed suggestions. Spec:
+// docs/superpowers/specs/2026-08-03-ambiance-experience-zone-design.md
+
+// Rec. 709 relative luminance, 0..1.
+function luminance(r, g, b) {
+  return (0.2126 * r + 0.7152 * g + 0.0722 * b) / 255;
+}
+
+// Mean + variance of luminance for pixels whose x falls in [x0, x1).
+function thirdStats(img, x0, x1) {
+  const { data, width, height } = img;
+  let sum = 0, sumSq = 0, n = 0;
+  for (let y = 0; y < height; y++) {
+    for (let x = x0; x < x1; x++) {
+      const i = (y * width + x) * 4;
+      const l = luminance(data[i], data[i + 1], data[i + 2]);
+      sum += l; sumSq += l * l; n++;
+    }
+  }
+  const mean = n ? sum / n : 0;
+  return { mean: mean, variance: n ? (sumSq / n) - (mean * mean) : 0 };
+}
+
+function toHex(v) {
+  const s = Math.round(v).toString(16);
+  return s.length === 1 ? '0' + s : s;
+}
+
+// Dominant colors: quantize to 4 bits/channel, count buckets, return the top
+// 3 distinct buckets as hex (bucket-center color).
+function dominantColors(img) {
+  const { data, width, height } = img;
+  const counts = {};
+  for (let p = 0; p < width * height; p++) {
+    const i = p * 4;
+    const key = ((data[i] >> 4) << 8) | ((data[i + 1] >> 4) << 4) | (data[i + 2] >> 4);
+    counts[key] = (counts[key] || 0) + 1;
+  }
+  return Object.keys(counts)
+    .sort(function(a, b) { return counts[b] - counts[a]; })
+    .slice(0, 3)
+    .map(function(key) {
+      const k = parseInt(key, 10);
+      const r = ((k >> 8) & 0xf) * 16 + 8;
+      const g = ((k >> 4) & 0xf) * 16 + 8;
+      const b = (k & 0xf) * 16 + 8;
+      return '#' + toHex(r) + toHex(g) + toHex(b);
+    });
+}
+
+export function analyzeImageData(img) {
+  const w = img.width;
+  const t1 = Math.floor(w / 3);
+  const t2 = Math.floor((2 * w) / 3);
+  const thirds = [
+    { focus: 'left', stats: thirdStats(img, 0, t1) },
+    { focus: 'center', stats: thirdStats(img, t1, t2) },
+    { focus: 'right', stats: thirdStats(img, t2, w) }
+  ];
+
+  // Neutral space = the calmest (lowest-variance) third.
+  const calmest = thirds.reduce(function(best, cur) {
+    return cur.stats.variance < best.stats.variance ? cur : best;
+  });
+
+  // Overall luminance decides which ink family survives the image.
+  const overallMean = (thirds[0].stats.mean + thirds[1].stats.mean + thirds[2].stats.mean) / 3;
+
+  // Scrim scales with the busyness of the third content will sit on.
+  // Variance of luminance tops out at 0.25 (half-black/half-white).
+  const scrim = Math.min(0.8, Math.max(0.35, 0.35 + (calmest.stats.variance / 0.25) * 0.45));
+
+  return {
+    focus: calmest.focus,
+    recommendedPageMode: overallMean >= 0.5 ? 'light' : 'dark',
+    scrimStrength: Math.round(scrim * 100) / 100,
+    palette: dominantColors(img)
+  };
+}
+
+// Browser wrapper: downsample via canvas (≤96px wide keeps this O(10k) pixels)
+// and analyze. Resolves null on any failure — callers treat null as
+// "no suggestions", never as an error.
+export function analyzeAmbianceImage(src) {
+  return new Promise(function(resolve) {
+    if (typeof document === 'undefined') { resolve(null); return; }
+    const image = new Image();
+    image.crossOrigin = 'anonymous';
+    image.onload = function() {
+      try {
+        const scale = Math.min(1, 96 / image.naturalWidth);
+        const w = Math.max(3, Math.round(image.naturalWidth * scale));
+        const h = Math.max(3, Math.round(image.naturalHeight * scale));
+        const canvas = document.createElement('canvas');
+        canvas.width = w; canvas.height = h;
+        const ctx = canvas.getContext('2d');
+        ctx.drawImage(image, 0, 0, w, h);
+        resolve(analyzeImageData(ctx.getImageData(0, 0, w, h)));
+      } catch (error) {
+        resolve(null); // tainted canvas / decode failure — no suggestions
+      }
+    };
+    image.onerror = function() { resolve(null); };
+    image.src = src;
+  });
+}

--- a/imports/ui/theme/ambianceComposition.js
+++ b/imports/ui/theme/ambianceComposition.js
@@ -35,8 +35,11 @@ export function resolveComposition(options) {
   }
   if (kind === 'none') { pageMode = null; }
 
+  // Precedence: per-route user override (Ctrl+Shift+K) > route-declared
+  // baseline (route.defaultSurface) > global cardSurface > 'solid'.
   let cardSurface = SURFACE_VALUES.indexOf(opts.surfaceOverride) !== -1 ? opts.surfaceOverride
-    : (SURFACE_VALUES.indexOf(opts.cardSurface) !== -1 ? opts.cardSurface : 'solid');
+    : (SURFACE_VALUES.indexOf(opts.surfaceDefault) !== -1 ? opts.surfaceDefault
+      : (SURFACE_VALUES.indexOf(opts.cardSurface) !== -1 ? opts.cardSurface : 'solid'));
 
   return {
     background: background,

--- a/imports/ui/theme/ambianceComposition.js
+++ b/imports/ui/theme/ambianceComposition.js
@@ -1,3 +1,4 @@
+// imports/ui/theme/ambianceComposition.js
 //
 // The zone composition contract: resolve the active background + curation
 // record + persisted axes into the single layout object every enableAmbiance

--- a/imports/ui/theme/ambianceComposition.js
+++ b/imports/ui/theme/ambianceComposition.js
@@ -1,0 +1,48 @@
+//
+// The zone composition contract: resolve the active background + curation
+// record + persisted axes into the single layout object every enableAmbiance
+// route receives ("a background choice never arrives blank" — defaults fill
+// every gap). Pure and zero-import (bare-checkout node --test safe); the
+// 'color:' check is duplicated from backgroundValue.js deliberately to keep
+// this module dependency-free. Spec:
+// docs/superpowers/specs/2026-08-03-ambiance-experience-zone-design.md
+
+const FOCUS_VALUES = ['left', 'center', 'right'];
+const SURFACE_VALUES = ['solid', 'glass', 'flat'];
+const MODE_VALUES = ['light', 'dark'];
+
+function backgroundKind(background) {
+  if (!background || typeof background !== 'string') { return 'none'; }
+  if (background.indexOf('color:') === 0) { return 'color'; }
+  return 'image';
+}
+
+export function resolveComposition(options) {
+  const opts = options || {};
+  const background = (typeof opts.background === 'string') ? opts.background : '';
+  const entry = opts.entry || {};
+  const kind = backgroundKind(background);
+
+  const focus = FOCUS_VALUES.indexOf(entry.focus) !== -1 ? entry.focus : 'center';
+
+  let scrim = typeof entry.scrimStrength === 'number' ? entry.scrimStrength : 0.55;
+  scrim = Math.min(1, Math.max(0, scrim));
+
+  let pageMode = MODE_VALUES.indexOf(opts.pageMode) !== -1 ? opts.pageMode : null;
+  if (!pageMode && MODE_VALUES.indexOf(entry.recommendedPageMode) !== -1) {
+    pageMode = entry.recommendedPageMode;
+  }
+  if (kind === 'none') { pageMode = null; }
+
+  let cardSurface = SURFACE_VALUES.indexOf(opts.surfaceOverride) !== -1 ? opts.surfaceOverride
+    : (SURFACE_VALUES.indexOf(opts.cardSurface) !== -1 ? opts.cardSurface : 'solid');
+
+  return {
+    background: background,
+    kind: kind,
+    focus: kind === 'image' ? focus : 'center',
+    scrimStrength: scrim,
+    pageMode: pageMode,
+    cardSurface: cardSurface
+  };
+}

--- a/imports/ui/theme/backgroundValue.js
+++ b/imports/ui/theme/backgroundValue.js
@@ -1,0 +1,23 @@
+// imports/ui/theme/backgroundValue.js
+//
+// Pure helpers for the extended background axis: an ambiance background is
+// either an image path ('/backgrounds/ambiance/Zen.jpg') or a solid color
+// stored as a 'color:'-prefixed string ('color:#a67b5b') on the SAME
+// persistence axis (themePersistence backgroundImagePath). Spec:
+// docs/superpowers/specs/2026-08-03-ambiance-experience-zone-design.md
+// Zero imports — bare-checkout node --test safe.
+
+export const COLOR_BACKGROUND_PREFIX = 'color:';
+
+export function isColorBackground(value) {
+  return typeof value === 'string' && value.indexOf(COLOR_BACKGROUND_PREFIX) === 0;
+}
+
+export function colorFromBackground(value) {
+  if (!isColorBackground(value)) { return null; }
+  return value.slice(COLOR_BACKGROUND_PREFIX.length);
+}
+
+export function makeColorBackground(hex) {
+  return COLOR_BACKGROUND_PREFIX + hex;
+}

--- a/imports/ui/theme/contrastInk.js
+++ b/imports/ui/theme/contrastInk.js
@@ -1,0 +1,131 @@
+// imports/ui/theme/contrastInk.js
+//
+// Single-color contrast math — the ambiance AUTO idea applied to one color
+// instead of an image (Rec. 709 luminance, same formula as
+// ambianceAnalysis.js). Two consumers:
+//   - inkForColor(): CustomThemeProvider defaults app-bar TEXT from the
+//     resolved bar color when no explicit appBarTextColor(/Dark) exists.
+//   - readableAccent()/inverseHueSaturationBrightness(): AmbianceZone keeps
+//     accents legible on ambiance pages — a bright accent on a light surface
+//     gets its brightness inverted (hue/saturation preserved), so Tron cyan
+//     stays cyan but reads on paper-white.
+// Pure and zero-import (bare-checkout node --test safe).
+
+// First parseable color token in the string: #rgb / #rrggbb, rgb() / rgba().
+// Gradients resolve to their first color stop. Low-alpha colors (< 0.5)
+// return null — the effective color depends on an unknown backdrop, so the
+// caller should fall back rather than guess.
+export function parseFirstColor(value) {
+  if (typeof value !== 'string' || !value) { return null; }
+
+  const rgbMatch = value.match(/rgba?\(\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})\s*(?:,\s*([0-9.]+)\s*)?\)/i);
+  const hexMatch = value.match(/#([0-9a-f]{6}|[0-9a-f]{3})\b/i);
+
+  // Take whichever token appears first in the string.
+  const rgbIndex = rgbMatch ? value.indexOf(rgbMatch[0]) : -1;
+  const hexIndex = hexMatch ? value.indexOf(hexMatch[0]) : -1;
+
+  if (rgbMatch && (hexIndex === -1 || rgbIndex < hexIndex)) {
+    const alpha = rgbMatch[4] === undefined ? 1 : parseFloat(rgbMatch[4]);
+    if (!(alpha >= 0.5)) { return null; }
+    return { r: +rgbMatch[1], g: +rgbMatch[2], b: +rgbMatch[3] };
+  }
+  if (hexMatch) {
+    let h = hexMatch[1];
+    if (h.length === 3) { h = h[0] + h[0] + h[1] + h[1] + h[2] + h[2]; }
+    return {
+      r: parseInt(h.slice(0, 2), 16),
+      g: parseInt(h.slice(2, 4), 16),
+      b: parseInt(h.slice(4, 6), 16)
+    };
+  }
+  return null;
+}
+
+// Rec. 709 relative luminance, 0..1 (matches ambianceAnalysis.js).
+export function relativeLuminance(rgb) {
+  return (0.2126 * rgb.r + 0.7152 * rgb.g + 0.0722 * rgb.b) / 255;
+}
+
+// 'dark' (bright surface → dark text) | 'light' | null (unparseable).
+export function inkForColor(value) {
+  const rgb = parseFirstColor(value);
+  if (!rgb) { return null; }
+  return relativeLuminance(rgb) >= 0.5 ? 'dark' : 'light';
+}
+
+// ---------------------------------------------------------------------------
+// Hue-preserving brightness inversion — "the cyan stays cyan, but readable".
+
+function rgbToHsl(rgb) {
+  const r = rgb.r / 255, g = rgb.g / 255, b = rgb.b / 255;
+  const max = Math.max(r, g, b), min = Math.min(r, g, b);
+  const l = (max + min) / 2;
+  if (max === min) { return { h: 0, s: 0, l: l }; }
+  const d = max - min;
+  const s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+  let h;
+  if (max === r) { h = ((g - b) / d + (g < b ? 6 : 0)); }
+  else if (max === g) { h = (b - r) / d + 2; }
+  else { h = (r - g) / d + 4; }
+  return { h: h * 60, s: s, l: l };
+}
+
+function hue2rgb(p, q, t) {
+  if (t < 0) { t += 1; }
+  if (t > 1) { t -= 1; }
+  if (t < 1 / 6) { return p + (q - p) * 6 * t; }
+  if (t < 1 / 2) { return q; }
+  if (t < 2 / 3) { return p + (q - p) * (2 / 3 - t) * 6; }
+  return p;
+}
+
+function hslToHex(hsl) {
+  const h = ((hsl.h % 360) + 360) % 360 / 360;
+  const s = Math.min(1, Math.max(0, hsl.s));
+  const l = Math.min(1, Math.max(0, hsl.l));
+  let r, g, b;
+  if (s === 0) { r = g = b = l; }
+  else {
+    const q = l < 0.5 ? l * (1 + s) : l + s - l * s;
+    const p = 2 * l - q;
+    r = hue2rgb(p, q, h + 1 / 3);
+    g = hue2rgb(p, q, h);
+    b = hue2rgb(p, q, h - 1 / 3);
+  }
+  const toHex = function(v) {
+    const x = Math.round(v * 255).toString(16);
+    return x.length === 1 ? '0' + x : x;
+  };
+  return '#' + toHex(r) + toHex(g) + toHex(b);
+}
+
+// Invert a color's brightness while preserving hue and saturation
+// (HSL: L' = 1 - L). Bright cyan becomes deep teal-cyan; deep navy becomes
+// a pale sky. Unparseable input returns the input unchanged.
+export function inverseHueSaturationBrightness(value) {
+  const rgb = parseFirstColor(value);
+  if (!rgb) { return value; }
+  const hsl = rgbToHsl(rgb);
+  return hslToHex({ h: hsl.h, s: hsl.s, l: 1 - hsl.l });
+}
+
+// Accent legibility guard: invert brightness ONLY when the accent's polarity
+// matches the surface it sits on — a bright accent on a light surface (or a
+// dark accent on a dark surface) is washed out; opposite-polarity accents
+// pass through untouched. Conservative bands so mid-range colors are stable,
+// and the inversion is kept only when it genuinely moved luminance away from
+// the surface (HSL lightness and Rec. 709 luminance can disagree).
+export function readableAccent(value, surfaceMode) {
+  const rgb = parseFirstColor(value);
+  if (!rgb) { return value; }
+  const lum = relativeLuminance(rgb);
+  let inverted = null;
+  if (surfaceMode === 'light' && lum >= 0.55) { inverted = inverseHueSaturationBrightness(value); }
+  else if (surfaceMode === 'dark' && lum <= 0.25) { inverted = inverseHueSaturationBrightness(value); }
+  if (!inverted || inverted === value) { return value; }
+  const invLum = relativeLuminance(parseFirstColor(inverted));
+  if (surfaceMode === 'light' && invLum >= lum) { return value; }
+  if (surfaceMode === 'dark' && invLum <= lum) { return value; }
+  return inverted;
+}

--- a/imports/ui/theme/pageModeTheme.js
+++ b/imports/ui/theme/pageModeTheme.js
@@ -1,0 +1,26 @@
+// imports/ui/theme/pageModeTheme.js
+//
+// Build the "content ink" theme for ambiance pages: same brand accents +
+// typography as the app theme, but with the mode-dependent tokens
+// (text/background/divider) flipped to the forced mode. The app chrome
+// (header/footer/dialogs) keeps the real mode — only zone page content
+// consumes this. Promoted from DirectoryConsole's inline override.
+// Spec: docs/superpowers/specs/2026-08-03-ambiance-experience-zone-design.md
+
+import { createTheme } from '@mui/material/styles';
+
+export function buildPageModeTheme(appTheme, forcedMode) {
+  if (!forcedMode || !appTheme || forcedMode === appTheme.palette.mode) { return appTheme; }
+  return createTheme({
+    palette: {
+      mode: forcedMode,
+      primary: appTheme.palette.primary,
+      secondary: appTheme.palette.secondary,
+      error: appTheme.palette.error,
+      warning: appTheme.palette.warning,
+      info: appTheme.palette.info,
+      success: appTheme.palette.success
+    },
+    typography: appTheme.typography
+  });
+}

--- a/imports/ui/theme/surfaceStyles.js
+++ b/imports/ui/theme/surfaceStyles.js
@@ -1,0 +1,52 @@
+// imports/ui/theme/surfaceStyles.js
+//
+// Shared card-surface styles for the three states (solid | glass | flat) —
+// the DirectoryConsole overlay recipe generalized so AmbianceZone's
+// MuiCard/MuiPaper overrides and Meteor.StyledCard share one source of
+// truth. Pure and zero-import (bare-checkout node --test safe); hexAlpha is
+// a local helper so we don't pull in @mui utilities. Spec:
+// docs/superpowers/specs/2026-08-03-ambiance-experience-zone-design.md
+
+export const SURFACE_TRANSITION =
+  'background-color 0.35s ease, backdrop-filter 0.35s ease, border-color 0.35s ease, box-shadow 0.35s ease, opacity 0.35s ease';
+
+export function hexAlpha(hex, alpha) {
+  if (typeof hex !== 'string' || hex[0] !== '#') { return hex; }
+  let h = hex.slice(1);
+  if (h.length === 3) { h = h[0] + h[0] + h[1] + h[1] + h[2] + h[2]; }
+  if (h.length !== 6 || /[^0-9a-fA-F]/.test(h)) { return hex; }
+  const r = parseInt(h.slice(0, 2), 16);
+  const g = parseInt(h.slice(2, 4), 16);
+  const b = parseInt(h.slice(4, 6), 16);
+  return 'rgba(' + r + ', ' + g + ', ' + b + ', ' + alpha + ')';
+}
+
+export function buildSurfaceStyles(options) {
+  const opts = options || {};
+  const surface = opts.surface;
+
+  if (surface === 'glass') {
+    return {
+      root: {
+        backgroundColor: hexAlpha(opts.paperColor, 0.72),
+        backgroundImage: 'none',
+        backdropFilter: 'blur(8px)',
+        border: '1px solid ' + (opts.dividerColor || 'rgba(128,128,128,0.3)'),
+        boxShadow: 'none',
+        transition: SURFACE_TRANSITION
+      }
+    };
+  }
+  if (surface === 'flat') {
+    return {
+      root: {
+        backgroundColor: 'transparent',
+        backgroundImage: 'none',
+        border: 'none',
+        boxShadow: 'none',
+        transition: SURFACE_TRANSITION
+      }
+    };
+  }
+  return { root: { transition: SURFACE_TRANSITION } };
+}

--- a/imports/ui/themeBackgrounds.js
+++ b/imports/ui/themeBackgrounds.js
@@ -5,6 +5,11 @@
 // whichever preset is active, applied via the theme's existing
 // backgroundImagePath key.
 //
+// Entries are CURATION RECORDS: beyond name/src, optional focus (where the
+// image's neutral space is: left|center|right), recommendedPageMode (which
+// ink family survives it), and scrimStrength (0-1 content-column scrim).
+// See docs/superpowers/specs/2026-08-03-ambiance-experience-zone-design.md.
+//
 // The list is settings-driven: settings.public.theme.backgroundLibrary = [{name,
 // src}] overrides the default set below. That's the seam for a future
 // orchestration extension to supply its own asset directory / links without a
@@ -13,23 +18,30 @@
 
 import { Meteor } from 'meteor/meteor';
 import { get } from 'lodash';
+import { makeColorBackground } from './theme/backgroundValue.js';
 
 const BASE = '/backgrounds/ambiance';
 
 // Default library (code fallback). Curated spa / zen / medical / gradient set.
+// Entries are CURATION RECORDS: beyond name/src, optional focus (where the
+// image's neutral space is: left|center|right), recommendedPageMode (which
+// ink family survives it), and scrimStrength (0-1 content-column scrim).
+// Seed values below were drafted with ambianceAnalysis.analyzeAmbianceImage()
+// and eyeballed; refine with the Tuning HUD (Phase 3). Omitted fields fall
+// back to: focus 'center', pageMode unset (app mode stands), scrim 0.55.
 export const DEFAULT_BACKGROUND_LIBRARY = [
-  { name: 'Zen Rocks',   src: BASE + '/Zen-Rocks.jpg' },
-  { name: 'Zen Garden',  src: BASE + '/Zen.jpg' },
-  { name: 'Large Zen',   src: BASE + '/LargeZenRocks.jpg' },
-  { name: 'Bamboo',      src: BASE + '/BambooIllustration.jpg' },
-  { name: 'Yoga Ocean',  src: BASE + '/Yoga-Ocean.jpg' },
-  { name: 'Spa Candles', src: BASE + '/Candles.jpg' },
-  { name: 'Spa Beds',    src: BASE + '/SpaBeds.jpg' },
-  { name: 'Bath Petals', src: BASE + '/BathPetals.jpg' },
-  { name: 'Massage',     src: BASE + '/Massage.jpg' },
-  { name: 'Med Bay',     src: BASE + '/MedBay.jpg' },
-  { name: 'Plasmid',     src: BASE + '/PlasmidBlue.jpg' },
-  { name: 'Gradient',    src: BASE + '/Gradient.jpg' }
+  { name: 'Zen Rocks',   src: BASE + '/Zen-Rocks.jpg',          focus: 'right',  recommendedPageMode: 'light', scrimStrength: 0.5 },
+  { name: 'Zen Garden',  src: BASE + '/Zen.jpg',                focus: 'center', recommendedPageMode: 'light', scrimStrength: 0.5 },
+  { name: 'Large Zen',   src: BASE + '/LargeZenRocks.jpg',      focus: 'right',  recommendedPageMode: 'light', scrimStrength: 0.55 },
+  { name: 'Bamboo',      src: BASE + '/BambooIllustration.jpg', focus: 'left',   recommendedPageMode: 'light', scrimStrength: 0.45 },
+  { name: 'Yoga Ocean',  src: BASE + '/Yoga-Ocean.jpg',         focus: 'left',   recommendedPageMode: 'dark',  scrimStrength: 0.6 },
+  { name: 'Spa Candles', src: BASE + '/Candles.jpg',            focus: 'center', recommendedPageMode: 'dark',  scrimStrength: 0.55 },
+  { name: 'Spa Beds',    src: BASE + '/SpaBeds.jpg',            focus: 'center', recommendedPageMode: 'light', scrimStrength: 0.55 },
+  { name: 'Bath Petals', src: BASE + '/BathPetals.jpg',         focus: 'center', recommendedPageMode: 'light', scrimStrength: 0.55 },
+  { name: 'Massage',     src: BASE + '/Massage.jpg',            focus: 'center', recommendedPageMode: 'dark',  scrimStrength: 0.55 },
+  { name: 'Med Bay',     src: BASE + '/MedBay.jpg',             focus: 'center', recommendedPageMode: 'dark',  scrimStrength: 0.6 },
+  { name: 'Plasmid',     src: BASE + '/PlasmidBlue.jpg',        focus: 'center', recommendedPageMode: 'dark',  scrimStrength: 0.55 },
+  { name: 'Gradient',    src: BASE + '/Gradient.jpg',           focus: 'center', recommendedPageMode: 'light', scrimStrength: 0.4 }
 ];
 
 // Resolve the active library: operator/extension override, else the default.
@@ -39,4 +51,25 @@ export function getBackgroundLibrary() {
     return configured.filter(function(entry) { return entry && entry.src; });
   }
   return DEFAULT_BACKGROUND_LIBRARY;
+}
+
+// Solid earth-tone backgrounds — row 2 of the dialog's Ambiance section.
+// Values ride the SAME persistence axis as images ('color:'-prefixed).
+export const EARTH_TONES = [
+  { name: 'Clay',       value: makeColorBackground('#a67b5b') },
+  { name: 'Sand',       value: makeColorBackground('#d9c7a7') },
+  { name: 'Terracotta', value: makeColorBackground('#b0674b') },
+  { name: 'Moss',       value: makeColorBackground('#6b7d5a') },
+  { name: 'Sage',       value: makeColorBackground('#a3b18a') },
+  { name: 'Stone',      value: makeColorBackground('#8d8578') },
+  { name: 'Ochre',      value: makeColorBackground('#c49a3c') },
+  { name: 'Espresso',   value: makeColorBackground('#4a3728') }
+];
+
+// Look up the active IMAGE background's curation record. Solid 'color:'
+// entries and unknown/operator paths return null — callers fall back to
+// defaults (focus 'center', scrim 0.55), which is correct for solids.
+export function getBackgroundEntry(activeValue) {
+  if (!activeValue) { return null; }
+  return getBackgroundLibrary().find(function(entry) { return entry.src === activeValue; }) || null;
 }

--- a/imports/ui/themeBackgrounds.js
+++ b/imports/ui/themeBackgrounds.js
@@ -3,12 +3,8 @@
 // The ambiance-background library backing the ThemeDialog carousel. This is a
 // SEPARATE axis from the palette/font presets — a background layers over
 // whichever preset is active, applied via the theme's existing
-// backgroundImagePath key.
-//
-// Entries are CURATION RECORDS: beyond name/src, optional focus (where the
-// image's neutral space is: left|center|right), recommendedPageMode (which
-// ink family survives it), and scrimStrength (0-1 content-column scrim).
-// See docs/superpowers/specs/2026-08-03-ambiance-experience-zone-design.md.
+// backgroundImagePath key. Entries are curation records (focus, scrim, ink) —
+// see docs/superpowers/specs/2026-08-03-ambiance-experience-zone-design.md.
 //
 // The list is settings-driven: settings.public.theme.backgroundLibrary = [{name,
 // src}] overrides the default set below. That's the seam for a future

--- a/imports/ui/themePresets.js
+++ b/imports/ui/themePresets.js
@@ -270,7 +270,7 @@ export function applyThemeChoiceAtBoot() {
   if (choice.pageMode === 'light' || choice.pageMode === 'dark') {
     Session.set(PAGE_MODE, choice.pageMode);
   }
-  if (['solid', 'glass', 'flat'].indexOf(choice.cardSurface) !== -1) {
+  if (CARD_SURFACES.indexOf(choice.cardSurface) !== -1) {
     Session.set(CARD_SURFACE, choice.cardSurface);
   }
 

--- a/imports/ui/themePresets.js
+++ b/imports/ui/themePresets.js
@@ -18,7 +18,7 @@ import { Meteor } from 'meteor/meteor';
 import { Session } from 'meteor/session';
 import { get, set } from 'lodash';
 import { saveThemeChoice, loadThemeChoice } from '/imports/lib/themePersistence.js';
-import { PAGE_MODE, CARD_SURFACE } from '/imports/lib/SessionKeys.js';
+import { PAGE_MODE, CARD_SURFACE, PAGE_SURFACE_OVERRIDES } from '/imports/lib/SessionKeys.js';
 
 // Self-hosted display pairing (client/main.css @font-face; /fonts/*.woff2).
 export const CHAKRA_FONT = "'Chakra Petch', 'Avenir Next Condensed', sans-serif";
@@ -228,6 +228,29 @@ export function setCardSurface(surface) {
   pokeRefresh();
 }
 
+// Live control: advance the card surface one step (Ctrl+Shift+L).
+export function cycleCardSurface() {
+  const current = Session.get(CARD_SURFACE) || 'solid';
+  const next = CARD_SURFACES[(CARD_SURFACES.indexOf(current) + 1) % CARD_SURFACES.length];
+  setCardSurface(next);
+}
+
+// Live control: per-route card <-> full-height override (Ctrl+Shift+K).
+// Toggles the active pathname between 'flat' (one-page/full-height) and no
+// override (global cardSurface stands). Spec: onePageLayout revival.
+export function togglePageSurfaceOverride(pathname) {
+  if (!pathname) { return; }
+  const overrides = Object.assign({}, Session.get(PAGE_SURFACE_OVERRIDES) || {});
+  if (overrides[pathname]) {
+    delete overrides[pathname];
+  } else {
+    overrides[pathname] = 'flat';
+  }
+  Session.set(PAGE_SURFACE_OVERRIDES, overrides);
+  saveThemeChoice({ pageSurfaceOverrides: overrides });
+  pokeRefresh();
+}
+
 // Boot: re-apply the persisted choice into Meteor.settings BEFORE the
 // CustomThemeProvider mounts, so createDynamicTheme reads correct values on
 // first render (no flash). Deliberately does NOT save or poke refresh — the
@@ -272,6 +295,16 @@ export function applyThemeChoiceAtBoot() {
   }
   if (CARD_SURFACES.indexOf(choice.cardSurface) !== -1) {
     Session.set(CARD_SURFACE, choice.cardSurface);
+  }
+
+  // Per-route surface overrides — keep only well-formed entries.
+  const rawOverrides = choice.pageSurfaceOverrides;
+  if (rawOverrides && typeof rawOverrides === 'object' && !Array.isArray(rawOverrides)) {
+    const clean = {};
+    Object.keys(rawOverrides).forEach(function(path) {
+      if (rawOverrides[path] === 'flat' || rawOverrides[path] === 'solid') { clean[path] = rawOverrides[path]; }
+    });
+    if (Object.keys(clean).length) { Session.set(PAGE_SURFACE_OVERRIDES, clean); }
   }
 
   // Per-field overrides last, so they win over the preset + accent base

--- a/imports/ui/themePresets.js
+++ b/imports/ui/themePresets.js
@@ -122,6 +122,10 @@ export function applyThemePreset(presetId, options) {
 
   Object.assign(theme.palette, preset.palette);
 
+  // A preset switch is a fresh base — drop any per-field overrides from the
+  // previous preset so e.g. a Tron appbar tweak doesn't bleed into Limestone.
+  saveThemeChoice({ paletteOverrides: null });
+
   const accentHue = get(options, 'accentHueOverride') || preset.accentHue;
   if (accentHue) {
     theme.palette.primaryColor = accentHue;
@@ -165,6 +169,25 @@ export function setAccentHue(hex) {
     theme.palette.appBarTextColorDark = hex;
   }
   saveThemeChoice({ accentHue: hex });
+  pokeRefresh();
+}
+
+// Live control: set one per-field palette override (from PaletteFieldEditor).
+// Writes the live settings AND persists into the choice's paletteOverrides map
+// so it survives reload (re-applied at boot after the preset). Empty value
+// clears that key's override.
+export function setPaletteOverride(fieldKey, value) {
+  const theme = ensureThemeSettings();
+  const choice = loadThemeChoice() || {};
+  const overrides = Object.assign({}, get(choice, 'paletteOverrides', {}));
+  if (value) {
+    theme.palette[fieldKey] = value;
+    overrides[fieldKey] = value;
+  } else {
+    delete theme.palette[fieldKey];
+    delete overrides[fieldKey];
+  }
+  saveThemeChoice({ paletteOverrides: overrides });
   pokeRefresh();
 }
 
@@ -220,5 +243,13 @@ export function applyThemeChoiceAtBoot() {
   }
   if ('backgroundImagePath' in choice) {
     set(theme, 'backgroundImagePath', choice.backgroundImagePath || '');
+  }
+
+  // Per-field overrides last, so they win over the preset + accent base
+  // (matches createDynamicTheme precedence). Set by PaletteFieldEditor via
+  // setPaletteOverride; cleared on preset switch.
+  const overrides = get(choice, 'paletteOverrides', null);
+  if (overrides && typeof overrides === 'object') {
+    Object.assign(theme.palette, overrides);
   }
 }

--- a/imports/ui/themePresets.js
+++ b/imports/ui/themePresets.js
@@ -18,6 +18,7 @@ import { Meteor } from 'meteor/meteor';
 import { Session } from 'meteor/session';
 import { get, set } from 'lodash';
 import { saveThemeChoice, loadThemeChoice } from '/imports/lib/themePersistence.js';
+import { PAGE_MODE, CARD_SURFACE } from '/imports/lib/SessionKeys.js';
 
 // Self-hosted display pairing (client/main.css @font-face; /fonts/*.woff2).
 export const CHAKRA_FONT = "'Chakra Petch', 'Avenir Next Condensed', sans-serif";
@@ -208,6 +209,25 @@ export function setThemeBackground(src) {
   pokeRefresh();
 }
 
+const CARD_SURFACES = ['solid', 'glass', 'flat'];
+
+// Live control: content-ink mode for ambiance-enabled pages ('light'|'dark');
+// null/undefined clears the override (app mode stands). Chrome keeps Session('theme').
+export function setPageMode(mode) {
+  const next = (mode === 'light' || mode === 'dark') ? mode : null;
+  Session.set(PAGE_MODE, next || undefined);
+  saveThemeChoice({ pageMode: next });
+  pokeRefresh();
+}
+
+// Live control: card surface state. Unknown values coerce to 'solid'.
+export function setCardSurface(surface) {
+  const next = CARD_SURFACES.indexOf(surface) !== -1 ? surface : 'solid';
+  Session.set(CARD_SURFACE, next);
+  saveThemeChoice({ cardSurface: next });
+  pokeRefresh();
+}
+
 // Boot: re-apply the persisted choice into Meteor.settings BEFORE the
 // CustomThemeProvider mounts, so createDynamicTheme reads correct values on
 // first render (no flash). Deliberately does NOT save or poke refresh — the
@@ -243,6 +263,15 @@ export function applyThemeChoiceAtBoot() {
   }
   if ('backgroundImagePath' in choice) {
     set(theme, 'backgroundImagePath', choice.backgroundImagePath || '');
+  }
+
+  // Ambiance axes — unknown persisted values are treated as unset
+  // (forward/backward compat per the ambiance spec).
+  if (choice.pageMode === 'light' || choice.pageMode === 'dark') {
+    Session.set(PAGE_MODE, choice.pageMode);
+  }
+  if (['solid', 'glass', 'flat'].indexOf(choice.cardSurface) !== -1) {
+    Session.set(CARD_SURFACE, choice.cardSurface);
   }
 
   // Per-field overrides last, so they win over the preset + accent base

--- a/imports/ui/themePresets.js
+++ b/imports/ui/themePresets.js
@@ -56,6 +56,7 @@ export const THEME_PRESETS = [
     description: 'Grayscale + one accent hue. Dial the hue below.',
     mode: 'dark',
     accentHue: '#53e6ff',            // default cyan; user dials via HueSelector
+    appBarTracksAccent: true,        // header + footer text follow the dialed hue
     palette: {
       mode: 'dark',
       primaryColor: '#53e6ff',
@@ -74,6 +75,7 @@ export const THEME_PRESETS = [
     advanced: true,
     mode: 'dark',
     accentHue: '#ffb454',            // amber lead; green/cyan/magenta as secondaries
+    appBarTracksAccent: true,        // header + footer text follow the amber lead
     fontFamily: CHAKRA_FONT,
     displayFontFamily: CHAKRA_FONT,
     palette: {
@@ -123,6 +125,12 @@ export function applyThemePreset(presetId, options) {
   const accentHue = get(options, 'accentHueOverride') || preset.accentHue;
   if (accentHue) {
     theme.palette.primaryColor = accentHue;
+    // Accent presets (Tron/Vaporwave) carry the hue into the app chrome so the
+    // Header title/icons and Footer track it; Limestone keeps its neutral ink.
+    if (preset.appBarTracksAccent) {
+      theme.palette.appBarTextColor = accentHue;
+      theme.palette.appBarTextColorDark = accentHue;
+    }
   }
 
   const font = get(options, 'fontOverride') || preset.fontFamily || null;
@@ -144,10 +152,18 @@ export function applyThemePreset(presetId, options) {
   pokeRefresh();
 }
 
-// Live control: set only the accent hue (Tron/Limestone slider).
+// Live control: set only the accent hue (Tron/Limestone slider). When the
+// active preset tracks accent in its chrome (Tron/Vaporwave), the appbar text
+// follows too so Header + Footer restyle with the dial.
 export function setAccentHue(hex) {
   const theme = ensureThemeSettings();
   theme.palette.primaryColor = hex;
+  const choice = loadThemeChoice() || {};
+  const activePreset = getPreset(choice.presetId);
+  if (activePreset && activePreset.appBarTracksAccent) {
+    theme.palette.appBarTextColor = hex;
+    theme.palette.appBarTextColorDark = hex;
+  }
   saveThemeChoice({ accentHue: hex });
   pokeRefresh();
 }
@@ -186,7 +202,13 @@ export function applyThemeChoiceAtBoot() {
       theme.darkMode = preset.mode === 'dark';
     }
   }
-  if (choice.accentHue) { theme.palette.primaryColor = choice.accentHue; }
+  if (choice.accentHue) {
+    theme.palette.primaryColor = choice.accentHue;
+    if (preset && preset.appBarTracksAccent) {
+      theme.palette.appBarTextColor = choice.accentHue;
+      theme.palette.appBarTextColorDark = choice.accentHue;
+    }
+  }
   if (choice.mode) {
     theme.palette.mode = choice.mode;
     theme.darkMode = choice.mode === 'dark';

--- a/imports/ui/themePresets.js
+++ b/imports/ui/themePresets.js
@@ -121,6 +121,15 @@ export function applyThemePreset(presetId, options) {
   if (!preset) { return; }
   const theme = ensureThemeSettings();
 
+  // A preset apply is a fresh chrome base: clear the light-mode app-bar
+  // color/text carried over from the settings file or a previous apply
+  // (presets only declare *Dark chrome). Deleted BEFORE the assign so a
+  // preset that explicitly defines them still wins. Absent, the bar falls
+  // back to the accent and the provider auto-contrasts the ink from the
+  // bar's own brightness (contrastInk.js).
+  delete theme.palette.appBarColor;
+  delete theme.palette.appBarTextColor;
+
   Object.assign(theme.palette, preset.palette);
 
   // A preset switch is a fresh base — drop any per-field overrides from the
@@ -130,10 +139,10 @@ export function applyThemePreset(presetId, options) {
   const accentHue = get(options, 'accentHueOverride') || preset.accentHue;
   if (accentHue) {
     theme.palette.primaryColor = accentHue;
-    // Accent presets (Tron/Vaporwave) carry the hue into the app chrome so the
-    // Header title/icons and Footer track it; Limestone keeps its neutral ink.
+    // Accent presets (Tron/Vaporwave) carry the hue into the DARK app chrome
+    // (bar is near-black there, so accent text reads). Light mode leaves the
+    // text unset — the provider auto-contrasts it from the bar's brightness.
     if (preset.appBarTracksAccent) {
-      theme.palette.appBarTextColor = accentHue;
       theme.palette.appBarTextColorDark = accentHue;
     }
   }
@@ -166,8 +175,10 @@ export function setAccentHue(hex) {
   const choice = loadThemeChoice() || {};
   const activePreset = getPreset(choice.presetId);
   if (activePreset && activePreset.appBarTracksAccent) {
-    theme.palette.appBarTextColor = hex;
+    // Dark chrome only — the light-mode bar's background IS the accent
+    // (appBarColor defaults to primaryColor), so accent text would vanish.
     theme.palette.appBarTextColorDark = hex;
+    delete theme.palette.appBarTextColor;
   }
   saveThemeChoice({ accentHue: hex });
   pokeRefresh();
@@ -211,6 +222,15 @@ export function setThemeBackground(src) {
 
 const CARD_SURFACES = ['solid', 'glass', 'flat'];
 
+// Live control: app-wide light/dark mode. Session('theme') is canonical —
+// CustomThemeProvider mirrors it into its React state, so the header
+// Sun/Moon icon, the Theme & Palette MODE control, and presets all agree.
+export function setThemeMode(mode) {
+  const next = mode === 'dark' ? 'dark' : 'light';
+  Session.set('theme', next);
+  saveThemeChoice({ mode: next });
+}
+
 // Live control: content-ink mode for ambiance-enabled pages ('light'|'dark');
 // null/undefined clears the override (app mode stands). Chrome keeps Session('theme').
 export function setPageMode(mode) {
@@ -235,16 +255,32 @@ export function cycleCardSurface() {
   setCardSurface(next);
 }
 
+// Per-route baseline card surface, from route-level `defaultSurface`
+// declarations (e.g. /patient-chart is flat-by-default). AmbianceZone
+// registers the active route's baseline at render time so the Ctrl+Shift+K
+// toggle knows which way to flip.
+const routeSurfaceDefaults = {};
+export function registerRouteSurfaceDefault(pathname, surface) {
+  if (!pathname) { return; }
+  if (CARD_SURFACES.indexOf(surface) !== -1) {
+    routeSurfaceDefaults[pathname] = surface;
+  } else {
+    delete routeSurfaceDefaults[pathname];
+  }
+}
+
 // Live control: per-route card <-> full-height override (Ctrl+Shift+K).
-// Toggles the active pathname between 'flat' (one-page/full-height) and no
-// override (global cardSurface stands). Spec: onePageLayout revival.
+// Toggles the active pathname between its baseline and the opposite surface:
+// normal routes flip to 'flat' (one-page/full-height); flat-by-default routes
+// (route defaultSurface: 'flat') flip to 'solid' cards. Removing the override
+// returns to the baseline. Spec: onePageLayout revival.
 export function togglePageSurfaceOverride(pathname) {
   if (!pathname) { return; }
   const overrides = Object.assign({}, Session.get(PAGE_SURFACE_OVERRIDES) || {});
   if (overrides[pathname]) {
     delete overrides[pathname];
   } else {
-    overrides[pathname] = 'flat';
+    overrides[pathname] = routeSurfaceDefaults[pathname] === 'flat' ? 'solid' : 'flat';
   }
   Session.set(PAGE_SURFACE_OVERRIDES, overrides);
   saveThemeChoice({ pageSurfaceOverrides: overrides });
@@ -271,8 +307,10 @@ export function applyThemeChoiceAtBoot() {
   if (choice.accentHue) {
     theme.palette.primaryColor = choice.accentHue;
     if (preset && preset.appBarTracksAccent) {
-      theme.palette.appBarTextColor = choice.accentHue;
+      // Dark chrome only — light-mode bar background defaults to the accent,
+      // so accent text there is invisible (matches applyThemePreset).
       theme.palette.appBarTextColorDark = choice.accentHue;
+      delete theme.palette.appBarTextColor;
     }
   }
   if (choice.mode) {

--- a/npmPackages/fhircast/client/components/FhircastNavButtons.jsx
+++ b/npmPackages/fhircast/client/components/FhircastNavButtons.jsx
@@ -39,7 +39,9 @@ function FhircastNavButtons() {
             key={route.path}
             id={'fhircast-' + route.label.toLowerCase().replace(/\s+/g, '-') + '-footer-btn'}
             variant={isActive ? 'contained' : 'text'}
-            color={isActive ? 'secondary' : 'inherit'}
+            // Active button fills with the dialed accent (primary), not the
+            // fixed secondary hue — so the selected footer tab tracks the theme.
+            color={isActive ? 'primary' : 'inherit'}
             size="small"
             startIcon={<IconComponent />}
             onClick={function() { navigate(route.path); }}

--- a/npmPackages/international-patient-summary/client.js
+++ b/npmPackages/international-patient-summary/client.js
@@ -32,7 +32,18 @@ const DynamicRoutes = workflowConfig.routes.map(function(route) {
   } else {
     log.warn('Unknown component in workflow.json:', { component: route.component });
   }
-  return { name: route.name, path: route.path, element: element, requireAuth: route.requireAuth || false };
+  return {
+    name: route.name,
+    path: route.path,
+    element: element,
+    requireAuth: route.requireAuth || false,
+    requirePatient: route.requirePatient || false,
+    // Ambiance flags ride the route object so App.jsx wraps the page in
+    // AmbianceZone (background composition, page-text ink, card surfaces).
+    enableAmbiance: route.enableAmbiance || false,
+    enableFluidInterface: route.enableFluidInterface || false,
+    defaultSurface: route.defaultSurface
+  };
 });
 
 const SidebarWorkflows = workflowConfig.sidebarItems.map(function(item) {

--- a/npmPackages/international-patient-summary/client/InternationalPatientSummaryPage.jsx
+++ b/npmPackages/international-patient-summary/client/InternationalPatientSummaryPage.jsx
@@ -617,6 +617,12 @@ function InternationalPatientSummaryPage(props) {
 
   // Single column responsive layout
   function renderSingleColumnLayout() {
+    // Focus-aware column (ambiance content focus: left | center | right).
+    // StyledContainer supplies the alignment from the zone composition; the
+    // sx below overrides its width/padding scheme with this page's animated
+    // maxWidth. Plain Box fallback keeps the old centered behavior.
+    const FocusColumn = Meteor.StyledContainer || Box;
+    const focusAware = !!Meteor.StyledContainer;
     return (
       <Box sx={{
         height: '100%',
@@ -629,7 +635,7 @@ function InternationalPatientSummaryPage(props) {
         pb: 3,
         overflow: 'hidden'
       }}>
-        <Box sx={{
+        <FocusColumn maxWidth={false} sx={{
           // Tabbed view goes full-bleed (20px gutters); accordion/editor keep
           // the constrained portrait column. maxWidth stays a length in both
           // states so the width change animates instead of jumping.
@@ -637,7 +643,8 @@ function InternationalPatientSummaryPage(props) {
             ? '100%'
             : (isPanelOpen && isDesktop ? 1600 : 1200),
           width: '100%',
-          mx: 'auto',
+          boxSizing: 'border-box',
+          ...(focusAware ? {} : { mx: 'auto' }),
           px: viewMode === 'tabbed' ? '20px' : { xs: 2, sm: 3 },
           display: 'flex',
           gap: 3,
@@ -817,7 +824,7 @@ function InternationalPatientSummaryPage(props) {
               )}
             </Box>
           )}
-        </Box>
+        </FocusColumn>
       </Box>
     );
   }

--- a/npmPackages/international-patient-summary/client/InternationalPatientSummaryPage.jsx
+++ b/npmPackages/international-patient-summary/client/InternationalPatientSummaryPage.jsx
@@ -637,15 +637,20 @@ function InternationalPatientSummaryPage(props) {
       }}>
         <FocusColumn maxWidth={false} sx={{
           // Tabbed view goes full-bleed (20px gutters); accordion/editor keep
-          // the constrained portrait column. maxWidth stays a length in both
-          // states so the width change animates instead of jumping.
+          // the constrained portrait column with StyledContainer's own gutter
+          // scheme (xs 2 / md 3 / xl 200px easement) so the padding matches
+          // the other ambiance pages (/patient-chart, /timeline-vertical).
+          // maxWidth stays a length in both states so the width change
+          // animates instead of jumping.
           maxWidth: viewMode === 'tabbed'
             ? '100%'
             : (isPanelOpen && isDesktop ? 1600 : 1200),
-          width: '100%',
-          boxSizing: 'border-box',
-          ...(focusAware ? {} : { mx: 'auto' }),
-          px: viewMode === 'tabbed' ? '20px' : { xs: 2, sm: 3 },
+          ...(viewMode === 'tabbed' ? { px: '20px', boxSizing: 'border-box' } : {}),
+          ...(focusAware ? {} : {
+            width: '100%',
+            mx: 'auto',
+            px: viewMode === 'tabbed' ? '20px' : { xs: 2, sm: 3 }
+          }),
           display: 'flex',
           gap: 3,
           flex: 1,

--- a/npmPackages/international-patient-summary/client/InternationalPatientSummaryPage.jsx
+++ b/npmPackages/international-patient-summary/client/InternationalPatientSummaryPage.jsx
@@ -190,7 +190,6 @@ function InternationalPatientSummaryPage(props) {
   // Theme-aware colors
   const cardBgColor = isDark ? '#1e1e1e' : '#ffffff';
   const cardTextColor = isDark ? 'rgba(255, 255, 255, 0.87)' : 'rgba(0, 0, 0, 0.87)';
-  const pageBgColor = isDark ? '#121212' : '#f5f5f5';
 
   function handleResourceClick(resource) {
     setSelectedResource(resource);
@@ -623,7 +622,9 @@ function InternationalPatientSummaryPage(props) {
         height: '100%',
         display: 'flex',
         flexDirection: 'column',
-        bgcolor: pageBgColor,
+        // No page-level bgcolor: StyledMainRouter paints background.default,
+        // and on enableAmbiance routes the ambiance background must show
+        // through — an opaque wash here was hiding it.
         pt: 3,
         pb: 3,
         overflow: 'hidden'

--- a/npmPackages/international-patient-summary/client/components/GeneratePatientNarrativeModal.jsx
+++ b/npmPackages/international-patient-summary/client/components/GeneratePatientNarrativeModal.jsx
@@ -37,6 +37,7 @@ import {
   IconButton,
   Tooltip
 } from '@mui/material';
+import { darken, lighten } from '@mui/material/styles';
 
 import {
   Security as SecurityIcon,
@@ -69,25 +70,23 @@ function GeneratePatientNarrativeModal({ open, onClose, onGenerated }) {
   const [generationStatus, setGenerationStatus] = useState('');
   const [downloadProgress, setDownloadProgress] = useState(0);
 
-  // Get Honeycomb theme for dark mode support
-  const useAppTheme = Meteor.useTheme;
-  const appTheme = useAppTheme ? useAppTheme() : { theme: 'light' };
-  const isDark = appTheme.theme === 'dark';
-
-  // Theme-aware colors
-  const cardBgColor = isDark ? '#1e1e1e' : '#ffffff';
-  const cardTextColor = isDark ? 'rgba(255, 255, 255, 0.87)' : 'rgba(0, 0, 0, 0.87)';
-  const textSecondary = isDark ? 'rgba(255, 255, 255, 0.6)' : 'rgba(0, 0, 0, 0.6)';
-
-  // Jewel-tone alert styles for dark mode
+  // Jewel-tone alert styles derived from the ACTIVE theme palette (so the
+  // Theme & Palette presets/accent dial restyle them live) — dark mode gets
+  // a dense severity-tinted surface; light mode keeps MUI's standard alert
+  // styling. Returned as an sx theme-callback: use sx={alertSx('info')} or
+  // sx={[{ mb: 2 }, alertSx('info')]}.
   function alertSx(severity) {
-    if (!isDark) return {};
-    const styles = {
-      info:    { bgcolor: '#0d47a1', color: '#e3f2fd', '& .MuiAlert-icon': { color: '#90caf9' }, '& .MuiAlertTitle-root': { color: '#e3f2fd' } },
-      warning: { bgcolor: '#e65100', color: '#fff3e0', '& .MuiAlert-icon': { color: '#ffcc80' }, '& .MuiAlertTitle-root': { color: '#fff3e0' } },
-      success: { bgcolor: '#1b5e20', color: '#e8f5e9', '& .MuiAlert-icon': { color: '#81c784' }, '& .MuiAlertTitle-root': { color: '#e8f5e9' } }
+    return function (theme) {
+      if (theme.palette.mode !== 'dark') { return {}; }
+      const main = get(theme.palette, severity + '.main', theme.palette.info.main);
+      const bg = darken(main, 0.65);
+      return {
+        bgcolor: bg,
+        color: theme.palette.getContrastText(bg),
+        '& .MuiAlert-icon': { color: lighten(main, 0.35) },
+        '& .MuiAlertTitle-root': { color: 'inherit' }
+      };
     };
-    return styles[severity] || {};
   }
 
   // Load configuration from settings
@@ -386,14 +385,8 @@ function GeneratePatientNarrativeModal({ open, onClose, onGenerated }) {
       onClose={onClose}
       maxWidth="md"
       fullWidth
-      PaperProps={{
-        sx: {
-          bgcolor: cardBgColor,
-          color: cardTextColor
-        }
-      }}
     >
-      <DialogTitle sx={{ bgcolor: cardBgColor, color: cardTextColor }}>
+      <DialogTitle>
         <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
           <Typography variant="h6">Generate IPS Narrative</Typography>
           <Tooltip title="Learn more about LLM options">
@@ -404,26 +397,10 @@ function GeneratePatientNarrativeModal({ open, onClose, onGenerated }) {
         </Box>
       </DialogTitle>
       
-      <DialogContent dividers sx={{
-        bgcolor: cardBgColor,
-        color: cardTextColor,
-        borderColor: isDark ? 'rgba(255,255,255,0.12)' : 'rgba(0,0,0,0.12)',
-        '& .MuiRadio-root': { color: cardTextColor },
-        '& .MuiFormControlLabel-label': { color: 'inherit' },
-        '& .MuiDivider-root': { borderColor: isDark ? 'rgba(255,255,255,0.12)' : 'rgba(0,0,0,0.12)' },
-        '& .MuiListItemIcon-root .MuiSvgIcon-root': { color: cardTextColor },
-        '& .MuiListItemText-primary': { color: cardTextColor },
-        '& .MuiChip-outlined.MuiChip-colorDefault': {
-          color: cardTextColor,
-          borderColor: isDark ? 'rgba(255,255,255,0.23)' : 'rgba(0,0,0,0.23)'
-        },
-        '& .MuiTextField-root': {
-          '& .MuiInputBase-root': { color: cardTextColor },
-          '& .MuiOutlinedInput-notchedOutline': { borderColor: isDark ? 'rgba(255,255,255,0.23)' : 'rgba(0,0,0,0.23)' },
-          '& .MuiInputLabel-root': { color: textSecondary },
-          '& .MuiFormHelperText-root': { color: textSecondary }
-        }
-      }}>
+      {/* Theme tokens drive all surfaces/text — the dialog renders under
+          CustomThemeProvider, so paper, ink, dividers, inputs and chips
+          resolve for both modes without per-component recoloring. */}
+      <DialogContent dividers>
         <Box sx={{ mb: 3 }}>
           <Typography variant="subtitle2" gutterBottom>
             Select LLM Provider
@@ -438,8 +415,6 @@ function GeneratePatientNarrativeModal({ open, onClose, onGenerated }) {
                   p: 2,
                   mb: 2,
                   cursor: 'pointer',
-                  bgcolor: cardBgColor,
-                  color: cardTextColor,
                   border: selectedProvider === provider.id ? 2 : 1,
                   borderColor: selectedProvider === provider.id ? 'primary.main' : 'divider'
                 }}
@@ -456,7 +431,7 @@ function GeneratePatientNarrativeModal({ open, onClose, onGenerated }) {
                           {provider.name}
                         </Typography>
                       </Box>
-                      <Typography variant="body2" sx={{ color: textSecondary, mb: 1 }}>
+                      <Typography variant="body2" sx={{ color: 'text.secondary', mb: 1 }}>
                         {provider.description}
                       </Typography>
                       <Box sx={{ display: 'flex', gap: 1, mb: 1 }}>
@@ -475,7 +450,7 @@ function GeneratePatientNarrativeModal({ open, onClose, onGenerated }) {
                     {provider.id === 'webllm' && (
                       <Alert
                         severity={cachedModels.length > 0 ? "success" : "info"}
-                        sx={{ mb: 2, ...alertSx(cachedModels.length > 0 ? 'success' : 'info') }}
+                        sx={[{ mb: 2 }, alertSx(cachedModels.length > 0 ? 'success' : 'info')]}
                         icon={cachedModels.length > 0 ? <CheckCircleIcon /> : <InfoIcon />}
                       >
                         {cachedModels.length > 0 ? (
@@ -644,7 +619,7 @@ function GeneratePatientNarrativeModal({ open, onClose, onGenerated }) {
 
         {/* HIPAA Compliance Warning */}
         {currentProvider && currentProvider.hipaa !== 'compliant' && (
-          <Alert severity="warning" sx={{ mt: 2, ...alertSx('warning') }}>
+          <Alert severity="warning" sx={[{ mt: 2 }, alertSx('warning')]}>
             <AlertTitle>HIPAA Compliance Warning</AlertTitle>
             <Typography variant="body2">
               This provider may not be HIPAA compliant by default. Ensure you have:
@@ -659,7 +634,7 @@ function GeneratePatientNarrativeModal({ open, onClose, onGenerated }) {
         )}
       </DialogContent>
 
-      <DialogActions sx={{ bgcolor: cardBgColor, color: cardTextColor }}>
+      <DialogActions>
         <Box sx={{ flex: 1, mr: 2 }}>
           {loading && (
             <Box>

--- a/npmPackages/international-patient-summary/workflow.json
+++ b/npmPackages/international-patient-summary/workflow.json
@@ -2,7 +2,7 @@
   "name": "international-patient-summary",
   "displayName": "International Patient Summary",
   "routes": [
-    { "name": "International Patient Summary", "path": "/international-patient-summary", "component": "InternationalPatientSummaryPage", "requireAuth": true }
+    { "name": "International Patient Summary", "path": "/international-patient-summary", "component": "InternationalPatientSummaryPage", "requireAuth": true, "requirePatient": true, "enableAmbiance": true }
   ],
   "sidebarItems": [
     { "primaryText": "International Summary", "to": "/international-patient-summary", "iconName": "Map", "requireAuth": true }

--- a/npmPackages/pacio-core/client/components/FhirFetchPanel.jsx
+++ b/npmPackages/pacio-core/client/components/FhirFetchPanel.jsx
@@ -44,12 +44,26 @@ export function FhirFetchPanel() {
   const cardBgColor = isDark ? '#1e1e1e' : '#ffffff';
   const cardTextColor = isDark ? 'rgba(255, 255, 255, 0.87)' : 'rgba(0, 0, 0, 0.87)';
 
-  const [patientId, setPatientId] = useState('patient-betsysmith-johnson01');
+  // URL params override the configured defaults, so a launching system (or a
+  // returning OAuth redirect) can pre-populate the form:
+  //   ?patientId= / ?patient=            → Patient Identifier
+  //   ?fhirServerUrl= / ?serverUrl= / ?iss= → FHIR Server URL
+  const initialParams = new URLSearchParams(window.location.search);
+  const urlPatientId = initialParams.get('patientId') || initialParams.get('patient') || '';
+  const urlServerUrl = initialParams.get('fhirServerUrl') || initialParams.get('serverUrl') || initialParams.get('iss') || '';
+
+  const [patientId, setPatientId] = useState(urlPatientId || 'patient-betsysmith-johnson01');
   // Default to the configured inbound-fetch interface
   // (settings.public.interfaces.default — see /server-configuration?tab=interfaces)
   const [fhirServerUrl, setFhirServerUrl] = useState(
+    urlServerUrl ||
     get(Meteor, 'settings.public.interfaces.default.channel.endpoint', '') ||
     Meteor.absoluteUrl('baseR4')
+  );
+  // Where the current form values came from, when not the defaults —
+  // surfaced as a dismissible info Alert above the form.
+  const [contextNote, setContextNote] = useState(
+    (urlPatientId || urlServerUrl) ? 'FHIR Server URL and Patient Identifier were provided by the launching URL.' : null
   );
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState(null);
@@ -127,6 +141,12 @@ export function FhirFetchPanel() {
           });
           addLog('Connected to ' + get(session, 'fhirBaseUrl', 'EHR') +
             ' — patient context: ' + (get(session, 'patient') || '(none)'), 'success');
+          // Reflect the actual EHR connection in the form — otherwise the
+          // fields keep showing the configured defaults while the real
+          // fetch runs against the connected server.
+          if (get(session, 'fhirBaseUrl')) { setFhirServerUrl(get(session, 'fhirBaseUrl')); }
+          if (get(session, 'patient')) { setPatientId(get(session, 'patient')); }
+          setContextNote('Connected via SMART launch — FHIR Server URL and Patient Identifier reflect the EHR session.');
           setConnecting(false);
           await runFetch({ sessionToken: get(session, 'sessionToken') },
             get(session, 'patient', ''));
@@ -213,6 +233,9 @@ export function FhirFetchPanel() {
           const pageInfo = result.pagesFetched > 1 ? ` across ${result.pagesFetched} pages` : '';
           setSuccess(`Successfully fetched ${result.resourceCount || 0} resources${pageInfo} for patient ${result.patientId || displayPatientId}`);
 
+          // Keep the form in sync with what was actually fetched
+          if (result.patientId) { setPatientId(result.patientId); }
+
           // Import the bundle if available
           if (result.bundle) {
             setIsImporting(true);
@@ -223,6 +246,7 @@ export function FhirFetchPanel() {
                 Meteor.MedicalRecordImporter.importBundle(result.bundle);
                 addLog('Import completed successfully!', 'success');
                 setIsImporting(false);
+                setIsLoading(false);
 
                 // Set session variables and navigate to patient chart if successful
                 if (result.patientId) {
@@ -241,6 +265,7 @@ export function FhirFetchPanel() {
                 console.error('Import error:', importError);
                 addLog(`Import error: ${importError.message}`, 'error');
                 setIsImporting(false);
+                setIsLoading(false);
               }
             }, 100);
           } else {
@@ -365,6 +390,12 @@ export function FhirFetchPanel() {
       }}>
         <CardContent>
           <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
+            {contextNote && (
+              <Alert severity="info" onClose={() => setContextNote(null)}>
+                {contextNote}
+              </Alert>
+            )}
+
             <TextField
               fullWidth
               label="FHIR Server URL"

--- a/npmPackages/provider-directory/client.js
+++ b/npmPackages/provider-directory/client.js
@@ -69,7 +69,8 @@ let DynamicRoutes = [{
   name: 'ProviderDirectory',
   path: '/provider-directory',
   element: <DirectoryConsole />,
-  requireAuth: true
+  requireAuth: true,
+  enableAmbiance: true
 }, {
   name: 'ProviderDirectoryClassic',
   path: '/provider-directory-classic',

--- a/npmPackages/provider-directory/client/DirectoryConsole.jsx
+++ b/npmPackages/provider-directory/client/DirectoryConsole.jsx
@@ -881,7 +881,8 @@ export function DirectoryConsole() {
                 ${alpha(theme.palette.background.default, scrimStrength * 0.85)} 100%)`
             : 'transparent',
           backdropFilter: activeBg ? 'blur(2px)' : 'none',
-          borderRadius: '4px'
+          borderRadius: '4px',
+          '@media print': { background: 'transparent', backdropFilter: 'none' }
         }}>
 
           {/* ---- masthead ---- */}

--- a/npmPackages/provider-directory/client/DirectoryConsole.jsx
+++ b/npmPackages/provider-directory/client/DirectoryConsole.jsx
@@ -23,11 +23,16 @@
 
 import React, { useState, useEffect, useMemo, useRef, useCallback } from 'react';
 import { Box, Collapse, Button, CircularProgress } from '@mui/material';
-import { useTheme, alpha, darken, lighten, createTheme } from '@mui/material/styles';
+import { useTheme, alpha, darken, lighten } from '@mui/material/styles';
 import { useSearchParams } from 'react-router-dom';
 import { Meteor } from 'meteor/meteor';
+import { Session } from 'meteor/session';
+import { useTracker } from 'meteor/react-meteor-data';
 import { get } from 'lodash';
 import { SpiderScanLine, useSpiderScanning, withSpiderScanning } from '/imports/ui/components/SpiderScanLine.jsx';
+import { buildPageModeTheme } from '/imports/ui/theme/pageModeTheme.js';
+import { PAGE_MODE } from '/imports/lib/SessionKeys.js';
+import { getBackgroundEntry } from '/imports/ui/themeBackgrounds.js';
 
 const log = (Meteor.Logger ? Meteor.Logger.for('DirectoryConsole') : console);
 
@@ -115,9 +120,19 @@ const CONSOLE_STATIC_CSS = `
   white-space: nowrap;
 }
 
+/* Result rows get a panel backing so org names never sit naked on the photo.
+   Combined-class selector (.gc-row-btn.gc-row) beats the plain .gc-row-btn
+   background rule above regardless of stylesheet order. */
+.gc-row-btn.gc-row { background: color-mix(in srgb, var(--panel-hard) 45%, transparent); }
+.gc-row-btn.gc-row:hover {
+  background:
+    linear-gradient(90deg, color-mix(in srgb, var(--amber) 7%, transparent), color-mix(in srgb, var(--stone) 3%, transparent) 60%, transparent),
+    color-mix(in srgb, var(--panel-hard) 70%, transparent);
+}
+
 .gc-chip-btn {
   font-family: var(--mono); font-size: 10px; letter-spacing: 0.18em;
-  color: var(--stone); background: transparent; border: 1px solid var(--stone-dim);
+  color: var(--stone); background: color-mix(in srgb, var(--panel-hard) 60%, transparent); border: 1px solid var(--stone-dim);
   padding: 6px 14px; cursor: pointer; transition: all 0.18s ease;
 }
 .gc-chip-btn:hover { border-color: var(--amber); color: var(--amber); background: color-mix(in srgb, var(--amber) 6%, transparent); }
@@ -532,6 +547,7 @@ function StatusChip({ status }) {
       fontFamily: 'var(--mono)', fontSize: '9px', letterSpacing: '0.2em',
       px: 1, py: 0.4, whiteSpace: 'nowrap',
       color: live ? 'var(--green)' : 'var(--ink-dim)',
+      background: 'color-mix(in srgb, var(--panel-hard) 60%, transparent)',
       border: '1px solid ' + (live ? 'color-mix(in srgb, var(--green) 40%, transparent)' : 'color-mix(in srgb, var(--ink-dim) 40%, transparent)'),
       animation: live ? 'gcPulse 3s ease-in-out infinite' : 'none'
     }}>
@@ -564,7 +580,7 @@ function ResultBand({ band, config, revealIndex, onLoadMore, loadingMore }) {
         </Box>
         <Box component="span" sx={{
           fontFamily: 'var(--mono)', fontSize: '10px', letterSpacing: '0.18em',
-          color: band.matchCount ? config.accent : 'var(--ink-dim)'
+          color: band.matchCount ? config.accent : 'var(--ink)'
         }}>
           — {band.matchCount ? (countLabel + ' ' + config.unit) : 'BAND SILENT'}
         </Box>
@@ -674,40 +690,33 @@ export function DirectoryConsole() {
   const appMuiTheme = useTheme();
   const [searchParams] = useSearchParams();
 
-  // ?align=left|center|right — horizontal placement of the console body within
-  // the router area (defaults to centered).
-  const alignParam = (searchParams.get('align') || 'center').toLowerCase();
-  const bodyAlign = alignParam === 'left' ? { ml: 0, mr: 'auto' }
-    : alignParam === 'right' ? { ml: 'auto', mr: 0 }
-    : { mx: 'auto' };
-
-  // ?page-theme=light|dark — override ONLY this page's palette (the CSS-var
-  // block that drives all console text/surfaces/borders), NOT the global app
-  // theme. Rationale: the ambiance background can read visually "dark" yet
-  // average light (e.g. black stones on pale water), so the theme-default text
-  // color may be unreadable over it. This flips the console's ink/panels to
-  // suit the chosen background while the header/footer keep the user's real
-  // mode. Rebuilt with the app's accent palette + fonts, only the mode-
-  // dependent tokens (text/background/divider) change.
+  // Content-ink override: URL param (dev/demo) wins over the persisted
+  // Page Mode choice (Theme & Palette dialog). Falsy → app mode stands.
   const pageThemeParam = (searchParams.get('page-theme') || '').toLowerCase();
-  const forcedMode = (pageThemeParam === 'light' || pageThemeParam === 'dark') ? pageThemeParam : null;
+  const persistedPageMode = useTracker(function() { return Session.get(PAGE_MODE); }, []);
+  const paramMode = (pageThemeParam === 'light' || pageThemeParam === 'dark') ? pageThemeParam : null;
+  const forcedMode = paramMode || persistedPageMode || null;
   const theme = useMemo(function() {
-    if (!forcedMode || forcedMode === appMuiTheme.palette.mode) { return appMuiTheme; }
-    return createTheme({
-      palette: {
-        mode: forcedMode,
-        primary: appMuiTheme.palette.primary,
-        secondary: appMuiTheme.palette.secondary,
-        error: appMuiTheme.palette.error,
-        warning: appMuiTheme.palette.warning,
-        info: appMuiTheme.palette.info,
-        success: appMuiTheme.palette.success
-      },
-      typography: appMuiTheme.typography
-    });
+    return buildPageModeTheme(appMuiTheme, forcedMode);
   }, [appMuiTheme, forcedMode]);
 
   const consoleVars = buildConsoleVars(theme);
+
+  // Curation record for the active ambiance (scrim strength + focus).
+  const activeBg = useTracker(function() {
+    return get(Meteor, 'settings.public.theme.backgroundImagePath', '');
+  }, []);
+  const bgEntry = getBackgroundEntry(activeBg);
+  const scrimStrength = get(bgEntry, 'scrimStrength', 0.55);
+
+  // ?align param wins; otherwise the image's curated focus; otherwise center.
+  const alignParam = (searchParams.get('align') || '').toLowerCase();
+  const focus = ['left', 'center', 'right'].indexOf(alignParam) !== -1
+    ? alignParam
+    : (get(bgEntry, 'focus') || 'center');
+  const bodyAlign = focus === 'left' ? { ml: 0, mr: 'auto' }
+    : focus === 'right' ? { ml: 'auto', mr: 0 }
+    : { mx: 'auto' };
 
   const [query, setQuery] = useState('');
   const [facets, setFacets] = useState({ city: '', state: '', postalCode: '' });
@@ -849,8 +858,22 @@ export function DirectoryConsole() {
       <SpiderScanLine active={scanning || spiderScanning} zIndex={1} />
 
       {/* scrollable console body */}
-      <Box sx={{ flex: 1, minHeight: 0, overflow: 'auto', position: 'relative', zIndex: 2 }}>
-        <Box sx={{ maxWidth: '1180px', ...bodyAlign, px: { xs: 2.5, md: 5 }, pt: { xs: 3, md: 5 }, pb: 8 }}>
+      <Box sx={{ flex: 1, minHeight: 0, overflow: 'auto', position: 'relative', zIndex: 2, px: { xl: '200px' } }}>
+        <Box sx={{
+          maxWidth: '1180px', ...bodyAlign,
+          px: { xs: 2.5, md: 5 },
+          pt: { xs: 3, md: 5 }, pb: 8,
+          // Column scrim: a soft canvas-tinted backdrop so content survives
+          // bright photos. Strength comes from the image's curation record.
+          // Gated on an active background — no gray slab over a plain canvas.
+          background: activeBg
+            ? `linear-gradient(180deg,
+                ${alpha(theme.palette.background.default, scrimStrength)} 0%,
+                ${alpha(theme.palette.background.default, scrimStrength * 0.85)} 100%)`
+            : 'transparent',
+          backdropFilter: activeBg ? 'blur(2px)' : 'none',
+          borderRadius: '4px'
+        }}>
 
           {/* ---- masthead ---- */}
           <Box className="gc-boot" sx={{
@@ -875,7 +898,7 @@ export function DirectoryConsole() {
             </Box>
             <Box sx={{
               fontFamily: 'var(--mono)', fontSize: '10px', letterSpacing: '0.16em',
-              color: 'var(--ink-dim)', textAlign: 'right', lineHeight: 2
+              color: 'var(--ink)', textAlign: 'right', lineHeight: 2
             }}>
               <Box><LastUpdated iso={lastUpdated} /></Box>
               <Box>
@@ -965,7 +988,7 @@ export function DirectoryConsole() {
             <Box sx={{
               display: 'flex', justifyContent: 'space-between', flexWrap: 'wrap', gap: 1,
               fontFamily: 'var(--mono)', fontSize: '9.5px', letterSpacing: '0.2em',
-              color: 'var(--ink-dim)', mt: 1, px: 0.5
+              color: 'var(--ink)', mt: 1, px: 0.5
             }}>
               <Box>
                 {scanning

--- a/npmPackages/provider-directory/client/DirectoryConsole.jsx
+++ b/npmPackages/provider-directory/client/DirectoryConsole.jsx
@@ -21,9 +21,10 @@
 // public/workflows/provider-directory/. The classic facet page remains at
 // /provider-directory-classic.
 
-import React, { useState, useEffect, useRef, useCallback } from 'react';
+import React, { useState, useEffect, useMemo, useRef, useCallback } from 'react';
 import { Box, Collapse, Button, CircularProgress } from '@mui/material';
-import { useTheme, alpha, darken, lighten } from '@mui/material/styles';
+import { useTheme, alpha, darken, lighten, createTheme } from '@mui/material/styles';
+import { useSearchParams } from 'react-router-dom';
 import { Meteor } from 'meteor/meteor';
 import { get } from 'lodash';
 import { SpiderScanLine, useSpiderScanning, withSpiderScanning } from '/imports/ui/components/SpiderScanLine.jsx';
@@ -670,8 +671,44 @@ function ResultBand({ band, config, revealIndex, onLoadMore, loadingMore }) {
 // ---------------------------------------------------------------------------
 
 export function DirectoryConsole() {
-  const theme = useTheme();
+  const appMuiTheme = useTheme();
+  const [searchParams] = useSearchParams();
+
+  // ?align=left|center|right — horizontal placement of the console body within
+  // the router area (defaults to centered).
+  const alignParam = (searchParams.get('align') || 'center').toLowerCase();
+  const bodyAlign = alignParam === 'left' ? { ml: 0, mr: 'auto' }
+    : alignParam === 'right' ? { ml: 'auto', mr: 0 }
+    : { mx: 'auto' };
+
+  // ?page-theme=light|dark — override ONLY this page's palette (the CSS-var
+  // block that drives all console text/surfaces/borders), NOT the global app
+  // theme. Rationale: the ambiance background can read visually "dark" yet
+  // average light (e.g. black stones on pale water), so the theme-default text
+  // color may be unreadable over it. This flips the console's ink/panels to
+  // suit the chosen background while the header/footer keep the user's real
+  // mode. Rebuilt with the app's accent palette + fonts, only the mode-
+  // dependent tokens (text/background/divider) change.
+  const pageThemeParam = (searchParams.get('page-theme') || '').toLowerCase();
+  const forcedMode = (pageThemeParam === 'light' || pageThemeParam === 'dark') ? pageThemeParam : null;
+  const theme = useMemo(function() {
+    if (!forcedMode || forcedMode === appMuiTheme.palette.mode) { return appMuiTheme; }
+    return createTheme({
+      palette: {
+        mode: forcedMode,
+        primary: appMuiTheme.palette.primary,
+        secondary: appMuiTheme.palette.secondary,
+        error: appMuiTheme.palette.error,
+        warning: appMuiTheme.palette.warning,
+        info: appMuiTheme.palette.info,
+        success: appMuiTheme.palette.success
+      },
+      typography: appMuiTheme.typography
+    });
+  }, [appMuiTheme, forcedMode]);
+
   const consoleVars = buildConsoleVars(theme);
+
   const [query, setQuery] = useState('');
   const [facets, setFacets] = useState({ city: '', state: '', postalCode: '' });
   const [showFacets, setShowFacets] = useState(false);
@@ -783,12 +820,15 @@ export function DirectoryConsole() {
   return (
     <Box className="grid-console" sx={{
       height: '100%', display: 'flex', flexDirection: 'column', overflow: 'hidden',
-      background: 'var(--void)', position: 'relative',
+      // Transparent root: defer to StyledMainRouter's background.default + the
+      // ambiance image (rules/ui/theming.md — root containers don't paint their
+      // own page bgcolor). The translucent panels/overlays below keep content
+      // readable over whatever app background shows through.
+      background: 'transparent', position: 'relative',
       // atmosphere layers
       '&::before': {
         content: '""', position: 'absolute', inset: 0, pointerEvents: 'none', zIndex: 0,
         background: `
-          linear-gradient(160deg, var(--void-hi) 0%, var(--void) 45%, var(--void-lo) 100%),
           radial-gradient(120% 90% at 15% -10%, color-mix(in srgb, var(--ink) 6%, transparent), transparent 55%),
           radial-gradient(90% 70% at 95% 110%, color-mix(in srgb, var(--ink) 3%, transparent), transparent 60%),
           repeating-linear-gradient(0deg, color-mix(in srgb, var(--ink) 2%, transparent) 0px, color-mix(in srgb, var(--ink) 2%, transparent) 1px, transparent 1px, transparent 3px)
@@ -810,7 +850,7 @@ export function DirectoryConsole() {
 
       {/* scrollable console body */}
       <Box sx={{ flex: 1, minHeight: 0, overflow: 'auto', position: 'relative', zIndex: 2 }}>
-        <Box sx={{ maxWidth: '1180px', mx: 'auto', px: { xs: 2.5, md: 5 }, pt: { xs: 3, md: 5 }, pb: 8 }}>
+        <Box sx={{ maxWidth: '1180px', ...bodyAlign, px: { xs: 2.5, md: 5 }, pt: { xs: 3, md: 5 }, pb: 8 }}>
 
           {/* ---- masthead ---- */}
           <Box className="gc-boot" sx={{
@@ -828,9 +868,7 @@ export function DirectoryConsole() {
                 m: 0, fontFamily: 'var(--display)', fontWeight: 700,
                 fontSize: 'clamp(40px, 6.5vw, 76px)', lineHeight: 0.95,
                 letterSpacing: '0.06em', textTransform: 'uppercase',
-                background: 'linear-gradient(100deg, var(--amber) 10%, color-mix(in srgb, var(--amber) 55%, white) 38%, var(--stone) 90%)',
-                WebkitBackgroundClip: 'text', backgroundClip: 'text', color: 'transparent',
-                filter: 'drop-shadow(0 0 26px color-mix(in srgb, var(--amber) 18%, transparent))'
+                color: 'var(--ink)'
               }}>
                 Directory
               </Box>
@@ -850,12 +888,18 @@ export function DirectoryConsole() {
 
           {/* ---- census ticker ---- */}
           <Box className="gc-boot" sx={{
-            display: 'grid', gridTemplateColumns: { xs: '1fr 1fr', md: 'repeat(4, 1fr)' },
+            display: 'grid', gridTemplateColumns: { xs: '1fr 1fr', md: 'repeat(3, 1fr)' },
             gap: '1px', background: 'var(--hairline)', border: '1px solid var(--hairline)',
             mb: 5, position: 'relative', animationDelay: '120ms'
           }}>
             <Brackets />
-            {Object.keys(BAND_CONFIG).map(function(resourceName, index) {
+            {/* Practitioner ("Clinicians") is hidden from the census until that
+                directory is populated — Practitioners and InsurancePlans return
+                in a future update. BAND_CONFIG keeps its definition for the
+                search result bands. */}
+            {Object.keys(BAND_CONFIG).filter(function(resourceName) {
+              return resourceName !== 'Practitioner';
+            }).map(function(resourceName, index) {
               const config = BAND_CONFIG[resourceName];
               return (
                 <Box key={resourceName} sx={{ background: 'var(--panel)', px: 2.5, py: 2 }}>

--- a/npmPackages/provider-directory/client/DirectoryConsole.jsx
+++ b/npmPackages/provider-directory/client/DirectoryConsole.jsx
@@ -694,6 +694,12 @@ export function DirectoryConsole() {
   // Page Mode choice (Theme & Palette dialog). Falsy → app mode stands.
   const pageThemeParam = (searchParams.get('page-theme') || '').toLowerCase();
   const persistedPageMode = useTracker(function() { return Session.get(PAGE_MODE); }, []);
+
+  // Ctrl+Shift+N retracts the app chrome (Session 'displayNavbars'; undefined
+  // counts as visible — same convention as Header/Footer/App.jsx). With chrome
+  // up the console floats 40px below the header; with chrome retracted the
+  // gap collapses and the card runs the full page height.
+  const navbarsVisible = useTracker(function() { return Session.get('displayNavbars') !== false; }, []);
   const paramMode = (pageThemeParam === 'light' || pageThemeParam === 'dark') ? pageThemeParam : null;
 
   // Plain read each render: theme changes rebuild the MUI theme via
@@ -838,6 +844,12 @@ export function DirectoryConsole() {
   return (
     <Box className="grid-console" sx={{
       height: '100%', display: 'flex', flexDirection: 'column', overflow: 'hidden',
+      // Breathing room below the Header/ProminentHeader while chrome is up;
+      // Ctrl+Shift+N collapses it (the flex cascade already reclaims the
+      // header/footer rows, so 40px → 0 is the only page-side move). Matches
+      // the header's own 0.3s retract animation.
+      pt: navbarsVisible ? '40px' : 0,
+      transition: 'padding-top 0.3s ease-in-out',
       // Transparent root: defer to StyledMainRouter's background.default + the
       // ambiance image (rules/ui/theming.md — root containers don't paint their
       // own page bgcolor). The translucent panels/overlays below keep content
@@ -872,6 +884,11 @@ export function DirectoryConsole() {
           maxWidth: '1180px', ...bodyAlign,
           px: { xs: 2.5, md: 5 },
           pt: { xs: 3, md: 5 }, pb: 8,
+          // Chrome retracted → the card runs the full page height to the
+          // (hidden) footer edge; chrome up → content-height floating card.
+          minHeight: navbarsVisible ? '0%' : '100%',
+          boxSizing: 'border-box',
+          transition: 'min-height 0.3s ease-in-out',
           // Column scrim: a soft canvas-tinted backdrop so content survives
           // bright photos. Strength comes from the image's curation record.
           // Gated on an active background — no gray slab over a plain canvas.

--- a/npmPackages/provider-directory/client/DirectoryConsole.jsx
+++ b/npmPackages/provider-directory/client/DirectoryConsole.jsx
@@ -695,17 +695,13 @@ export function DirectoryConsole() {
   const pageThemeParam = (searchParams.get('page-theme') || '').toLowerCase();
   const persistedPageMode = useTracker(function() { return Session.get(PAGE_MODE); }, []);
   const paramMode = (pageThemeParam === 'light' || pageThemeParam === 'dark') ? pageThemeParam : null;
-  const forcedMode = paramMode || persistedPageMode || null;
-  const theme = useMemo(function() {
-    return buildPageModeTheme(appMuiTheme, forcedMode);
-  }, [appMuiTheme, forcedMode]);
 
-  const consoleVars = buildConsoleVars(theme);
+  // Plain read each render: theme changes rebuild the MUI theme via
+  // CustomThemeProvider (themeRefreshRequest), which re-renders us — same
+  // access pattern as ThemeControls. Do NOT wrap in useTracker (no reactive deps).
+  const activeBg = get(Meteor, 'settings.public.theme.backgroundImagePath', '');
 
   // Curation record for the active ambiance (scrim strength + focus).
-  const activeBg = useTracker(function() {
-    return get(Meteor, 'settings.public.theme.backgroundImagePath', '');
-  }, []);
   const bgEntry = getBackgroundEntry(activeBg);
   const scrimStrength = get(bgEntry, 'scrimStrength', 0.55);
 
@@ -717,6 +713,19 @@ export function DirectoryConsole() {
   const bodyAlign = focus === 'left' ? { ml: 0, mr: 'auto' }
     : focus === 'right' ? { ml: 'auto', mr: 0 }
     : { mx: 'auto' };
+
+  // Content-ink precedence: ?page-theme param (dev override) → the user's
+  // persisted Page Mode → the image's curated recommendedPageMode — the
+  // latter two only while a background is active (no background, no forced ink).
+  const forcedMode = paramMode
+    || (activeBg ? persistedPageMode : null)
+    || (activeBg ? get(bgEntry, 'recommendedPageMode', null) : null)
+    || null;
+  const theme = useMemo(function() {
+    return buildPageModeTheme(appMuiTheme, forcedMode);
+  }, [appMuiTheme, forcedMode]);
+
+  const consoleVars = buildConsoleVars(theme);
 
   const [query, setQuery] = useState('');
   const [facets, setFacets] = useState({ city: '', state: '', postalCode: '' });

--- a/npmPackages/provider-directory/client/DirectoryConsole.jsx
+++ b/npmPackages/provider-directory/client/DirectoryConsole.jsx
@@ -31,7 +31,7 @@ import { useTracker } from 'meteor/react-meteor-data';
 import { get } from 'lodash';
 import { SpiderScanLine, useSpiderScanning, withSpiderScanning } from '/imports/ui/components/SpiderScanLine.jsx';
 import { buildPageModeTheme } from '/imports/ui/theme/pageModeTheme.js';
-import { PAGE_MODE } from '/imports/lib/SessionKeys.js';
+import { PAGE_MODE, SANDBOX_ENDPOINTS } from '/imports/lib/SessionKeys.js';
 import { getBackgroundEntry } from '/imports/ui/themeBackgrounds.js';
 
 const log = (Meteor.Logger ? Meteor.Logger.for('DirectoryConsole') : console);
@@ -278,6 +278,12 @@ const BAND_CONFIG = {
   Location:      { label: 'LOCATIONS',     unit: 'SITES',      sigil: '◬', accent: 'var(--magenta)' },
   Endpoint:      { label: 'ENDPOINTS',     unit: 'UPLINKS',    sigil: '⌁', accent: 'var(--green)' }
 };
+
+// Seeded vendor-sandbox band (session-fed, not part of the unified search).
+// Rendered above ORGANIZATIONS whenever the SANDBOX_ENDPOINTS session array
+// holds records — see the SessionKeys contract; @orbital/lantern's config
+// panel seeds/clears it.
+const SANDBOX_BAND_CONFIG = { label: 'SANDBOXES', unit: 'SEEDED', sigil: '⚗', accent: 'var(--green)' };
 
 // Directory records live in the Directory.* collections, not the core resource
 // collections — so there is no detail page to navigate to. Instead each row
@@ -700,6 +706,31 @@ export function DirectoryConsole() {
   // up the console floats 40px below the header; with chrome retracted the
   // gap collapses and the card runs the full page height.
   const navbarsVisible = useTracker(function() { return Session.get('displayNavbars') !== false; }, []);
+
+  // Seeded vendor sandboxes (lantern config panel writes the session array).
+  // Shaped into Endpoint-band hits so ResultBand / RecordDetail /
+  // EndpointFetchPanel (probe → Connect & Fetch) work unchanged; the band
+  // renders only while records exist (count > 0).
+  const sandboxes = useTracker(function() { return Session.get(SANDBOX_ENDPOINTS) || []; }, []);
+  const sandboxBand = useMemo(function() {
+    if (!sandboxes.length) { return null; }
+    return {
+      resourceName: 'Endpoint',
+      matchCount: sandboxes.length,
+      hits: sandboxes.map(function(s) {
+        return {
+          _id: get(s, 'endpointId'),
+          id: get(s, 'endpointId'),
+          name: get(s, 'name', '(unnamed sandbox)'),
+          address: get(s, 'address', ''),
+          status: 'active',
+          _source: get(s, 'vendor') === 'cerner' ? 'cerner'
+            : (get(s, 'vendor') === 'epic' ? 'epic' : 'other'),
+          _connectable: !!get(s, 'patientLaunchable')
+        };
+      })
+    };
+  }, [sandboxes]);
   const paramMode = (pageThemeParam === 'light' || pageThemeParam === 'dark') ? pageThemeParam : null;
 
   // Plain read each render: theme changes rebuild the MUI theme via
@@ -1075,6 +1106,16 @@ export function DirectoryConsole() {
 
           {/* ---- results / idle state ---- */}
           <Box sx={{ mt: 4 }}>
+            {/* Seeded sandboxes ride above the search bands (and above the
+                idle state) whenever the session array holds records. */}
+            {sandboxBand ? (
+              <ResultBand
+                key={'sandboxes-' + sandboxBand.matchCount}
+                band={sandboxBand}
+                config={SANDBOX_BAND_CONFIG}
+                revealIndex={0}
+              />
+            ) : null}
             {bands === null ? (
               <Box className="gc-boot" sx={{ animationDelay: '360ms', textAlign: 'center', py: 6 }}>
                 <Box sx={{

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "test:smart-launch": "node --experimental-detect-module --test tests/unit/imports/lib/SmartLaunch.test.mjs",
     "test:analytics-scrub": "node --experimental-detect-module --test tests/unit/imports/lib/scrubAnalyticsPath.test.mjs",
     "test:update-check": "node --experimental-detect-module --test tests/unit/imports/lib/updateCheck.test.mjs",
+    "test:logger-redact": "node --test tests/unit/imports/lib/loggerRedact.test.mjs",
     "test:search-shadow": "node --experimental-detect-module --test tests/unit/npmPackages/provider-directory/searchShadow.test.mjs",
     "test:org-linkage": "node --experimental-detect-module --test tests/unit/npmPackages/provider-directory/OrgEndpointLinkage.test.mjs"
   },

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "test:background-value": "node --experimental-detect-module --test tests/unit/imports/ui/theme/backgroundValue.test.mjs",
     "test:ambiance-analysis": "node --experimental-detect-module --test tests/unit/imports/ui/theme/ambianceAnalysis.test.mjs",
     "test:ambiance-composition": "node --experimental-detect-module --test tests/unit/imports/ui/theme/ambianceComposition.test.mjs",
+    "test:surface-styles": "node --experimental-detect-module --test tests/unit/imports/ui/theme/surfaceStyles.test.mjs",
     "test:rpc": "node --test imports/lib/ServerMethodsCore.test.mjs",
     "test:extensions": "node --test imports/lib/extensions/extensions.test.mjs",
     "test:reference-ranges": "node --test imports/lib/referenceRanges/qualifiers.test.mjs imports/lib/referenceRanges/resolveReferenceRange.test.mjs imports/lib/sexForClinicalUse.test.mjs imports/data/reference-ranges/blood-panel.test.mjs server/referenceRanges/seedRecords.test.mjs server/referenceRanges/mergeCandidates.test.mjs server/referenceRanges/buildContext.test.mjs",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "test:workflow-navigation": "node --test imports/lib/WorkflowNavigation.test.mjs",
     "test:workflow-registry": "node --experimental-detect-module --test imports/lib/WorkflowRegistry.test.mjs",
     "test:session-key-groups": "node --experimental-detect-module --test tests/unit/imports/lib/sessionKeyGroups.test.mjs",
+    "test:background-value": "node --experimental-detect-module --test tests/unit/imports/ui/theme/backgroundValue.test.mjs",
     "test:rpc": "node --test imports/lib/ServerMethodsCore.test.mjs",
     "test:extensions": "node --test imports/lib/extensions/extensions.test.mjs",
     "test:reference-ranges": "node --test imports/lib/referenceRanges/qualifiers.test.mjs imports/lib/referenceRanges/resolveReferenceRange.test.mjs imports/lib/sexForClinicalUse.test.mjs imports/data/reference-ranges/blood-panel.test.mjs server/referenceRanges/seedRecords.test.mjs server/referenceRanges/mergeCandidates.test.mjs server/referenceRanges/buildContext.test.mjs",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "test:session-key-groups": "node --experimental-detect-module --test tests/unit/imports/lib/sessionKeyGroups.test.mjs",
     "test:background-value": "node --experimental-detect-module --test tests/unit/imports/ui/theme/backgroundValue.test.mjs",
     "test:ambiance-analysis": "node --experimental-detect-module --test tests/unit/imports/ui/theme/ambianceAnalysis.test.mjs",
+    "test:ambiance-composition": "node --experimental-detect-module --test tests/unit/imports/ui/theme/ambianceComposition.test.mjs",
     "test:rpc": "node --test imports/lib/ServerMethodsCore.test.mjs",
     "test:extensions": "node --test imports/lib/extensions/extensions.test.mjs",
     "test:reference-ranges": "node --test imports/lib/referenceRanges/qualifiers.test.mjs imports/lib/referenceRanges/resolveReferenceRange.test.mjs imports/lib/sexForClinicalUse.test.mjs imports/data/reference-ranges/blood-panel.test.mjs server/referenceRanges/seedRecords.test.mjs server/referenceRanges/mergeCandidates.test.mjs server/referenceRanges/buildContext.test.mjs",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "test:workflow-registry": "node --experimental-detect-module --test imports/lib/WorkflowRegistry.test.mjs",
     "test:session-key-groups": "node --experimental-detect-module --test tests/unit/imports/lib/sessionKeyGroups.test.mjs",
     "test:background-value": "node --experimental-detect-module --test tests/unit/imports/ui/theme/backgroundValue.test.mjs",
+    "test:ambiance-analysis": "node --experimental-detect-module --test tests/unit/imports/ui/theme/ambianceAnalysis.test.mjs",
     "test:rpc": "node --test imports/lib/ServerMethodsCore.test.mjs",
     "test:extensions": "node --test imports/lib/extensions/extensions.test.mjs",
     "test:reference-ranges": "node --test imports/lib/referenceRanges/qualifiers.test.mjs imports/lib/referenceRanges/resolveReferenceRange.test.mjs imports/lib/sexForClinicalUse.test.mjs imports/data/reference-ranges/blood-panel.test.mjs server/referenceRanges/seedRecords.test.mjs server/referenceRanges/mergeCandidates.test.mjs server/referenceRanges/buildContext.test.mjs",

--- a/server/connect/methods.js
+++ b/server/connect/methods.js
@@ -79,8 +79,32 @@ function smartConnectSettings() {
 function configuredVendors() {
   const vendors = get(smartConnectSettings(), 'vendors', {});
   return Object.keys(vendors).filter(function(vendor) {
-    return !!get(vendors, [vendor, 'clientId']);
+    return !!get(vendors, [vendor, 'clientId']) ||
+      !!get(vendors, [vendor, 'nonProductionClientId']);
   });
+}
+
+// Vendor sandboxes are registered separately from production (Epic issues a
+// distinct "Non-Production Client ID"), so a launch against a seeded sandbox
+// endpoint must present the non-production client. Seeded sandbox Endpoints
+// carry a meta.tag whose code names the sandbox (e.g. 'epic-sandbox' from
+// @orbital/lantern's seeder) — that tag is the discriminator.
+export function isNonProductionEndpoint(endpoint) {
+  const tags = Array.isArray(get(endpoint, 'meta.tag')) ? get(endpoint, 'meta.tag') : [];
+  return tags.some(function(tag) {
+    return String(get(tag, 'code', '')).toLowerCase().indexOf('sandbox') !== -1;
+  });
+}
+
+// clientId resolution: production endpoints use vendors.<v>.clientId;
+// sandbox endpoints prefer vendors.<v>.nonProductionClientId and fall back
+// to clientId (backward compat for configs that carried a sandbox client in
+// the single field). Both may be configured at once.
+export function resolveClientId(vendorConfig, nonProduction) {
+  if (nonProduction) {
+    return get(vendorConfig, 'nonProductionClientId') || get(vendorConfig, 'clientId') || '';
+  }
+  return get(vendorConfig, 'clientId') || '';
 }
 
 // Vendor scope resolution: settings string, optionally intersected with the
@@ -180,10 +204,13 @@ Meteor.ServerMethods.define('connect.beginLaunch', {
 
   const vendor = get(conformance, 'vendor', 'unknown');
   const vendorConfig = get(settings, ['vendors', vendor], null);
-  if (!vendorConfig || !get(vendorConfig, 'clientId')) {
+  const nonProduction = isNonProductionEndpoint(endpoint);
+  const clientId = resolveClientId(vendorConfig, nonProduction);
+  if (!vendorConfig || !clientId) {
+    const field = nonProduction ? 'nonProductionClientId' : 'clientId';
     throw new Meteor.Error('feature-disabled',
-      'No client_id configured for vendor "' + vendor +
-      '" (Meteor.settings.private.smartConnect.vendors.' + vendor + '.clientId).');
+      'No ' + (nonProduction ? 'non-production ' : '') + 'client_id configured for vendor "' + vendor +
+      '" (Meteor.settings.private.smartConnect.vendors.' + vendor + '.' + field + ').');
   }
 
   const codeVerifier = base64url(crypto.randomBytes(32));
@@ -197,14 +224,14 @@ Meteor.ServerMethods.define('connect.beginLaunch', {
     vendor: vendor,
     tokenEndpoint: tokenEndpoint,
     fhirBaseUrl: get(endpoint, 'address', ''),
-    clientId: get(vendorConfig, 'clientId'),
+    clientId: clientId,
     createdAt: Date.now()
   });
 
   const scope = resolveScopes(vendorConfig, get(conformance, 'smart.scopesSupported', []));
   const authorizeUrl = buildAuthorizeUrl({
     authorizationEndpoint: authorizationEndpoint,
-    clientId: get(vendorConfig, 'clientId'),
+    clientId: clientId,
     redirectUri: redirectUri,
     scope: scope,
     state: state,
@@ -212,7 +239,7 @@ Meteor.ServerMethods.define('connect.beginLaunch', {
     aud: get(endpoint, 'address', '')
   });
 
-  log.info('beginLaunch', { endpointId: endpoint._id, vendor: vendor });
+  log.info('beginLaunch', { endpointId: endpoint._id, vendor: vendor, nonProduction: nonProduction });
   return { authorizeUrl: authorizeUrl };
 });
 

--- a/settings/settings.honeycomb.localhost.json
+++ b/settings/settings.honeycomb.localhost.json
@@ -284,6 +284,14 @@
     }
   },
   "private": {
+    "cors": {
+      "browserPolicy": {
+        "allowFrameOrigin": [
+          "https://www.youtube-nocookie.com",
+          "https://www.youtube.com"
+        ]
+      }
+    },
     "directory": {
       "enabled": true,
       "baseUrl": "https://directory.cms.gov",
@@ -747,6 +755,7 @@
       "vendors": {
         "epic": {
           "clientId": "",
+          "nonProductionClientId": "",
           "scopes": "openid fhirUser launch/patient patient/*.read"
         },
         "oracle-cerner": {

--- a/tests/nightwatch/honeycomb/theme/ambianceControls.js
+++ b/tests/nightwatch/honeycomb/theme/ambianceControls.js
@@ -18,9 +18,9 @@ module.exports = {
     });
   },
 
-  '02. Page-mode toggle appears with a background and persists': function(browser) {
+  '02. Page-text toggle appears with a background and persists': function(browser) {
     browser.expect.element('#themePageModeToggle').to.be.present;
-    browser.execute(function() { document.querySelector('#themePageModeToggle').click(); });
+    browser.execute(function() { document.querySelector('#themePageText-light').click(); });
     browser.pause(500);
     browser.execute(function() {
       return JSON.parse(localStorage.getItem('honeycomb.theme') || '{}').pageMode;

--- a/tests/nightwatch/honeycomb/theme/ambianceControls.js
+++ b/tests/nightwatch/honeycomb/theme/ambianceControls.js
@@ -1,0 +1,55 @@
+// tests/nightwatch/honeycomb/theme/ambianceControls.js
+// E2E: Theme & Palette ambiance controls persist across reload.
+// Spec: docs/superpowers/specs/2026-08-03-ambiance-experience-zone-design.md
+
+module.exports = {
+  '01. Open dialog, pick an earth tone': function(browser) {
+    browser.url('http://localhost:3000/');
+    browser.pause(2000);
+    browser.execute(function() { Session.set('themeDialogOpen', true); });
+    browser.pause(1000);
+    browser.expect.element('#themeEarthTone-sand').to.be.present;
+    browser.execute(function() { document.querySelector('#themeEarthTone-sand').click(); });
+    browser.pause(500);
+    browser.execute(function() {
+      return JSON.parse(localStorage.getItem('honeycomb.theme') || '{}').backgroundImagePath;
+    }, [], function(result) {
+      browser.assert.equal(result.value, 'color:#d9c7a7', 'sand persisted on the background axis');
+    });
+  },
+
+  '02. Page-mode toggle appears with a background and persists': function(browser) {
+    browser.expect.element('#themePageModeToggle').to.be.present;
+    browser.execute(function() { document.querySelector('#themePageModeToggle').click(); });
+    browser.pause(500);
+    browser.execute(function() {
+      return JSON.parse(localStorage.getItem('honeycomb.theme') || '{}').pageMode;
+    }, [], function(result) {
+      browser.assert.ok(result.value === 'light' || result.value === 'dark', 'pageMode persisted');
+    });
+  },
+
+  '03. Card surface persists across reload': function(browser) {
+    browser.execute(function() { document.querySelector('#themeCardSurface-glass').click(); });
+    browser.pause(500);
+    browser.refresh();
+    browser.pause(3000);
+    browser.execute(function() { return Session.get('cardSurface'); }, [], function(result) {
+      browser.assert.equal(result.value, 'glass', 'cardSurface restored at boot');
+    });
+  },
+
+  '04. None hides page-mode control and clears the axis': function(browser) {
+    browser.execute(function() { Session.set('themeDialogOpen', true); });
+    browser.pause(1000);
+    browser.execute(function() {
+      var buttons = document.querySelectorAll('.MuiDialog-root button');
+      for (var i = 0; i < buttons.length; i++) {
+        if (buttons[i].textContent.trim() === 'None') { buttons[i].click(); return; }
+      }
+    });
+    browser.pause(500);
+    browser.expect.element('#themePageModeToggle').to.not.be.present;
+    browser.end();
+  }
+};

--- a/tests/nightwatch/honeycomb/theme/ambianceControls.js
+++ b/tests/nightwatch/honeycomb/theme/ambianceControls.js
@@ -50,6 +50,23 @@ module.exports = {
     });
     browser.pause(500);
     browser.expect.element('#themePageModeToggle').to.not.be.present;
+    browser.execute(function() {
+      return JSON.parse(localStorage.getItem('honeycomb.theme') || '{}').backgroundImagePath;
+    }, [], function(result) {
+      browser.assert.ok(!result.value, 'background axis cleared by None');
+    });
+  },
+
+  '05. Teardown: reset theme state': function(browser) {
+    browser.execute(function() {
+      var cur = JSON.parse(localStorage.getItem('honeycomb.theme') || '{}');
+      delete cur.backgroundImagePath; delete cur.pageMode; delete cur.cardSurface;
+      localStorage.setItem('honeycomb.theme', JSON.stringify(cur));
+      Session.set('pageMode', undefined);
+      Session.set('cardSurface', undefined);
+      return true;
+    });
+    browser.pause(300);
     browser.end();
   }
 };

--- a/tests/unit/imports/lib/loggerRedact.test.mjs
+++ b/tests/unit/imports/lib/loggerRedact.test.mjs
@@ -1,0 +1,85 @@
+// tests/unit/imports/lib/loggerRedact.test.mjs
+//
+// The PHI redaction walker must be safe to point at ARBITRARY runtime values —
+// log call sites pass whatever they have, including accidental host objects
+// (React SyntheticEvents whose .view is `window`). A path-based cycle guard
+// re-walks shared references once per path, which is exponential on dense
+// graphs and froze/crashed the browser tab (Add Member dialog, 2026-08-01).
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import redactModule from '../../../../imports/lib/loggerRedact.js';
+const { redactPhi } = redactModule;
+
+test('redacts PHI fields on a plain FHIR-ish object', function() {
+  const out = redactPhi({
+    resourceType: 'Observation',
+    status: 'final',
+    name: 'should be redacted',
+    subject: { display: 'ok', family: 'redact-me' }
+  });
+  assert.equal(out.status, 'final');
+  assert.deepEqual(out.name, { redacted: true });
+  assert.deepEqual(out.subject.family, { redacted: true });
+  assert.equal(out.subject.display, 'ok');
+});
+
+test('patient-compartment resources collapse to a stub', function() {
+  const out = redactPhi({ resourceType: 'Patient', id: 'p1', name: 'secret' });
+  assert.deepEqual(out, { redacted: true, resourceType: 'Patient', id: 'p1' });
+});
+
+test('true cycles terminate with a marker', function() {
+  const a = { label: 'a' };
+  a.self = a;
+  const out = redactPhi(a);
+  assert.equal(out.label, 'a');
+  assert.deepEqual(out.self, { redacted: true, circular: true });
+});
+
+test('shared references are visited once, not once per path', function() {
+  // A "diamond DAG": both x and y point at the same object. A path-based
+  // guard walks it twice (exponential on deep diamonds); a visited-set walks
+  // it once and marks the second sighting.
+  const shared = { v: 1 };
+  const out = redactPhi({ x: shared, y: shared });
+  const copies = [out.x, out.y].filter(function(o) { return o && o.v === 1; });
+  const markers = [out.x, out.y].filter(function(o) { return o && o.circular === true; });
+  assert.equal(copies.length, 1, 'shared object should be materialized exactly once');
+  assert.equal(markers.length, 1, 'second sighting should be a marker');
+});
+
+test('a deep diamond DAG returns quickly instead of exponentially exploding', function() {
+  // 40 levels, each object referenced twice by the level above: 2^40 paths.
+  // Path-based guarding never returns; visited-set returns instantly.
+  let node = { leaf: true };
+  for (let i = 0; i < 40; i++) {
+    node = { left: node, right: node };
+  }
+  const started = Date.now();
+  redactPhi(node);
+  assert.ok(Date.now() - started < 2000, 'walk should finish in bounded time');
+});
+
+test('depth is capped', function() {
+  let deep = { end: true };
+  for (let i = 0; i < 200; i++) {
+    deep = { child: deep };
+  }
+  const out = redactPhi(deep);
+  let cursor = out;
+  let depth = 0;
+  while (cursor && typeof cursor === 'object' && cursor.child) {
+    cursor = cursor.child;
+    depth++;
+  }
+  assert.ok(depth < 64, 'walker should truncate long chains, got depth ' + depth);
+});
+
+test('Error objects keep message and stack', function() {
+  const err = new Error('boom');
+  const out = redactPhi(err);
+  assert.equal(out.message, 'boom');
+  assert.ok(typeof out.stack === 'string');
+});

--- a/tests/unit/imports/ui/theme/ambianceAnalysis.test.mjs
+++ b/tests/unit/imports/ui/theme/ambianceAnalysis.test.mjs
@@ -1,0 +1,59 @@
+// tests/unit/imports/ui/theme/ambianceAnalysis.test.mjs
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { analyzeImageData } from '../../../../../imports/ui/theme/ambianceAnalysis.js';
+
+// Build a width×height RGBA array from a per-column color function.
+function makeImage(width, height, colorAt) {
+  const data = new Uint8ClampedArray(width * height * 4);
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      const [r, g, b] = colorAt(x, y);
+      const i = (y * width + x) * 4;
+      data[i] = r; data[i + 1] = g; data[i + 2] = b; data[i + 3] = 255;
+    }
+  }
+  return { data, width, height };
+}
+
+test('bright image → light page mode; dark image → dark page mode', function() {
+  const bright = analyzeImageData(makeImage(30, 12, function() { return [235, 230, 220]; }));
+  assert.equal(bright.recommendedPageMode, 'light');
+  const dark = analyzeImageData(makeImage(30, 12, function() { return [18, 20, 24]; }));
+  assert.equal(dark.recommendedPageMode, 'dark');
+});
+
+test('focus lands on the lowest-variance (calmest) third', function() {
+  // Left third: flat gray. Center+right thirds: harsh checkerboard.
+  const img = makeImage(30, 12, function(x, y) {
+    if (x < 10) { return [128, 128, 128]; }
+    return ((x + y) % 2 === 0) ? [255, 255, 255] : [0, 0, 0];
+  });
+  assert.equal(analyzeImageData(img).focus, 'left');
+
+  const imgRight = makeImage(30, 12, function(x, y) {
+    if (x >= 20) { return [128, 128, 128]; }
+    return ((x + y) % 2 === 0) ? [255, 255, 255] : [0, 0, 0];
+  });
+  assert.equal(analyzeImageData(imgRight).focus, 'right');
+});
+
+test('scrimStrength is clamped to [0.35, 0.8] and grows with busyness', function() {
+  const calm = analyzeImageData(makeImage(30, 12, function() { return [128, 128, 128]; }));
+  const busy = analyzeImageData(makeImage(30, 12, function(x, y) {
+    return ((x + y) % 2 === 0) ? [255, 255, 255] : [0, 0, 0];
+  }));
+  assert.ok(calm.scrimStrength >= 0.35 && calm.scrimStrength <= 0.8);
+  assert.ok(busy.scrimStrength >= 0.35 && busy.scrimStrength <= 0.8);
+  assert.ok(busy.scrimStrength > calm.scrimStrength, 'busy image needs a stronger scrim');
+});
+
+test('palette returns up to 3 dominant hex colors', function() {
+  // Two dominant colors: warm amber left half, deep blue right half.
+  const img = makeImage(30, 12, function(x) {
+    return x < 15 ? [232, 165, 75] : [20, 40, 90];
+  });
+  const palette = analyzeImageData(img).palette;
+  assert.ok(Array.isArray(palette) && palette.length >= 2 && palette.length <= 3);
+  palette.forEach(function(hex) { assert.match(hex, /^#[0-9a-f]{6}$/); });
+});

--- a/tests/unit/imports/ui/theme/ambianceComposition.test.mjs
+++ b/tests/unit/imports/ui/theme/ambianceComposition.test.mjs
@@ -1,0 +1,49 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { resolveComposition } from '../../../../../imports/ui/theme/ambianceComposition.js';
+
+test('no background → kind none, no forced ink, defaults', function() {
+  const c = resolveComposition({ background: '', entry: null, pageMode: 'dark', cardSurface: 'glass' });
+  assert.deepEqual(c, { background: '', kind: 'none', focus: 'center', scrimStrength: 0.55, pageMode: null, cardSurface: 'glass' });
+});
+
+test('image with full curation record resolves verbatim', function() {
+  const c = resolveComposition({
+    background: '/backgrounds/ambiance/Yoga-Ocean.jpg',
+    entry: { focus: 'left', recommendedPageMode: 'dark', scrimStrength: 0.6 },
+    pageMode: null, cardSurface: 'flat'
+  });
+  assert.equal(c.kind, 'image');
+  assert.equal(c.focus, 'left');
+  assert.equal(c.scrimStrength, 0.6);
+  assert.equal(c.pageMode, 'dark');       // curated fallback when user pageMode unset
+  assert.equal(c.cardSurface, 'flat');
+});
+
+test('explicit pageMode beats curated recommendation', function() {
+  const c = resolveComposition({
+    background: '/x.jpg', entry: { recommendedPageMode: 'dark' }, pageMode: 'light', cardSurface: 'solid'
+  });
+  assert.equal(c.pageMode, 'light');
+});
+
+test('solid color → kind color, center focus, entry ignored', function() {
+  const c = resolveComposition({ background: 'color:#a67b5b', entry: null, pageMode: 'light', cardSurface: 'solid' });
+  assert.equal(c.kind, 'color');
+  assert.equal(c.focus, 'center');
+  assert.equal(c.pageMode, 'light');      // solids still take forced ink
+});
+
+test('surfaceOverride wins over global cardSurface; junk values fall back', function() {
+  const c = resolveComposition({ background: '/x.jpg', entry: {}, pageMode: 'purple', cardSurface: 'wobbly', surfaceOverride: 'flat' });
+  assert.equal(c.cardSurface, 'flat');
+  assert.equal(c.pageMode, null);
+  const d = resolveComposition({ background: '/x.jpg', entry: {}, pageMode: null, cardSurface: 'wobbly' });
+  assert.equal(d.cardSurface, 'solid');
+});
+
+test('scrimStrength clamps to [0,1] and defaults to 0.55', function() {
+  assert.equal(resolveComposition({ background: '/x.jpg', entry: { scrimStrength: 7 } }).scrimStrength, 1);
+  assert.equal(resolveComposition({ background: '/x.jpg', entry: { scrimStrength: -2 } }).scrimStrength, 0);
+  assert.equal(resolveComposition({ background: '/x.jpg', entry: {} }).scrimStrength, 0.55);
+});

--- a/tests/unit/imports/ui/theme/ambianceComposition.test.mjs
+++ b/tests/unit/imports/ui/theme/ambianceComposition.test.mjs
@@ -42,6 +42,15 @@ test('surfaceOverride wins over global cardSurface; junk values fall back', func
   assert.equal(d.cardSurface, 'solid');
 });
 
+test('route surfaceDefault beats global cardSurface; user surfaceOverride beats both', function() {
+  const c = resolveComposition({ background: '/x.jpg', entry: {}, cardSurface: 'solid', surfaceDefault: 'flat' });
+  assert.equal(c.cardSurface, 'flat');
+  const d = resolveComposition({ background: '/x.jpg', entry: {}, cardSurface: 'solid', surfaceDefault: 'flat', surfaceOverride: 'solid' });
+  assert.equal(d.cardSurface, 'solid');
+  const e = resolveComposition({ background: '/x.jpg', entry: {}, cardSurface: 'glass', surfaceDefault: 'wobbly' });
+  assert.equal(e.cardSurface, 'glass');
+});
+
 test('scrimStrength clamps to [0,1] and defaults to 0.55', function() {
   assert.equal(resolveComposition({ background: '/x.jpg', entry: { scrimStrength: 7 } }).scrimStrength, 1);
   assert.equal(resolveComposition({ background: '/x.jpg', entry: { scrimStrength: -2 } }).scrimStrength, 0);

--- a/tests/unit/imports/ui/theme/backgroundValue.test.mjs
+++ b/tests/unit/imports/ui/theme/backgroundValue.test.mjs
@@ -1,0 +1,31 @@
+// tests/unit/imports/ui/theme/backgroundValue.test.mjs
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  COLOR_BACKGROUND_PREFIX, isColorBackground, colorFromBackground, makeColorBackground
+} from '../../../../../imports/ui/theme/backgroundValue.js';
+
+test('prefix constant is stable (persisted strings depend on it)', function() {
+  assert.equal(COLOR_BACKGROUND_PREFIX, 'color:');
+});
+
+test('isColorBackground distinguishes color entries from image paths', function() {
+  assert.equal(isColorBackground('color:#a67b5b'), true);
+  assert.equal(isColorBackground('/backgrounds/ambiance/Zen.jpg'), false);
+  assert.equal(isColorBackground(''), false);
+  assert.equal(isColorBackground(null), false);
+  assert.equal(isColorBackground(undefined), false);
+});
+
+test('colorFromBackground extracts the hex, null otherwise', function() {
+  assert.equal(colorFromBackground('color:#a67b5b'), '#a67b5b');
+  assert.equal(colorFromBackground('/backgrounds/ambiance/Zen.jpg'), null);
+  assert.equal(colorFromBackground(null), null);
+});
+
+test('makeColorBackground round-trips with colorFromBackground', function() {
+  const stored = makeColorBackground('#4a3728');
+  assert.equal(stored, 'color:#4a3728');
+  assert.equal(colorFromBackground(stored), '#4a3728');
+});

--- a/tests/unit/imports/ui/theme/contrastInk.test.mjs
+++ b/tests/unit/imports/ui/theme/contrastInk.test.mjs
@@ -1,0 +1,76 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  parseFirstColor, relativeLuminance, inkForColor,
+  inverseHueSaturationBrightness, readableAccent
+} from '../../../../../imports/ui/theme/contrastInk.js';
+
+test('parses hex, short hex, rgb() and rgba()', function() {
+  assert.deepEqual(parseFirstColor('#53e6ff'), { r: 0x53, g: 0xe6, b: 0xff });
+  assert.deepEqual(parseFirstColor('#fff'), { r: 255, g: 255, b: 255 });
+  assert.deepEqual(parseFirstColor('rgb(185, 179, 164)'), { r: 185, g: 179, b: 164 });
+  assert.deepEqual(parseFirstColor('rgba(20, 20, 22, 0.95)'), { r: 20, g: 20, b: 22 });
+});
+
+test('gradients resolve to the first color stop', function() {
+  assert.deepEqual(
+    parseFirstColor('linear-gradient(135deg, rgba(33, 150, 243, 0.9) 0%, rgba(156, 39, 176, 0.9) 100%)'),
+    { r: 33, g: 150, b: 243 }
+  );
+  assert.deepEqual(
+    parseFirstColor('linear-gradient(90deg, #070b12, #0b1220)'),
+    { r: 0x07, g: 0x0b, b: 0x12 }
+  );
+});
+
+test('low-alpha and junk values return null (caller falls back)', function() {
+  assert.equal(parseFirstColor('rgba(33, 150, 243, 0.3)'), null);
+  assert.equal(parseFirstColor('transparent'), null);
+  assert.equal(parseFirstColor(''), null);
+  assert.equal(parseFirstColor(null), null);
+});
+
+test('bright surfaces get dark ink, dark surfaces get light ink', function() {
+  assert.equal(inkForColor('#53e6ff'), 'dark');    // Tron cyan bar
+  assert.equal(inkForColor('#b9b3a4'), 'dark');    // Limestone stone bar
+  assert.equal(inkForColor('#ffb454'), 'dark');    // Vaporwave amber
+  assert.equal(inkForColor('#070b12'), 'light');   // Tron dark chrome
+  assert.equal(inkForColor('#141416'), 'light');   // near-black
+  assert.equal(inkForColor('#ffffff'), 'dark');
+  assert.equal(inkForColor('not-a-color'), null);
+});
+
+test('inverseHueSaturationBrightness flips lightness, preserves hue', function() {
+  // Bright cyan → dark teal-cyan (still readable as "cyan")
+  const darkCyan = inverseHueSaturationBrightness('#53e6ff');
+  const before = parseFirstColor('#53e6ff');
+  const after = parseFirstColor(darkCyan);
+  assert.ok(relativeLuminance(after) < relativeLuminance(before), 'brightness inverted downward');
+  // Hue preserved: blue channel still dominates, red still smallest
+  assert.ok(after.b > after.r && after.g > after.r, 'still a cyan family color');
+  // Involution-ish: inverting twice lands near the original lightness
+  const twice = parseFirstColor(inverseHueSaturationBrightness(darkCyan));
+  assert.ok(Math.abs(relativeLuminance(twice) - relativeLuminance(before)) < 0.1);
+  // Unparseable input passes through untouched
+  assert.equal(inverseHueSaturationBrightness('not-a-color'), 'not-a-color');
+});
+
+test('readableAccent inverts only matching-polarity combinations', function() {
+  // Bright accent on light surface → inverted (the washed-out case)
+  assert.notEqual(readableAccent('#53e6ff', 'light'), '#53e6ff');
+  // Bright accent on dark surface → untouched (looks great already)
+  assert.equal(readableAccent('#53e6ff', 'dark'), '#53e6ff');
+  // Dark accent on dark surface → inverted (would vanish)
+  assert.notEqual(readableAccent('#0b1220', 'dark'), '#0b1220');
+  // Dark accent on light surface → untouched
+  assert.equal(readableAccent('#0b1220', 'light'), '#0b1220');
+  // Mid-range accents are stable on both surfaces
+  assert.equal(readableAccent('#2aa5bd', 'light'), '#2aa5bd');
+  assert.equal(readableAccent('#2aa5bd', 'dark'), '#2aa5bd');
+});
+
+test('relativeLuminance matches Rec. 709 expectations', function() {
+  assert.equal(relativeLuminance({ r: 0, g: 0, b: 0 }), 0);
+  assert.ok(Math.abs(relativeLuminance({ r: 255, g: 255, b: 255 }) - 1) < 1e-9);
+  assert.ok(relativeLuminance({ r: 0, g: 255, b: 0 }) > relativeLuminance({ r: 255, g: 0, b: 0 }));
+});

--- a/tests/unit/imports/ui/theme/surfaceStyles.test.mjs
+++ b/tests/unit/imports/ui/theme/surfaceStyles.test.mjs
@@ -1,0 +1,38 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { buildSurfaceStyles, hexAlpha, SURFACE_TRANSITION } from '../../../../../imports/ui/theme/surfaceStyles.js';
+
+test('hexAlpha converts 6- and 3-digit hex; passes through non-hex', function() {
+  assert.equal(hexAlpha('#18181a', 0.72), 'rgba(24, 24, 26, 0.72)');
+  assert.equal(hexAlpha('#fff', 0.5), 'rgba(255, 255, 255, 0.5)');
+  assert.equal(hexAlpha('teal', 0.5), 'teal');
+});
+
+test('solid keeps the surface opaque (only the transition is added)', function() {
+  const s = buildSurfaceStyles({ surface: 'solid', paperColor: '#18181a', dividerColor: '#333' });
+  assert.deepEqual(Object.keys(s.root), ['transition']);
+  assert.equal(s.root.transition, SURFACE_TRANSITION);
+});
+
+test('glass is translucent paper + blur + hairline, shadowless', function() {
+  const s = buildSurfaceStyles({ surface: 'glass', paperColor: '#18181a', dividerColor: '#333' });
+  assert.equal(s.root.backgroundColor, 'rgba(24, 24, 26, 0.72)');
+  assert.equal(s.root.backdropFilter, 'blur(8px)');
+  assert.equal(s.root.border, '1px solid #333');
+  assert.equal(s.root.boxShadow, 'none');
+  assert.equal(s.root.transition, SURFACE_TRANSITION);
+});
+
+test('flat melts into negative space', function() {
+  const s = buildSurfaceStyles({ surface: 'flat', paperColor: '#18181a', dividerColor: '#333' });
+  assert.equal(s.root.backgroundColor, 'transparent');
+  assert.equal(s.root.border, 'none');
+  assert.equal(s.root.boxShadow, 'none');
+  assert.equal(s.root.backgroundImage, 'none');
+  assert.equal(s.root.transition, SURFACE_TRANSITION);
+});
+
+test('unknown surface behaves as solid', function() {
+  const s = buildSurfaceStyles({ surface: 'wobbly', paperColor: '#18181a', dividerColor: '#333' });
+  assert.deepEqual(Object.keys(s.root), ['transition']);
+});


### PR DESCRIPTION
## Summary

Go-live polish sweep across the theming system, key patient-facing pages, and the DICOM parsing path — 65 commits, ~5,600 insertions across 66 files.

### Ambiance experience zones (phases 1–3)
The centerpiece: routes can now opt into an **ambiance backdrop** (curated background imagery or color-prefixed earth-tone solids) with content floating over it in composed surfaces.
- Composition contract (`resolveComposition`) + `AmbianceZone` guard in the router chain; route-gated painting via `enableAmbiance` flags
- `Meteor.StyledCard` / `Meteor.StyledContainer` surface consumers with solid/glass/flat card recipes and animated transitions
- Ambiance analysis module: neutral-space focus, ink mode, scrim, palette extraction; curation records in the background library
- **Curation tooling**: Ambiance Tuning HUD (Cmd/Ctrl+Shift+E) with Copy-as-JSON authoring, Ctrl+Shift+L surface cycle, Ctrl+Shift+K per-route flat toggle
- Theme dialog restructure: ambiance under preset, page mode + card surface controls with persisted axes and boot restore; card-surface mini-preview chips
- Print safety: ambiance backgrounds and scrims never reach paper

### Page polish riding the new system
- **IPS** (`/international-patient-summary`): enableAmbiance + requirePatient, focus-aware content column, shared gutter scheme, themed Generate Narrative dialog
- **Sign-in**: theme-token login card, themed autofill, `?align`/`?valign` 3x3 placement, accent-tinted inputs, mobile fallback
- **Provider directory**: console-over-ambiance with curated focus and scrim system, SANDBOXES band above Organizations, 3-up census, chrome-retract-aware header
- **Patient chart**: flat-by-default ambiance surface + patient guards on chart routes
- **/theming**: now a live inverse-mode component gallery sharing components with ThemeDialog

### DICOM / dcmjs
- Uploads parse via the dcmjs **event stream (SAX push core)**; pixel-data guard for non-image files, multi-frame cine support, tab-aware routing
- Submodule bumped through the CLI-package + encapsulated-PDF → FHIR DocumentReference work (`awatson1978/dcmjs` development)

### Fixes along the way
- Tab freeze/OOM on crew-member add: bounded PHI redaction + row-click event leak
- Importer `LocalCollection.insert` signature fix; patient-fetch URL params override defaults and track the live SMART session
- `nonProductionClientId`: sandbox SMART launches present the non-production client_id
- RPC validation-failed errors name the failing fields

### Tests
- Unit: `contrastInk`, `surfaceStyles`; e2e: ambiance dialog controls persist across reload, CI wiring + teardown

🤖 Generated with [Claude Code](https://claude.com/claude-code)